### PR TITLE
Added handling of optional parameters for 'Accept' and 'Content-Type' headers

### DIFF
--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -802,7 +802,8 @@ fn match_header_value(key: &String, expected: &String, actual: &String, mismatch
         Err(message) => mismatches.push(Mismatch::HeaderMismatch { key: key.clone(),
                 expected: expected.clone(),
                 actual: actual.clone(),
-                mismatch: message }),
+                mismatch:
+                    format!("Expected header '{}' to have value '{}' but was '{}'", &key, expected, actual)}),
         Ok(_) => ()
     }
 }

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -764,7 +764,7 @@ fn match_parameter_header(expected: &String, actual: &String, mismatches: &mut V
     let actual_values: Vec<&str> = strip_whitespace(actual, ";");
     let expected_parameters = expected_values.as_slice().split_first().unwrap();
     let actual_parameters = actual_values.as_slice().split_first().unwrap();
-    let header_mismatch = Mismatch::HeaderMismatch { key: header.to_string(),
+    let header_mismatch = Mismatch::HeaderMismatch { key: header.clone(),
         expected: format!("{}", expected),
         actual: format!("{}", actual),
         mismatch: format!("Expected header '{}' to have value '{}' but was '{}'",

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -802,7 +802,7 @@ fn match_header_value(key: &String, expected: &String, actual: &String, mismatch
         expected.matches(&actual, &Matcher::EqualityMatcher)
     };
     match matcher_result {
-        Err(message) => mismatches.push(Mismatch::HeaderMismatch { key: key.clone(),
+        Err(_) => mismatches.push(Mismatch::HeaderMismatch { key: key.clone(),
                 expected: expected.clone(),
                 actual: actual.clone(),
                 mismatch:

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -377,6 +377,8 @@ lazy_static! {
     ];
 }
 
+static PARAMETERISED_HEADER_TYPES: [&'static str; 2] = ["accept", "content-type"];
+
 /// Enum that defines the different types of mismatches that can occur.
 #[derive(Debug, Clone)]
 pub enum Mismatch {
@@ -757,16 +759,16 @@ fn parse_charset_parameters(parameters: &[&str]) -> HashMap<String, String> {
         })
 }
 
-fn match_content_type(expected: &String, actual: &String, mismatches: &mut Vec<Mismatch>) {
+fn match_parameter_header(expected: &String, actual: &String, mismatches: &mut Vec<Mismatch>, header: &String) {
     let expected_values: Vec<&str> = strip_whitespace(expected, ";");
     let actual_values: Vec<&str> = strip_whitespace(actual, ";");
     let expected_parameters = expected_values.as_slice().split_first().unwrap();
     let actual_parameters = actual_values.as_slice().split_first().unwrap();
-    let header_mismatch = Mismatch::HeaderMismatch { key: "Content-Type".to_string(),
+    let header_mismatch = Mismatch::HeaderMismatch { key: header.to_string(),
         expected: format!("{}", expected),
         actual: format!("{}", actual),
-        mismatch: format!("Expected header 'Content-Type' to have value '{}' but was '{}'",
-            expected, actual) };
+        mismatch: format!("Expected header '{}' to have value '{}' but was '{}'",
+            header, expected, actual) };
 
     if expected_parameters.0 == actual_parameters.0 {
         let expected_parameter_map = parse_charset_parameters(expected_parameters.1);
@@ -790,10 +792,11 @@ fn match_header_value(key: &String, expected: &String, actual: &String, mismatch
     let path = vec![s!("$"), s!("headers"), key.clone()];
     let expected = strip_whitespace::<String>(expected, ",");
     let actual = strip_whitespace::<String>(actual, ",");
+
     let matcher_result = if matchers::matcher_is_defined(&path, matchers) {
         matchers::match_values(&path, matchers.clone().unwrap(), &expected, &actual)
-    } else if key.to_lowercase() == "content-type" {
-        match_content_type(&expected, &actual, mismatches);
+    } else if PARAMETERISED_HEADER_TYPES.contains(&key.to_lowercase().as_str()) {
+        match_parameter_header(&expected, &actual, mismatches, &key);
         Ok(())
     } else {
         expected.matches(&actual, &Matcher::EqualityMatcher)

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -192,8 +192,8 @@ fn mismatch_message_generated_when_headers_are_not_equal() {
     match_header_value(&s!("HEADER"), &s!("HEADER_VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
 
-    match(mismatches[0]) {
-        Mismatch::HeaderMismatch {ref key, ref expected, ref actual, ref mismatch} =>
+    match mismatches[0]  {
+        Mismatch::HeaderMismatch {key: _, expected: _, actual: _, ref mismatch} =>
             assert_eq!(mismatch, "Expected header 'HEADER' to have value 'HEADER_VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }
@@ -277,9 +277,8 @@ fn mismatched_header_description_reports_content_type_mismatches_correctly() {
     match_header_value(&s!("CONTENT-TYPE"), &s!("CONTENT-TYPE-VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
 
-    let ref raised_mismatch = mismatches[0];
-    match(*raised_mismatch) {
-        Mismatch::HeaderMismatch {ref key, ref expected, ref actual, ref mismatch} =>
+    match mismatches[0] {
+        Mismatch::HeaderMismatch {key: _, expected: _, actual: _, ref mismatch} =>
             assert_eq!(mismatch, "Expected header 'CONTENT-TYPE' to have value 'CONTENT-TYPE-VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }
@@ -322,9 +321,8 @@ fn mismatched_header_description_reports_accept_header_mismatches_correctly() {
     let mut mismatches = vec![];
     match_header_value(&s!("ACCEPT"), &s!("ACCEPT-VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
-    let ref raised_mismatch = mismatches[0];
-    match(*raised_mismatch) {
-        Mismatch::HeaderMismatch { ref key, ref expected, ref actual, ref mismatch } =>
+    match mismatches[0] {
+        Mismatch::HeaderMismatch { key: _, expected: _, actual: _, ref mismatch } =>
             assert_eq!(mismatch, "Expected header 'ACCEPT' to have value 'ACCEPT-VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -273,6 +273,65 @@ fn content_type_header_does_match_when_charsets_is_missing_from_expected_header(
 }
 
 #[test]
+fn mismatched_header_description_reports_content_type_mismatches_correctly() {
+    let mut mismatches = vec![];
+    match_header_value(&"CONTENT-TYPE".to_string(), &"CONTENT-TYPE-VALUE".to_string(), &"HEADER2".to_string(),
+                       &mut mismatches, &None);
+
+    let ref raised_mismatch = mismatches[0];
+    match(*raised_mismatch) {
+        Mismatch::HeaderMismatch {ref key, ref expected, ref actual, ref mismatch} =>
+            assert_eq!(mismatch, "Expected header 'CONTENT-TYPE' to have value 'CONTENT-TYPE-VALUE' but was 'HEADER2'"),
+        _ => panic!("Unexpected mismatch response")
+    }
+}
+
+#[test]
+fn accept_header_matches_when_headers_are_equal() {
+    let mut mismatches = vec![];
+    match_header_value(&"ACCEPT".to_string(), &"application/hal+json;charset=utf-8".to_string(),
+                       &"application/hal+json;charset=utf-8".to_string(), &mut mismatches, &None);
+    expect!(mismatches).to(be_empty());
+}
+
+#[test]
+fn accept_header_does_not_match_when_actual_is_empty() {
+    let mut mismatches = vec![];
+    match_header_value(&"ACCEPT".to_string(), &"application/hal+json".to_string(),
+                       &"".to_string(), &mut mismatches, &None);
+    expect!(mismatches).to_not(be_empty());
+}
+
+#[test]
+fn accept_header_does_match_when_charset_is_missing_from_expected_header() {
+    let mut mismatches = vec![];
+    match_header_value(&"ACCEPT".to_string(), &"application/hal+json".to_string(),
+        &"application/hal+json;charset=utf-8".to_string(), &mut mismatches, &None);
+    expect!(mismatches).to(be_empty());
+}
+
+#[test]
+fn accept_header_does_not_match_when_charsets_are_not_equal() {
+    let mut mismatches = vec![];
+    match_header_value(&"ACCEPT".to_string(), &"application/hal+json;charset=utf-8".to_string(),
+        &"application/hal+json;charset=utf-16".to_string(), &mut mismatches, &None);
+    expect!(mismatches).to_not(be_empty());
+}
+
+#[test]
+fn mismatched_header_description_reports_accept_header_mismatches_correctly() {
+    let mut mismatches = vec![];
+    match_header_value(&"ACCEPT".to_string(), &"ACCEPT-VALUE".to_string(), &"HEADER2".to_string(),
+                       &mut mismatches, &None);
+    let ref raised_mismatch = mismatches[0];
+    match(*raised_mismatch) {
+        Mismatch::HeaderMismatch { ref key, ref expected, ref actual, ref mismatch } =>
+            assert_eq!(mismatch, "Expected header 'ACCEPT' to have value 'ACCEPT-VALUE' but was 'HEADER2'"),
+        _ => panic!("Unexpected mismatch response")
+    }
+}
+
+#[test]
 fn body_does_not_match_if_different_content_types() {
     let mut mismatches = vec![];
     let expected = Request { method: s!("GET"), path: s!("/"), query: None,

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -193,7 +193,7 @@ fn mismatch_message_generated_when_headers_are_not_equal() {
                        &mut mismatches, &None);
 
     match mismatches[0]  {
-        Mismatch::HeaderMismatch {key: _, expected: _, actual: _, ref mismatch} =>
+        Mismatch::HeaderMismatch {ref mismatch, ..} =>
             assert_eq!(mismatch, "Expected header 'HEADER' to have value 'HEADER_VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }
@@ -278,7 +278,7 @@ fn mismatched_header_description_reports_content_type_mismatches_correctly() {
                        &mut mismatches, &None);
 
     match mismatches[0] {
-        Mismatch::HeaderMismatch {key: _, expected: _, actual: _, ref mismatch} =>
+        Mismatch::HeaderMismatch {ref mismatch, ..} =>
             assert_eq!(mismatch, "Expected header 'CONTENT-TYPE' to have value 'CONTENT-TYPE-VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }
@@ -322,7 +322,7 @@ fn mismatched_header_description_reports_accept_header_mismatches_correctly() {
     match_header_value(&s!("ACCEPT"), &s!("ACCEPT-VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
     match mismatches[0] {
-        Mismatch::HeaderMismatch { key: _, expected: _, actual: _, ref mismatch } =>
+        Mismatch::HeaderMismatch {ref mismatch, ..} =>
             assert_eq!(mismatch, "Expected header 'ACCEPT' to have value 'ACCEPT-VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
     }

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -7,22 +7,22 @@ use models::{Request, OptionalBody};
 #[test]
 fn match_method_returns_nothing_if_the_method_matches() {
     let mut mismatches = vec![];
-    match_method("GET".to_string(), "GET".to_string(), &mut mismatches);
+    match_method(s!("GET"), s!("GET"), &mut mismatches);
     assert!(mismatches.is_empty());
 }
 
 #[test]
 fn match_method_returns_a_mismatch_if_the_method_does_not_match() {
     let mut mismatches = vec![];
-    match_method("GET".to_string(), "POST".to_string(), &mut mismatches);
+    match_method(s!("GET"), s!("POST"), &mut mismatches);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::MethodMismatch { expected: "GET".to_string(), actual: "POST".to_string() });
+    assert_eq!(mismatches[0], Mismatch::MethodMismatch { expected: s!("GET"), actual: s!("POST") });
 }
 
 #[test]
 fn match_method_returns_nothing_if_the_method_matches_with_differnt_case() {
     let mut mismatches = vec![];
-    match_method("POST".to_string(), "post".to_string(), &mut mismatches);
+    match_method(s!("POST"), s!("post"), &mut mismatches);
     assert!(mismatches.is_empty());
 }
 
@@ -55,122 +55,122 @@ fn match_query_returns_a_mismatch_if_there_is_no_expected_query_string() {
     let mut mismatches = vec![];
     let expected = None;
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "a".to_string(),
-        expected: "".to_string(), actual: "[\"b\"]".to_string(),
-        mismatch: "Unexpected query parameter 'a' received".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("a"),
+        expected: s!(""), actual: s!("[\"b\"]"),
+        mismatch: s!("Unexpected query parameter 'a' received") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_there_is_no_actual_query_string() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let expected = Some(query_map);
     let actual = None;
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "a".to_string(),
-        expected: "[\"b\"]".to_string(), actual: "".to_string(),
-        mismatch: "Expected query parameter 'a' but was missing".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("a"),
+        expected: s!("[\"b\"]"), actual: s!(""),
+        mismatch: s!("Expected query parameter 'a' but was missing") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_there_is_an_actual_query_parameter_that_is_not_expected() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec!["d".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![s!("d")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "c".to_string(),
-        expected: "".to_string(), actual: "[\"d\"]".to_string(),
-        mismatch: "Unexpected query parameter 'c' received".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("c"),
+        expected: s!(""), actual: s!("[\"d\"]"),
+        mismatch: s!("Unexpected query parameter 'c' received") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_there_is_an_expected_query_parameter_that_is_not_received() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec!["d".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![s!("d")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "c".to_string(),
-        expected: "[\"d\"]".to_string(), actual: "".to_string(),
-        mismatch: "Expected query parameter 'c' but was missing".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("c"),
+        expected: s!("[\"d\"]"), actual: s!(""),
+        mismatch: s!("Expected query parameter 'c' but was missing") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_there_is_an_empty_expected_query_parameter_and_a_non_empty_actual() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec![]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec!["d".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![s!("d")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "c".to_string(),
-        expected: "[]".to_string(), actual: "[\"d\"]".to_string(),
-        mismatch: "Expected an empty parameter list for 'c' but received [\"d\"]".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("c"),
+        expected: s!("[]"), actual: s!("[\"d\"]"),
+        mismatch: s!("Expected an empty parameter list for 'c' but received [\"d\"]") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_the_query_values_have_different_lengths() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec!["d".to_string(), "e".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![s!("d"), s!("e")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
-    query_map.insert("c".to_string(), vec!["d".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
+    query_map.insert(s!("c"), vec![s!("d")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert_eq!(mismatches.len(), 2);
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "c".to_string(),
-        expected: "[\"d\", \"e\"]".to_string(), actual: "[\"d\"]".to_string(),
-        mismatch: "Expected query parameter 'c' with 2 value(s) but received 1 value(s)".to_string() });
-    assert_eq!(mismatches[1], Mismatch::QueryMismatch { parameter: "c".to_string(),
-        expected: "[\"d\", \"e\"]".to_string(), actual: "[\"d\"]".to_string(),
-        mismatch: "Expected query parameter 'c' value 'e' but was missing".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("c"),
+        expected: s!("[\"d\", \"e\"]"), actual: s!("[\"d\"]"),
+        mismatch: s!("Expected query parameter 'c' with 2 value(s) but received 1 value(s)") });
+    assert_eq!(mismatches[1], Mismatch::QueryMismatch { parameter: s!("c"),
+        expected: s!("[\"d\", \"e\"]"), actual: s!("[\"d\"]"),
+        mismatch: s!("Expected query parameter 'c' value 'e' but was missing") });
 }
 
 #[test]
 fn match_query_returns_a_mismatch_if_the_values_are_not_the_same() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["c".to_string()]);
+    query_map.insert(s!("a"), vec![s!("c")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "a".to_string(),
-        expected: "b".to_string(), actual: "c".to_string(),
-        mismatch: "Expected 'b' but received 'c' for query parameter 'a'".to_string() });
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("a"),
+        expected: s!("b"), actual: s!("c"),
+        mismatch: s!("Expected 'b' but received 'c' for query parameter 'a'") });
 }
 
 #[test]
 fn matching_headers_be_true_when_headers_are_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER".to_string(), &"HEADER".to_string(),
+    match_header_value(&s!("HEADER"), &s!("HEADER"), &s!("HEADER"),
         &mut mismatches, &None);
     assert!(mismatches.is_empty());
 }
@@ -178,22 +178,21 @@ fn matching_headers_be_true_when_headers_are_equal() {
 #[test]
 fn matching_headers_be_false_when_headers_are_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER".to_string(), &"HEADER2".to_string(),
+    match_header_value(&s!("HEADER"), &s!("HEADER"), &s!("HEADER2"),
         &mut mismatches, &None);
     assert!(!mismatches.is_empty());
-    assert_eq!(mismatches[0], Mismatch::HeaderMismatch { key: "HEADER".to_string(),
-        expected: "HEADER".to_string(), actual: "HEADER2".to_string(),
-        mismatch: "".to_string() });
+    assert_eq!(mismatches[0], Mismatch::HeaderMismatch { key: s!("HEADER"),
+        expected: s!("HEADER"), actual: s!("HEADER2"),
+        mismatch: s!("") });
 }
 
 #[test]
 fn mismatch_message_generated_when_headers_are_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER_VALUE".to_string(), &"HEADER2".to_string(),
+    match_header_value(&s!("HEADER"), &s!("HEADER_VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
 
-    let ref raised_mismatch = mismatches[0];
-    match(*raised_mismatch) {
+    match(mismatches[0]) {
         Mismatch::HeaderMismatch {ref key, ref expected, ref actual, ref mismatch} =>
             assert_eq!(mismatch, "Expected header 'HEADER' to have value 'HEADER_VALUE' but was 'HEADER2'"),
         _ => panic!("Unexpected mismatch response")
@@ -203,79 +202,79 @@ fn mismatch_message_generated_when_headers_are_not_equal() {
 #[test]
 fn matching_headers_exclude_whitespaces() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER1, HEADER2,   3".to_string(),
-        &"HEADER1,HEADER2,3".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("HEADER"), &s!("HEADER1, HEADER2,   3"),
+        &s!("HEADER1,HEADER2,3"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn matching_headers_includes_whitespaces_within_a_value() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER 1, \tHEADER 2,\n3".to_string(),
-        &"HEADER 1,HEADER 2,3".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("HEADER"), &s!("HEADER 1, \tHEADER 2,\n3"),
+        &s!("HEADER 1,HEADER 2,3"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn content_type_header_matches_when_headers_are_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/json;charset=UTF-8".to_string(),
-        &"application/json; charset=UTF-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/json;charset=UTF-8"),
+        &s!("application/json; charset=UTF-8"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn content_type_header_does_not_match_when_headers_are_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/pdf;charset=UTF-8".to_string(),
-        &"application/json;charset=UTF-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/pdf;charset=UTF-8"),
+        &s!("application/json;charset=UTF-8"), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn content_type_header_does_not_match_when_expected_is_empty() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"".to_string(),
-        &"application/json;charset=UTF-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!(""),
+        &s!("application/json;charset=UTF-8"), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn content_type_header_does_not_match_when_actual_is_empty() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/pdf;charset=UTF-8".to_string(),
-        &"".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/pdf;charset=UTF-8"),
+        &s!(""), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn content_type_header_does_not_match_when_charsets_are_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/json;charset=UTF-8".to_string(),
-        &"application/json;charset=UTF-16".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/json;charset=UTF-8"),
+        &s!("application/json;charset=UTF-16"), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn content_type_header_does_not_match_when_charsets_other_parameters_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/json;declaration=\"<950118.AEB0@XIson.com>\"".to_string(),
-        &"application/json;charset=UTF-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/json;declaration=\"<950118.AEB0@XIson.com>\""),
+        &s!("application/json;charset=UTF-8"), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn content_type_header_does_match_when_charsets_is_missing_from_expected_header() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"application/json".to_string(),
-        &"application/json;charset=UTF-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("CONTENT-TYPE"), &s!("application/json"),
+        &s!("application/json;charset=UTF-8"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn mismatched_header_description_reports_content_type_mismatches_correctly() {
     let mut mismatches = vec![];
-    match_header_value(&"CONTENT-TYPE".to_string(), &"CONTENT-TYPE-VALUE".to_string(), &"HEADER2".to_string(),
+    match_header_value(&s!("CONTENT-TYPE"), &s!("CONTENT-TYPE-VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
 
     let ref raised_mismatch = mismatches[0];
@@ -289,39 +288,39 @@ fn mismatched_header_description_reports_content_type_mismatches_correctly() {
 #[test]
 fn accept_header_matches_when_headers_are_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"ACCEPT".to_string(), &"application/hal+json;charset=utf-8".to_string(),
-                       &"application/hal+json;charset=utf-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("ACCEPT"), &s!("application/hal+json;charset=utf-8"),
+                       &s!("application/hal+json;charset=utf-8"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn accept_header_does_not_match_when_actual_is_empty() {
     let mut mismatches = vec![];
-    match_header_value(&"ACCEPT".to_string(), &"application/hal+json".to_string(),
-                       &"".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("ACCEPT"), &s!("application/hal+json"),
+                       &s!(""), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn accept_header_does_match_when_charset_is_missing_from_expected_header() {
     let mut mismatches = vec![];
-    match_header_value(&"ACCEPT".to_string(), &"application/hal+json".to_string(),
-        &"application/hal+json;charset=utf-8".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("ACCEPT"), &s!("application/hal+json"),
+        &s!("application/hal+json;charset=utf-8"), &mut mismatches, &None);
     expect!(mismatches).to(be_empty());
 }
 
 #[test]
 fn accept_header_does_not_match_when_charsets_are_not_equal() {
     let mut mismatches = vec![];
-    match_header_value(&"ACCEPT".to_string(), &"application/hal+json;charset=utf-8".to_string(),
-        &"application/hal+json;charset=utf-16".to_string(), &mut mismatches, &None);
+    match_header_value(&s!("ACCEPT"), &s!("application/hal+json;charset=utf-8"),
+        &s!("application/hal+json;charset=utf-16"), &mut mismatches, &None);
     expect!(mismatches).to_not(be_empty());
 }
 
 #[test]
 fn mismatched_header_description_reports_accept_header_mismatches_correctly() {
     let mut mismatches = vec![];
-    match_header_value(&"ACCEPT".to_string(), &"ACCEPT-VALUE".to_string(), &"HEADER2".to_string(),
+    match_header_value(&s!("ACCEPT"), &s!("ACCEPT-VALUE"), &s!("HEADER2"),
                        &mut mismatches, &None);
     let ref raised_mismatch = mismatches[0];
     match(*raised_mismatch) {
@@ -337,12 +336,12 @@ fn body_does_not_match_if_different_content_types() {
     let expected = Request { method: s!("GET"), path: s!("/"), query: None,
         headers: Some(hashmap!{ s!("Content-Type") => s!("application/json") }),
         body: OptionalBody::Present(s!("")), matching_rules: None };
-    let actual = Request { method: "GET".to_string(), path: "/".to_string(), query: None,
-        headers: Some(hashmap!{ "Content-Type".to_string() => "text/plain".to_string() }),
+    let actual = Request { method: s!("GET"), path: s!("/"), query: None,
+        headers: Some(hashmap!{ s!("Content-Type") => s!("text/plain") }),
         body: OptionalBody::Missing, matching_rules: None };
     match_body(&expected, &actual, DiffConfig::NoUnexpectedKeys, &mut mismatches, &None);
     expect!(mismatches.clone()).to_not(be_empty());
-    expect!(mismatches[0].clone()).to(be_equal_to(Mismatch::BodyTypeMismatch { expected: "application/json".to_string(),
+    expect!(mismatches[0].clone()).to(be_equal_to(Mismatch::BodyTypeMismatch { expected: s!("application/json"),
         actual: s!("text/plain") }));
 }
 
@@ -573,10 +572,10 @@ fn match_path_returns_a_mismatch_if_the_path_does_not_match_with_a_matcher() {
 fn match_query_returns_no_mismatch_if_the_values_are_not_the_same_but_match_by_a_matcher() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["c".to_string()]);
+    query_map.insert(s!("a"), vec![s!("c")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &Some(hashmap!{
         s!("$.query.a") => hashmap!{ s!("match") => s!("regex"), s!("regex") => s!("\\w+") }
@@ -588,24 +587,24 @@ fn match_query_returns_no_mismatch_if_the_values_are_not_the_same_but_match_by_a
 fn match_query_returns_a_mismatch_if_the_values_do_not_match_by_a_matcher() {
     let mut mismatches = vec![];
     let mut query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let expected = Some(query_map);
     query_map = HashMap::new();
-    query_map.insert("a".to_string(), vec!["b".to_string()]);
+    query_map.insert(s!("a"), vec![s!("b")]);
     let actual = Some(query_map);
     match_query(expected, actual, &mut mismatches, &Some(hashmap!{
         s!("$.query.a") => hashmap!{ s!("match") => s!("regex"), s!("regex") => s!("\\d+") }
     }));
     expect!(mismatches.clone()).to_not(be_empty());
-    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: "a".to_string(),
-        expected: "b".to_string(), actual: "b".to_string(),
+    assert_eq!(mismatches[0], Mismatch::QueryMismatch { parameter: s!("a"),
+        expected: s!("b"), actual: s!("b"),
         mismatch: s!("") });
 }
 
 #[test]
 fn matching_headers_be_true_when_headers_match_by_matcher() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADERX".to_string(), &"HEADERY".to_string(),
+    match_header_value(&s!("HEADER"), &s!("HEADERX"), &s!("HEADERY"),
         &mut mismatches, &Some(hashmap!{
             s!("$.headers.HEADER") => hashmap!{ s!("match") => s!("regex"), s!("regex") => s!("\\w+") }
         }));
@@ -615,12 +614,12 @@ fn matching_headers_be_true_when_headers_match_by_matcher() {
 #[test]
 fn matching_headers_be_false_when_headers_do_not_match_by_matcher() {
     let mut mismatches = vec![];
-    match_header_value(&"HEADER".to_string(), &"HEADER".to_string(), &"HEADER".to_string(),
+    match_header_value(&s!("HEADER"), &s!("HEADER"), &s!("HEADER"),
         &mut mismatches, &Some(hashmap!{
             s!("$.headers.HEADER") => hashmap!{ s!("match") => s!("regex"), s!("regex") => s!("\\d+") }
         }));
     expect!(mismatches.clone()).to_not(be_empty());
-    assert_eq!(mismatches[0], Mismatch::HeaderMismatch { key: "HEADER".to_string(),
-        expected: "HEADER".to_string(), actual: "HEADER".to_string(),
+    assert_eq!(mismatches[0], Mismatch::HeaderMismatch { key: s!("HEADER"),
+        expected: s!("HEADER"), actual: s!("HEADER"),
         mismatch: s!("") });
 }

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -183,7 +183,21 @@ fn matching_headers_be_false_when_headers_are_not_equal() {
     assert!(!mismatches.is_empty());
     assert_eq!(mismatches[0], Mismatch::HeaderMismatch { key: "HEADER".to_string(),
         expected: "HEADER".to_string(), actual: "HEADER2".to_string(),
-        mismatch: "Expected header 'HEADER' to have value 'HEADER' but was 'HEADER2'".to_string() });
+        mismatch: "".to_string() });
+}
+
+#[test]
+fn mismatch_message_generated_when_headers_are_not_equal() {
+    let mut mismatches = vec![];
+    match_header_value(&"HEADER".to_string(), &"HEADER_VALUE".to_string(), &"HEADER2".to_string(),
+                       &mut mismatches, &None);
+
+    let ref raised_mismatch = mismatches[0];
+    match(*raised_mismatch) {
+        Mismatch::HeaderMismatch {ref key, ref expected, ref actual, ref mismatch} =>
+            assert_eq!(mismatch, "Expected header 'HEADER' to have value 'HEADER_VALUE' but was 'HEADER2'"),
+        _ => panic!("Unexpected mismatch response")
+    }
 }
 
 #[test]


### PR DESCRIPTION
`Accept` and `Content-Type` headers now optionally accept parameter values if they are not specified in the expectation, but are enforced if they are specified. Resolves #1 

Also made mismatch messaging consistent when the fallback `EqualityMatcher` is used during header checks and plus tests.