### PR TITLE
Replace deprecated rustc_serialize json library with serde json library

### DIFF
--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -14,8 +14,10 @@ exclude = [
 ]
 
 [dependencies]
-rustc-serialize = "0.3"
+serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
+hex = "0.2.0"
 log = "0.3.5"
 regex = "0.1.56"
 p-macro = "0.2.0"

--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
 
 [dependencies]
 rustc-serialize = "0.3"
+serde_json = "1.0"
 log = "0.3.5"
 regex = "0.1.56"
 p-macro = "0.2.0"

--- a/rust/pact_matching/generate-spec-tests.groovy
+++ b/rust/pact_matching/generate-spec-tests.groovy
@@ -20,16 +20,14 @@ specs.eachFileRecurse(FileType.DIRECTORIES) { dir ->
       pw.println('#[allow(unused_imports)]')
       pw.println('use pact_matching::match_request;')
       pw.println('#[allow(unused_imports)]')
-      pw.println('use rustc_serialize::json::Json;')
-      pw.println('#[allow(unused_imports)]')
       pw.println('use expectest::prelude::*;')
+      pw.println('use serde_json;')
     } else if (requestResponsePath == 'response') {
       pw.println('#[allow(unused_imports)]')
       pw.println('use pact_matching::match_response;')
       pw.println('#[allow(unused_imports)]')
-      pw.println('use rustc_serialize::json::Json;')
-      pw.println('#[allow(unused_imports)]')
       pw.println('use expectest::prelude::*;')
+      pw.println('use serde_json;')
     }
 
     dir.eachDir {
@@ -42,7 +40,7 @@ specs.eachFileRecurse(FileType.DIRECTORIES) { dir ->
         |#[test]
         |fn ${it.name.replaceAll(' ', '_').replaceAll('-', '_').replaceAll('\\.json', '')}() {
         |    env_logger::init().unwrap_or(());
-        |    let pact = Json::from_str(r#"
+        |    let pact : serde_json::Value = serde_json::from_str(r#"
       """
       it.text.eachLine { line ->
         testBody += '|      ' + line + '\n'
@@ -50,12 +48,12 @@ specs.eachFileRecurse(FileType.DIRECTORIES) { dir ->
       testBody += '|    "#).unwrap();' + '\n'
       if (requestResponsePath == 'request') {
         testBody += """
-        |    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::$specVersion);
+        |    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::$specVersion);
         |    println!("{:?}", expected);
-        |    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::$specVersion);
+        |    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::$specVersion);
         |    println!("{:?}", actual);
-        |    let pact_match = pact.find("match").unwrap();
-        |    if pact_match.as_boolean().unwrap() {
+        |    let pact_match = pact.get("match").unwrap();
+        |    if pact_match.as_bool().unwrap() {
         |       expect!(match_request(expected, actual)).to(be_empty());
         |    } else {
         |       expect!(match_request(expected, actual)).to_not(be_empty());
@@ -63,13 +61,13 @@ specs.eachFileRecurse(FileType.DIRECTORIES) { dir ->
         """
       } else if (requestResponsePath == 'response') {
         testBody += """
-        |    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::$specVersion);
+        |    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::$specVersion);
         |    println!("{:?}", expected);
-        |    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::$specVersion);
+        |    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::$specVersion);
         |    println!("{:?}", actual);
-        |    let pact_match = pact.find("match").unwrap();
+        |    let pact_match = pact.get("match").unwrap();
         |    let result = match_response(expected, actual);
-        |    if pact_match.as_boolean().unwrap() {
+        |    if pact_match.as_bool().unwrap() {
         |       expect!(result).to(be_empty());
         |    } else {
         |       expect!(result).to_not(be_empty());

--- a/rust/pact_matching/src/json.rs
+++ b/rust/pact_matching/src/json.rs
@@ -232,22 +232,22 @@ fn compare_maps(path: &Vec<String>, expected: &serde_json::Map<String, Value>, a
 
     if expected.is_empty() && !actual.is_empty() {
       mismatches.push(Mismatch::BodyMismatch { path: path.join("."),
-          expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-          actual: Some(value_of(&json!(serde_json::to_string(actual).unwrap()))),
-          mismatch: format!("Expected an empty Map but received {}", value_of(&json!(serde_json::to_string(actual).unwrap())))});
+          expected: Some(value_of(&json!(expected))),
+          actual: Some(value_of(&json!(actual))),
+          mismatch: format!("Expected an empty Map but received {}", value_of(&json!(actual)))});
     } else {
         match config {
             &DiffConfig::AllowUnexpectedKeys if expected.len() > actual.len() => {
                 mismatches.push(Mismatch::BodyMismatch { path: path.join("."),
-                    expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-                    actual: Some(value_of(&json!(serde_json::to_string(&actual).unwrap()))),
+                    expected: Some(value_of(&json!(expected))),
+                    actual: Some(value_of(&json!(&actual))),
                     mismatch: format!("Expected a Map with at least {} elements but received {} elements",
                     expected.len(), actual.len())});
             },
             &DiffConfig::NoUnexpectedKeys if expected.len() != actual.len() => {
                 mismatches.push(Mismatch::BodyMismatch { path: path.join("."),
-                    expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-                    actual: Some(value_of(&json!(serde_json::to_string(&actual).unwrap()))),
+                    expected: Some(value_of(&json!(expected))),
+                    actual: Some(value_of(&json!(&actual))),
                     mismatch: format!("Expected a Map with {} elements but received {} elements",
                     expected.len(), actual.len())});
             },
@@ -274,8 +274,8 @@ fn compare_maps(path: &Vec<String>, expected: &serde_json::Map<String, Value>, a
                     compare(&p, value, &actual[key], config, mismatches, matchers);
                 } else {
                     mismatches.push(Mismatch::BodyMismatch { path: path.join("."),
-                        expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-                        actual: Some(value_of(&json!(serde_json::to_string(&actual).unwrap()))),
+                        expected: Some(value_of(&json!(expected))),
+                        actual: Some(value_of(&json!(&actual))),
                         mismatch: format!("Expected entry {}={} but was missing", key, value_of(value))});
                 }
             }
@@ -304,15 +304,15 @@ fn compare_lists(path: &Vec<String>, expected: &Vec<Value>, actual: &Vec<Value>,
     } else {
         if expected.is_empty() && !actual.is_empty() {
             mismatches.push(Mismatch::BodyMismatch { path: spath,
-                expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-                actual: Some(value_of(&json!(serde_json::to_string(actual).unwrap()))),
-                mismatch: format!("Expected an empty List but received {}", value_of(&json!(serde_json::to_string(actual).unwrap())))});
+                expected: Some(value_of(&json!(expected))),
+                actual: Some(value_of(&json!(actual))),
+                mismatch: format!("Expected an empty List but received {}", value_of(&json!(actual)))});
         } else {
             compare_list_content(path, expected, actual, config, mismatches, matchers);
             if expected.len() != actual.len() {
                 mismatches.push(Mismatch::BodyMismatch { path: spath,
-                    expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-                    actual: Some(value_of(&json!(serde_json::to_string(actual).unwrap()))),
+                    expected: Some(value_of(&json!(expected))),
+                    actual: Some(value_of(&json!(actual))),
                     mismatch: format!("Expected a List with {} elements but received {} elements",
                         expected.len(), actual.len())});
             }
@@ -331,8 +331,8 @@ fn compare_list_content(path: &Vec<String>, expected: &Vec<Value>, actual: &Vec<
           compare(&p, value, &actual[index], config, mismatches, matchers);
       } else if !matcher_is_defined(&p, matchers) {
           mismatches.push(Mismatch::BodyMismatch { path: path.join("."),
-              expected: Some(value_of(&json!(serde_json::to_string(expected).unwrap()))),
-              actual: Some(value_of(&json!(serde_json::to_string(actual).unwrap()))),
+              expected: Some(value_of(&json!(expected))),
+              actual: Some(value_of(&json!(actual))),
               mismatch: format!("Expected {} but was missing", value_of(value))});
       }
     }

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -326,13 +326,14 @@
 //!
 
 #![warn(missing_docs)]
-
-extern crate rustc_serialize;
 #[macro_use] extern crate serde_json;
+#[macro_use]extern crate serde_derive;
+//extern crate serde;
 #[macro_use] extern crate log;
 #[macro_use] extern crate p_macro;
 #[macro_use] extern crate maplit;
 #[macro_use] extern crate lazy_static;
+extern crate hex;
 extern crate regex;
 extern crate semver;
 #[macro_use] extern crate itertools;
@@ -351,7 +352,6 @@ macro_rules! s {
 
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use rustc_serialize::json::{Json, ToJson};
 use regex::Regex;
 use ansi_term::*;
 use ansi_term::Colour::*;
@@ -448,76 +448,69 @@ pub enum Mismatch {
 
 impl Mismatch {
     /// Converts the mismatch to a `Json` struct.
-    pub fn to_json(&self) -> Json {
+    pub fn to_json(&self) -> serde_json::Value {
         match self {
             &Mismatch::MethodMismatch { expected: ref e, actual: ref a } => {
-                let map = btreemap!{
-                    s!("type") => s!("MethodMismatch").to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("MethodMismatch"),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a)
+                })
             },
             &Mismatch::PathMismatch { expected: ref e, actual: ref a, mismatch: ref m } => {
-                let map = btreemap!{
-                    s!("type") => s!("PathMismatch").to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json(),
-                    s!("mismatch") => m.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("PathMismatch"),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a),
+                    s!("mismatch") : json!(m)
+                })
             },
             &Mismatch::StatusMismatch { expected: ref e, actual: ref a } => {
-                let map = btreemap!{
-                    s!("type") => s!("StatusMismatch").to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("StatusMismatch"),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a)
+                })
             },
             &Mismatch::QueryMismatch { parameter: ref p, expected: ref e, actual: ref a, mismatch: ref m } => {
-                let map = btreemap!{
-                    s!("type") => s!("QueryMismatch").to_json(),
-                    s!("parameter") => p.to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json(),
-                    s!("mismatch") => m.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("QueryMismatch"),
+                    s!("parameter") : json!(p),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a),
+                    s!("mismatch") : json!(m)
+                })
             },
             &Mismatch::HeaderMismatch { key: ref k, expected: ref e, actual: ref a, mismatch: ref m } => {
-                let map = btreemap!{
-                    s!("type") => s!("HeaderMismatch").to_json(),
-                    s!("key") => k.to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json(),
-                    s!("mismatch") => m.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("HeaderMismatch"),
+                    s!("key") : json!(k),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a),
+                    s!("mismatch") : json!(m)
+                })
             },
             &Mismatch::BodyTypeMismatch { expected: ref e, actual: ref a } => {
-                let map = btreemap!{
-                    s!("type") => s!("BodyTypeMismatch").to_json(),
-                    s!("expected") => e.to_json(),
-                    s!("actual") => a.to_json()
-                };
-                Json::Object(map)
+                json!({
+                    s!("type") : json!("BodyTypeMismatch"),
+                    s!("expected") : json!(e),
+                    s!("actual") : json!(a)
+                })
             },
             &Mismatch::BodyMismatch { path: ref p, expected: ref e, actual: ref a, mismatch: ref m } => {
-                let map = btreemap!{
-                    s!("type") => s!("BodyMismatch").to_json(),
-                    s!("path") => p.to_json(),
-                    s!("expected") => match e {
-                        &Some(ref v) => v.to_json(),
-                        &None => Json::Null
+                 json!({
+                    s!("type") : json!("BodyMismatch"),
+                    s!("path") : json!(p),
+                    s!("expected") : match e {
+                        &Some(ref v) => json!(v),
+                        &None => serde_json::Value::Null
                     },
-                    s!("actual") => match a {
-                        &Some(ref v) => v.to_json(),
-                        &None => Json::Null
+                    s!("actual") : match a {
+                        &Some(ref v) => json!(v),
+                        &None => serde_json::Value::Null
                     },
-                    s!("mismatch") => m.to_json()
-                };
-                Json::Object(map)
+                    s!("mismatch") : json!(m)
+                })
             }
         }
     }

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -327,8 +327,7 @@
 
 #![warn(missing_docs)]
 #[macro_use] extern crate serde_json;
-#[macro_use]extern crate serde_derive;
-//extern crate serde;
+#[macro_use] extern crate serde_derive;
 #[macro_use] extern crate log;
 #[macro_use] extern crate p_macro;
 #[macro_use] extern crate maplit;

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -328,6 +328,7 @@
 #![warn(missing_docs)]
 
 extern crate rustc_serialize;
+#[macro_use] extern crate serde_json;
 #[macro_use] extern crate log;
 #[macro_use] extern crate p_macro;
 #[macro_use] extern crate maplit;

--- a/rust/pact_matching/src/matchers.rs
+++ b/rust/pact_matching/src/matchers.rs
@@ -7,7 +7,7 @@ fn matches_token(path_fragment: &String, path_token: &PathToken) -> u32 {
     match *path_token {
         PathToken::Root if path_fragment == "$" => 2,
         PathToken::Field(ref name) if *path_fragment == name.clone() => 2,
-        PathToken::Index(ref index) => match path_fragment.parse() {
+        PathToken::Index(ref index) => match path_fragment.parse::<usize>() {
             Ok(ref i) if index == i => 2,
             _ => 0
         },

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -943,7 +943,7 @@ impl Pact {
     /// Reads the pact file and parses the resulting JSON into a `Pact` struct
     pub fn read_pact(file: &Path) -> io::Result<Pact> {
         let mut f = try!(File::open(file));
-        let pact_json = serde_json::de::from_reader(&mut f);
+        let pact_json = serde_json::from_reader(&mut f);
         match pact_json {
             Ok(ref json) => Ok(Pact::from_json(&format!("{:?}", file), json)),
             Err(err) => Err(Error::new(ErrorKind::Other, format!("Failed to parse Pact JSON - {}", err)))
@@ -977,14 +977,14 @@ impl Pact {
             match existing_pact.merge(self) {
                 Ok(ref merged_pact) => {
                     let mut file = try!(File::create(path));
-                    try!(file.write_all(format!("{:?}", serde_json::to_string_pretty(&merged_pact.to_json())).as_bytes()));
+                    try!(file.write_all(format!("{}", serde_json::to_string_pretty(&merged_pact.to_json()).unwrap()).as_bytes()));
                     Ok(())
                 },
                 Err(ref message) => Err(Error::new(ErrorKind::Other, message.clone()))
             }
         } else {
             let mut file = try!{ File::create(path) };
-            try!{ file.write_all(format!("{:?}", serde_json::to_string_pretty(&self.to_json())).as_bytes()) };
+            try!{ file.write_all(format!("{}", serde_json::to_string_pretty(&self.to_json()).unwrap()).as_bytes()) };
             Ok(())
         }
     }

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -334,7 +334,7 @@ fn body_from_json(request: &Value, headers: &Option<HashMap<String, String>>) ->
                     OptionalBody::Empty
                 } else if content_type.unwrap_or(s!("")) == "application/json" {
                     // fuck, that's all I have to say about this
-                    match serde_json::from_str::<String>(&s) {
+                    match serde_json::from_str::<HashMap<String, Value>>(&s) {
                         Ok(_) => OptionalBody::Present(s.clone()),
                         Err(_) => OptionalBody::Present(format!("\"{}\"", s))
                     }

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -2,8 +2,10 @@
 
 use std::collections::HashMap;
 use std::collections::BTreeMap;
-use rustc_serialize::json::Json;
-use rustc_serialize::hex::FromHex;
+use serde_json;
+use serde_json::Value;
+use serde_json::Value::{Object, Number};
+use hex::FromHex;
 use super::strip_whitespace;
 use regex::Regex;
 use semver::Version;
@@ -13,6 +15,7 @@ use std::io::prelude::*;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
+use std::iter::Map;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use hyper::client::Client;
@@ -65,10 +68,10 @@ pub struct Consumer {
 
 impl Consumer {
     /// Builds a `Consumer` from the `Json` struct.
-    pub fn from_json(pact_json: &Json) -> Consumer {
-        let val = match pact_json.find("name") {
+    pub fn from_json(pact_json: &Value) -> Consumer {
+        let val = match pact_json.get("name") {
             Some(v) => match v.clone() {
-                Json::String(s) => s,
+                Value::String(s) => s,
                 _ => v.to_string()
             },
             None => "consumer".to_string()
@@ -77,8 +80,8 @@ impl Consumer {
     }
 
     /// Converts this `Consumer` to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        Json::Object(btreemap!{ s!("name") => Json::String(self.name.clone()) })
+    pub fn to_json(&self) -> Value {
+        json!({ s!("name") : json!(self.name.clone()) })
     }
 }
 
@@ -91,10 +94,10 @@ pub struct Provider {
 
 impl Provider {
     /// Builds a `Provider` from a `Json` struct.
-    pub fn from_json(pact_json: &Json) -> Provider {
-        let val = match pact_json.find("name") {
+    pub fn from_json(pact_json: &Value) -> Provider {
+        let val = match pact_json.get("name") {
             Some(v) => match v.clone() {
-                Json::String(s) => s,
+                Value::String(s) => s,
                 _ => v.to_string()
             },
             None => "provider".to_string()
@@ -103,14 +106,14 @@ impl Provider {
     }
 
     /// Converts this `Provider` to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        Json::Object(btreemap!{ s!("name") => Json::String(self.name.clone()) })
+    pub fn to_json(&self) -> Value {
+        json!({ s!("name") : json!(self.name.clone()) })
     }
 }
 
 /// Enum that defines the four main states that a body of a request and response can be in a pact
 /// file.
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum OptionalBody {
     /// A body is missing if it is not present in the pact file
     Missing,
@@ -218,9 +221,9 @@ pub trait HttpPart {
     /// Returns the general content type (ignoring subtypes)
     fn content_type_enum(&self) -> DetectedContentType {
         let content_type = self.content_type();
-        if JSON_CONTENT_TYPE.is_match(&content_type) {
+        if JSON_CONTENT_TYPE.is_match(&content_type[..]) {
             DetectedContentType::Json
-        } else if XML_CONTENT_TYPE.is_match(&content_type) {
+        } else if XML_CONTENT_TYPE.is_match(&content_type[..]) {
             DetectedContentType::Xml
         } else {
             DetectedContentType::Text
@@ -288,12 +291,12 @@ impl Hash for Request {
     }
 }
 
-fn headers_from_json(request: &Json) -> Option<HashMap<String, String>> {
-    match request.find("headers") {
+fn headers_from_json(request: &Value) -> Option<HashMap<String, String>> {
+    match request.get("headers") {
         Some(v) => match *v {
-            Json::Object(ref m) => Some(m.iter().map(|(key, val)| {
+            Value::Object(ref m) => Some(m.iter().map(|(key, val)| {
                 match val {
-                    &Json::String(ref s) => (key.clone(), s.clone()),
+                    &Value::String(ref s) => (key.clone(), s.clone()),
                     _ => (key.clone(), val.to_string())
                 }
             }).collect()),
@@ -303,14 +306,14 @@ fn headers_from_json(request: &Json) -> Option<HashMap<String, String>> {
     }
 }
 
-fn headers_to_json(headers: &HashMap<String, String>) -> Json {
-    Json::Object(headers.iter().fold(BTreeMap::new(), |mut map, kv| {
-        map.insert(kv.0.clone(), Json::String(kv.1.clone()));
+fn headers_to_json(headers: &HashMap<String, String>) -> Value {
+    json!(headers.iter().fold(BTreeMap::new(), |mut map, kv| {
+        map.insert(kv.0.clone(), Value::String(kv.1.clone()));
         map
     }))
 }
 
-fn body_from_json(request: &Json, headers: &Option<HashMap<String, String>>) -> OptionalBody {
+fn body_from_json(request: &Value, headers: &Option<HashMap<String, String>>) -> OptionalBody {
     let content_type = match headers {
         &Some(ref h) => match h.iter().find(|kv| kv.0.to_lowercase() == s!("content-type")) {
             Some(kv) => {
@@ -324,14 +327,14 @@ fn body_from_json(request: &Json, headers: &Option<HashMap<String, String>>) -> 
         &None => None
     };
 
-    match request.find("body") {
+    match request.get("body") {
         Some(v) => match *v {
-            Json::String(ref s) => {
+            Value::String(ref s) => {
                 if s.is_empty() {
                     OptionalBody::Empty
                 } else if content_type.unwrap_or(s!("")) == "application/json" {
                     // fuck, that's all I have to say about this
-                    match Json::from_str(&s) {
+                    match serde_json::from_str::<String>(&s) {
                         Ok(_) => OptionalBody::Present(s.clone()),
                         Err(_) => OptionalBody::Present(format!("\"{}\"", s))
                     }
@@ -339,7 +342,7 @@ fn body_from_json(request: &Json, headers: &Option<HashMap<String, String>>) -> 
                     OptionalBody::Present(s.clone())
                 }
             },
-            Json::Null => OptionalBody::Null,
+            Value::Null => OptionalBody::Null,
             _ => OptionalBody::Present(v.to_string())
         },
         None => OptionalBody::Missing
@@ -359,19 +362,19 @@ pub fn build_query_string(query: HashMap<String, Vec<String>>) -> String {
         .join("&")
 }
 
-fn matchers_from_json(json: &Json, deprecated_name: String) -> Option<Matchers> {
-    let matchers_json = match (json.find("matchingRules"), json.find(&deprecated_name)) {
+fn matchers_from_json(json: &Value, deprecated_name: String) -> Option<Matchers> {
+    let matchers_json = match (json.get("matchingRules"), json.get(&deprecated_name)) {
         (Some(v), _) => Some(v),
         (None, Some(v)) => Some(v),
         (None, None) => None
     };
     let matchers = matchers_json.map(|v| {
         match *v {
-            Json::Object(ref m) => m.iter().map(|(k, val)| {
+            Value::Object(ref m) => m.iter().map(|(k, val)| {
                 (k.clone(), match *val {
-                    Json::Object(ref m2) => m2.iter().map(|(k2, v2)| {
+                    Value::Object(ref m2) => m2.iter().map(|(k2, v2)| {
                         (k2.clone(), match v2 {
-                            &Json::String(ref s) => s.clone(),
+                            &Value::String(ref s) => s.clone(),
                             _ => v2.to_string()
                         })
                     }).collect(),
@@ -391,10 +394,10 @@ fn matchers_from_json(json: &Json, deprecated_name: String) -> Option<Matchers> 
     }
 }
 
-fn matchers_to_json(matchers: &Matchers) -> Json {
-    Json::Object(matchers.iter().fold(BTreeMap::new(), |mut map, kv| {
-        map.insert(kv.0.clone(), Json::Object(kv.1.clone().iter().fold(BTreeMap::new(), |mut map, kv| {
-            map.insert(kv.0.clone(), Json::String(kv.1.clone()));
+fn matchers_to_json(matchers: &Matchers) -> Value {
+    json!(matchers.iter().fold(BTreeMap::new(), |mut map, kv| {
+        map.insert(kv.0.clone(), json!(kv.1.clone().iter().fold(BTreeMap::new(), |mut map, kv| {
+            map.insert(kv.0.clone(), Value::String(kv.1.clone()));
             map
         })));
         map
@@ -403,24 +406,24 @@ fn matchers_to_json(matchers: &Matchers) -> Json {
 
 impl Request {
     /// Builds a `Request` from a `Json` struct.
-    pub fn from_json(request_json: &Json, spec_version: &PactSpecification) -> Request {
-        let method_val = match request_json.find("method") {
+    pub fn from_json(request_json: &Value, spec_version: &PactSpecification) -> Request {
+        let method_val = match request_json.get("method") {
             Some(v) => match *v {
-                Json::String(ref s) => s.to_uppercase(),
+                Value::String(ref s) => s.to_uppercase(),
                 _ => v.to_string().to_uppercase()
             },
             None => "GET".to_string()
         };
-        let path_val = match request_json.find("path") {
+        let path_val = match request_json.get("path") {
             Some(v) => match *v {
-                Json::String(ref s) => s.clone(),
+                Value::String(ref s) => s.clone(),
                 _ => v.to_string()
             },
             None => "/".to_string()
         };
-        let query_val = match request_json.find("query") {
+        let query_val = match request_json.get("query") {
             Some(v) => match *v {
-                Json::String(ref s) => parse_query_string(s),
+                Value::String(ref s) => parse_query_string(s),
                 _ => {
                     warn!("Only string versions of request query strings are supported with specification version {}, ignoring.",
                         spec_version.to_string());
@@ -441,39 +444,42 @@ impl Request {
     }
 
     /// Converts this `Request` to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        let mut json = btreemap!{
-            s!("method") => Json::String(self.method.to_uppercase()),
-            s!("path") => Json::String(self.path.clone())
-        };
-        if self.query.is_some() {
-            json.insert(s!("query"), Json::String(build_query_string(self.query.clone().unwrap())));
-        }
-        if self.headers.is_some() {
-            json.insert(s!("headers"), headers_to_json(&self.headers.clone().unwrap()));
-        }
-        match self.body {
-            OptionalBody::Present(ref body) => {
-                if self.content_type() == "application/json" {
-                    match Json::from_str(body) {
-                        Ok(json_body) => { json.insert(s!("body"), json_body); },
-                        Err(err) => {
-                            warn!("Failed to parse json body: {}", err);
-                            json.insert(s!("body"), Json::String(body.clone()));
+    pub fn to_json(&self) -> Value {
+        let mut json = json!({
+            s!("method") : Value::String(self.method.to_uppercase()),
+            s!("path") : Value::String(self.path.clone())
+        });
+        {
+            let mut map = json.as_object_mut().unwrap();
+            if self.query.is_some() {
+                map.insert(s!("query"), Value::String(build_query_string(self.query.clone().unwrap())));
+            }
+            if self.headers.is_some() {
+                map.insert(s!("headers"), headers_to_json(&self.headers.clone().unwrap()));
+            }
+            match self.body {
+                OptionalBody::Present(ref body) => {
+                    if self.content_type() == "application/json" {
+                        match serde_json::from_str(body) {
+                            Ok(json_body) => { map.insert(s!("body"), json_body); },
+                            Err(err) => {
+                                warn!("Failed to parse json body: {}", err);
+                                map.insert(s!("body"), Value::String(body.clone()));
+                            }
                         }
+                    } else {
+                        map.insert(s!("body"), Value::String(body.clone()));
                     }
-                } else {
-                    json.insert(s!("body"), Json::String(body.clone()));
-                }
-            },
-            OptionalBody::Empty => { json.insert(s!("body"), Json::String(s!(""))); },
-            OptionalBody::Missing => (),
-            OptionalBody::Null => { json.insert(s!("body"), Json::Null); }
+                },
+                OptionalBody::Empty => { map.insert(s!("body"), Value::String(s!(""))); },
+                OptionalBody::Missing => (),
+                OptionalBody::Null => { map.insert(s!("body"), Value::Null); }
+            }
+            if self.matching_rules.is_some() {
+                map.insert(s!("matchingRules"), matchers_to_json(&self.matching_rules.clone().unwrap()));
+            }
         }
-        if self.matching_rules.is_some() {
-            json.insert(s!("matchingRules"), matchers_to_json(&self.matching_rules.clone().unwrap()));
-        }
-        Json::Object(json)
+        json
     }
 
     /// Returns the default request: a GET request to the root.
@@ -529,8 +535,8 @@ pub struct Response {
 impl Response {
 
     /// Build a `Response` from a `Json` struct.
-    pub fn from_json(response: &Json, _: &PactSpecification) -> Response {
-        let status_val = match response.find("status") {
+    pub fn from_json(response: &Value, _: &PactSpecification) -> Response {
+        let status_val = match response.get("status") {
             Some(v) => v.as_u64().unwrap() as u16,
             None => 200
         };
@@ -554,35 +560,38 @@ impl Response {
     }
 
     /// Converts this response to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        let mut json = btreemap!{
-            s!("status") => Json::U64(self.status as u64)
-        };
-        if self.headers.is_some() {
-            json.insert(s!("headers"), headers_to_json(&self.headers.clone().unwrap()));
-        }
-        match self.body {
-            OptionalBody::Present(ref body) => {
-                if self.content_type() == "application/json" {
-                    match Json::from_str(body) {
-                        Ok(json_body) => { json.insert(s!("body"), json_body); },
-                        Err(err) => {
-                            warn!("Failed to parse json body: {}", err);
-                            json.insert(s!("body"), Json::String(body.clone()));
+    pub fn to_json(&self) -> Value {
+        let mut json = json!({
+            s!("status") : json!(self.status)
+        });
+        {
+            let mut map = json.as_object_mut().unwrap();
+            if self.headers.is_some() {
+                map.insert(s!("headers"), headers_to_json(&self.headers.clone().unwrap()));
+            }
+            match self.body {
+                OptionalBody::Present(ref body) => {
+                    if self.content_type() == "application/json" {
+                        match serde_json::from_str(body) {
+                            Ok(json_body) => { map.insert(s!("body"), json_body); },
+                            Err(err) => {
+                                warn!("Failed to parse json body: {}", err);
+                                map.insert(s!("body"), Value::String(body.clone()));
+                            }
                         }
+                    } else {
+                        map.insert(s!("body"), Value::String(body.clone()));
                     }
-                } else {
-                    json.insert(s!("body"), Json::String(body.clone()));
-                }
-            },
-            OptionalBody::Empty => { json.insert(s!("body"), Json::String(s!(""))); },
-            OptionalBody::Missing => (),
-            OptionalBody::Null => { json.insert(s!("body"), Json::Null); }
+                },
+                OptionalBody::Empty => { map.insert(s!("body"), Value::String(s!(""))); },
+                OptionalBody::Missing => (),
+                OptionalBody::Null => { map.insert(s!("body"), Value::Null); }
+            }
+            if self.matching_rules.is_some() {
+                map.insert(s!("matchingRules"), matchers_to_json(&self.matching_rules.clone().unwrap()));
+            }
         }
-        if self.matching_rules.is_some() {
-            json.insert(s!("matchingRules"), matchers_to_json(&self.matching_rules.clone().unwrap()));
-        }
-        Json::Object(json)
+        json
     }
 
     /// Return a description of all the differences from the other response
@@ -665,31 +674,31 @@ pub struct Interaction {
 
 impl Interaction {
     /// Constructs an `Interaction` from the `Json` struct.
-    pub fn from_json(index: usize, pact_json: &Json, spec_version: &PactSpecification) -> Interaction {
-        let description = match pact_json.find("description") {
+    pub fn from_json(index: usize, pact_json: &Value, spec_version: &PactSpecification) -> Interaction {
+        let description = match pact_json.get("description") {
             Some(v) => match *v {
-                Json::String(ref s) => s.clone(),
+                Value::String(ref s) => s.clone(),
                 _ => v.to_string()
             },
             None => format!("Interaction {}", index)
         };
-        let provider_state = match pact_json.find("providerState").or(pact_json.find("provider_state")) {
+        let provider_state = match pact_json.get("providerState").or(pact_json.get("provider_state")) {
             Some(v) => match *v {
-                Json::String(ref s) => if s.is_empty() {
+                Value::String(ref s) => if s.is_empty() {
                     None
                 } else {
                     Some(s.clone())
                 },
-                Json::Null => None,
+                Value::Null => None,
                 _ => Some(v.to_string())
             },
             None => None
         };
-        let request = match pact_json.find("request") {
+        let request = match pact_json.get("request") {
             Some(v) => Request::from_json(v, spec_version),
             None => Request::default_request()
         };
-        let response = match pact_json.find("response") {
+        let response = match pact_json.get("response") {
             Some(v) => Response::from_json(v, spec_version),
             None => Response::default_response()
         };
@@ -702,16 +711,17 @@ impl Interaction {
     }
 
     /// Converts this interaction to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        let mut map = btreemap!{
-            s!("description") => Json::String(self.description.clone()),
-            s!("request") => self.request.to_json(),
-            s!("response") => self.response.to_json()
-        };
+    pub fn to_json(&self) -> Value {
+        let mut value = json!({
+            s!("description") : Value::String(self.description.clone()),
+            s!("request") : self.request.to_json(),
+            s!("response") : self.response.to_json()
+        });
         if self.provider_state.is_some() {
-            map.insert(s!("providerState"), Json::String(self.provider_state.clone().unwrap()));
+            let mut map = value.as_object_mut().unwrap();
+            map.insert(s!("providerState"), json!(self.provider_state.clone().unwrap()));
         }
-        Json::Object(map)
+        value
     }
 
     /// Returns list of conflicts if this interaction conflicts with the other interaction.
@@ -758,14 +768,14 @@ pub struct Pact {
     pub specification_version: PactSpecification
 }
 
-fn parse_meta_data(pact_json: &Json) -> BTreeMap<String, BTreeMap<String, String>> {
-    match pact_json.find("metadata") {
+fn parse_meta_data(pact_json: &Value) -> BTreeMap<String, BTreeMap<String, String>> {
+    match pact_json.get("metadata") {
         Some(v) => match *v {
-            Json::Object(ref obj) => obj.iter().map(|(k, v)| {
+            Value::Object(ref obj) => obj.iter().map(|(k, v)| {
                 let val = match *v {
-                    Json::Object(ref obj) => obj.iter().map(|(k, v)| {
+                    Value::Object(ref obj) => obj.iter().map(|(k, v)| {
                         match *v {
-                            Json::String(ref s) => (k.clone(), s.clone()),
+                            Value::String(ref s) => (k.clone(), s.clone()),
                             _ => (k.clone(), v.to_string())
                         }
                     }).collect(),
@@ -779,10 +789,10 @@ fn parse_meta_data(pact_json: &Json) -> BTreeMap<String, BTreeMap<String, String
     }
 }
 
-fn parse_interactions(pact_json: &Json, spec_version: PactSpecification) -> Vec<Interaction> {
-    match pact_json.find("interactions") {
+fn parse_interactions(pact_json: &Value, spec_version: PactSpecification) -> Vec<Interaction> {
+    match pact_json.get("interactions") {
         Some(v) => match *v {
-            Json::Array(ref array) => array.iter().enumerate().map(|(index, ijson)| {
+            Value::Array(ref array) => array.iter().enumerate().map(|(index, ijson)| {
                 Interaction::from_json(index, ijson, &spec_version)
             }).collect(),
             _ => vec![]
@@ -832,15 +842,15 @@ fn determin_spec_version(file: &String, metadata: &BTreeMap<String, BTreeMap<Str
 impl Pact {
 
     /// Creates a `Pact` from a `Json` struct.
-    pub fn from_json(file: &String, pact_json: &Json) -> Pact {
+    pub fn from_json(file: &String, pact_json: &Value) -> Pact {
         let metadata = parse_meta_data(pact_json);
         let spec_version = determin_spec_version(file, &metadata);
 
-        let consumer = match pact_json.find("consumer") {
+        let consumer = match pact_json.get("consumer") {
             Some(v) => Consumer::from_json(v),
             None => Consumer { name: s!("consumer") }
         };
-        let provider = match pact_json.find("provider") {
+        let provider = match pact_json.get("provider") {
             Some(v) => Provider::from_json(v),
             None => Provider { name: s!("provider") }
         };
@@ -854,25 +864,27 @@ impl Pact {
     }
 
     /// Converts this pact to a `Json` struct.
-    pub fn to_json(&self) -> Json {
-        let map = btreemap!{
-            s!("consumer") => self.consumer.to_json(),
-            s!("provider") => self.provider.to_json(),
-            s!("interactions") => Json::Array(self.interactions.iter().map(|i| i.to_json()).collect()),
-            s!("metadata") => Json::Object(self.metadata_to_json())
-        };
-        Json::Object(map)
+    pub fn to_json(&self) -> Value {
+        json!({
+            s!("consumer"): self.consumer.to_json(),
+            s!("provider"): self.provider.to_json(),
+            s!("interactions"): Value::Array(self.interactions.iter().map(|i| i.to_json()).collect()),
+            s!("metadata"): json!(self.metadata_to_json())
+        })
     }
 
     /// Creates a BTreeMap of the metadata of this pact.
-    pub fn metadata_to_json(&self) -> BTreeMap<String, Json> {
-        let mut md_map: BTreeMap<String, Json> = self.metadata.iter()
+    pub fn metadata_to_json(&self) -> BTreeMap<String, Value> {
+        let mut md_map: BTreeMap<String, Value> = self.metadata.iter()
             .map(|(k, v)| {
-                (k.clone(), Json::Object(v.iter().map(|(k, v)| (k.clone(), Json::String(v.clone()))).collect()))
+                (k.clone(), json!(v.iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<BTreeMap<String, String>>()))
             })
             .collect();
-        md_map.insert(s!("pact-specification"), Json::Object(btreemap!{ s!("version") => Json::String(PactSpecification::V2.version_str()) }));
-        md_map.insert(s!("pact-rust"), Json::Object(btreemap!{ s!("version") => Json::String(s!(VERSION.unwrap_or("unknown"))) }));
+        md_map.insert(s!("pact-specification"), json!({"version" : PactSpecification::V2.version_str()}));
+
+        md_map.insert(s!("pact-rust"), json!({"version" : s!(VERSION.unwrap_or("unknown"))}));
         md_map
     }
 
@@ -931,7 +943,7 @@ impl Pact {
     /// Reads the pact file and parses the resulting JSON into a `Pact` struct
     pub fn read_pact(file: &Path) -> io::Result<Pact> {
         let mut f = try!(File::open(file));
-        let pact_json = Json::from_reader(&mut f);
+        let pact_json = serde_json::de::from_reader(&mut f);
         match pact_json {
             Ok(ref json) => Ok(Pact::from_json(&format!("{:?}", file), json)),
             Err(err) => Err(Error::new(ErrorKind::Other, format!("Failed to parse Pact JSON - {}", err)))
@@ -943,7 +955,7 @@ impl Pact {
         let client = Client::new();
         match client.get(url).send() {
             Ok(mut res) => if res.status.is_success() {
-                    let pact_json = Json::from_reader(&mut res);
+                    let pact_json = serde_json::de::from_reader(&mut res);
                     match pact_json {
                         Ok(ref json) => Ok(Pact::from_json(url, json)),
                         Err(err) => Err(format!("Failed to parse Pact JSON - {}", err))
@@ -965,14 +977,14 @@ impl Pact {
             match existing_pact.merge(self) {
                 Ok(ref merged_pact) => {
                     let mut file = try!(File::create(path));
-                    try!(file.write_all(format!("{}", merged_pact.to_json().pretty()).as_bytes()));
+                    try!(file.write_all(format!("{:?}", serde_json::to_string_pretty(&merged_pact.to_json())).as_bytes()));
                     Ok(())
                 },
                 Err(ref message) => Err(Error::new(ErrorKind::Other, message.clone()))
             }
         } else {
             let mut file = try!{ File::create(path) };
-            try!{ file.write_all(format!("{}", self.to_json().pretty()).as_bytes()) };
+            try!{ file.write_all(format!("{:?}", serde_json::to_string_pretty(&self.to_json())).as_bytes()) };
             Ok(())
         }
     }
@@ -1007,7 +1019,8 @@ fn decode_query(query: &str) -> String {
                     let mut s = String::new();
                     s.push(v1);
                     s.push(v2);
-                    match s.as_str().from_hex() {
+                    let decoded: Result<Vec<u8>, _> = FromHex::from_hex(s.into_bytes());
+                    match decoded {
                         Ok(n) => result.push(n[0] as char),
                         Err(_) => {
                             result.push('%');

--- a/rust/pact_matching/src/models/tests.rs
+++ b/rust/pact_matching/src/models/tests.rs
@@ -11,26 +11,26 @@ use std::hash::{Hash, Hasher, SipHasher};
 
 #[test]
 fn request_from_json_defaults_to_get() {
-    let request_json = json!(r#"
+    let request_json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {}
       }
-    "#);
+     "#).unwrap();
     let request = Request::from_json(&request_json, &PactSpecification::V1_1);
     assert_eq!(request.method, "GET".to_string());
 }
 
 #[test]
 fn request_from_json_defaults_to_root_for_path() {
-    let request_json = json!(r#"
+    let request_json : serde_json::Value = serde_json::from_str(r#"
       {
           "method": "PUT",
           "query": "",
           "headers": {}
       }
-    "#);
+     "#).unwrap();
     println!("request_json: {}", request_json);
     let request = Request::from_json(&request_json, &PactSpecification::V1_1);
     assert_eq!(request.path, "/".to_string());
@@ -38,11 +38,11 @@ fn request_from_json_defaults_to_root_for_path() {
 
 #[test]
 fn response_from_json_defaults_to_status_200() {
-    let response_json = json!(r#"
+    let response_json : serde_json::Value = serde_json::from_str(r#"
       {
           "headers": {}
       }
-    "#);
+     "#).unwrap();
     let response = Response::from_json(&response_json, &PactSpecification::V1_1);
     assert_eq!(response.status, 200);
 }
@@ -210,7 +210,7 @@ fn loading_interaction_from_json() {
         "description": "String",
         "providerState": "provider state"
     }"#;
-    let interaction = Interaction::from_json(0, &json!(interaction_json), &PactSpecification::V1_1);
+    let interaction = Interaction::from_json(0, &serde_json::from_str({interaction_json}).unwrap(), &PactSpecification::V1_1);
     expect!(interaction.description).to(be_equal_to("String"));
     expect!(interaction.provider_state).to(be_some().value("provider state"));
 }
@@ -220,7 +220,7 @@ fn defaults_to_number_if_no_description() {
     let interaction_json = r#"{
         "providerState": "provider state"
     }"#;
-    let interaction = Interaction::from_json(0, &json!(interaction_json), &PactSpecification::V1_1);
+    let interaction = Interaction::from_json(0, &serde_json::from_str({interaction_json}).unwrap(), &PactSpecification::V1_1);
     expect!(interaction.description).to(be_equal_to("Interaction 0"));
     expect!(interaction.provider_state).to(be_some().value("provider state"));
 }
@@ -229,7 +229,7 @@ fn defaults_to_number_if_no_description() {
 fn defaults_to_none_if_no_provider_state() {
     let interaction_json = r#"{
     }"#;
-    let interaction = Interaction::from_json(0, &json!(interaction_json), &PactSpecification::V1_1);
+    let interaction = Interaction::from_json(0, &serde_json::from_str({interaction_json}).unwrap(), &PactSpecification::V1_1);
     expect!(interaction.provider_state).to(be_none());
 }
 
@@ -238,14 +238,14 @@ fn defaults_to_none_if_provider_state_null() {
     let interaction_json = r#"{
         "providerState": null
     }"#;
-    let interaction = Interaction::from_json(0, &json!(interaction_json), &PactSpecification::V1_1);
+    let interaction = Interaction::from_json(0, &serde_json::from_str({interaction_json}).unwrap(), &PactSpecification::V1_1);
     expect!(interaction.provider_state).to(be_none());
 }
 
 #[test]
 fn load_empty_pact() {
     let pact_json = r#"{}"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.provider.name).to(be_equal_to("provider"));
     expect!(pact.consumer.name).to(be_equal_to("consumer"));
     expect!(pact.interactions.iter()).to(have_count(0));
@@ -256,7 +256,7 @@ fn load_empty_pact() {
 #[test]
 fn missing_metadata() {
     let pact_json = r#"{}"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V2));
 }
 
@@ -266,7 +266,7 @@ fn missing_spec_version() {
         "metadata" : {
         }
     }"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V2));
 }
 
@@ -279,7 +279,7 @@ fn missing_version_in_spec_version() {
             }
         }
     }"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V2));
 }
 
@@ -292,7 +292,7 @@ fn empty_version_in_spec_version() {
             }
         }
     }"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::Unknown));
 }
 
@@ -305,7 +305,7 @@ fn correct_version_in_spec_version() {
             }
         }
     }"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V1));
 }
 
@@ -318,7 +318,7 @@ fn invalid_version_in_spec_version() {
             }
         }
     }"#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::Unknown));
 }
 
@@ -352,7 +352,7 @@ fn load_basic_pact() {
         ]
     }
     "#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(&pact.provider.name).to(be_equal_to("Alice Service"));
     expect!(&pact.consumer.name).to(be_equal_to("Consumer"));
     expect!(pact.interactions.iter()).to(have_count(1));
@@ -421,7 +421,7 @@ fn load_pact() {
       }
     }
     "#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(&pact.provider.name).to(be_equal_to("test_provider"));
     expect!(&pact.consumer.name).to(be_equal_to("test_consumer"));
     expect!(pact.metadata.iter()).to(have_count(2));
@@ -491,7 +491,7 @@ fn load_pact_encoded_query_string() {
       }
     }
     "#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.interactions.iter()).to(have_count(1));
     let interaction = pact.interactions[0].clone();
     expect!(interaction.request).to(be_equal_to(Request {
@@ -521,7 +521,7 @@ fn load_pact_converts_methods_to_uppercase() {
       "metadata" : {}
     }
     "#;
-    let pact = Pact::from_json(&s!(""), &json!(pact_json));
+    let pact = Pact::from_json(&s!(""), &serde_json::from_str(pact_json).unwrap());
     expect!(pact.interactions.iter()).to(have_count(1));
     let interaction = pact.interactions[0].clone();
     expect!(interaction.request).to(be_equal_to(Request {
@@ -1131,34 +1131,34 @@ fn hash_for_response() {
 
 #[test]
 fn matchers_from_json_handles_missing_matchers() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {}
       }
-    "#);
+     "#).unwrap();
     let matchers = matchers_from_json(&json, s!("deprecatedName"));
     expect!(matchers).to(be_none());
 }
 
 #[test]
 fn matchers_from_json_handles_empty_matchers() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {},
           "matchingRules": {}
       }
-    "#);
+     "#).unwrap();
     let matchers = matchers_from_json(&json, s!("deprecatedName"));
     expect!(matchers).to(be_none());
 }
 
 #[test]
 fn matchers_from_json_handles_matcher_with_no_matching_rules() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
@@ -1167,7 +1167,7 @@ fn matchers_from_json_handles_matcher_with_no_matching_rules() {
             "*.path": {}
           }
       }
-    "#);
+     "#).unwrap();
     let matchers = matchers_from_json(&json, s!("deprecatedName"));
     expect!(matchers).to(be_some().value(hashmap!{
         s!("*.path") => hashmap!{}
@@ -1176,7 +1176,7 @@ fn matchers_from_json_handles_matcher_with_no_matching_rules() {
 
 #[test]
 fn matchers_from_json_loads_matchers_correctly() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
@@ -1188,7 +1188,7 @@ fn matchers_from_json_loads_matchers_correctly() {
             }
           }
       }
-    "#);
+     "#).unwrap();
     let matchers = matchers_from_json(&json, s!("deprecatedName"));
     expect!(matchers).to(be_some().value(hashmap!{
         s!("*.path") => hashmap!{
@@ -1200,7 +1200,7 @@ fn matchers_from_json_loads_matchers_correctly() {
 
 #[test]
 fn matchers_from_json_loads_matchers_from_deprecated_name() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
@@ -1212,7 +1212,7 @@ fn matchers_from_json_loads_matchers_from_deprecated_name() {
             }
           }
       }
-    "#);
+     "#).unwrap();
     let matchers = matchers_from_json(&json, s!("deprecatedName"));
     expect!(matchers).to(be_some().value(hashmap!{
         s!("*.path") => hashmap!{
@@ -1289,7 +1289,7 @@ fn write_pact_test_with_matchers() {
 
 #[test]
 fn body_from_json_returns_missing_if_there_is_no_body() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
@@ -1298,28 +1298,28 @@ fn body_from_json_returns_missing_if_there_is_no_body() {
             "*.path": {}
           }
       }
-    "#);
+     "#).unwrap();
     let body = body_from_json(&json, &None);
     expect!(body).to(be_equal_to(OptionalBody::Missing));
 }
 
 #[test]
 fn body_from_json_returns_null_if_the_body_is_null() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {},
           "body": null
       }
-    "#);
+     "#).unwrap();
     let body = body_from_json(&json, &None);
     expect!(body).to(be_equal_to(OptionalBody::Null));
 }
 
 #[test]
 fn body_from_json_returns_json_string_if_the_body_is_json_but_not_a_string() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
@@ -1328,49 +1328,49 @@ fn body_from_json_returns_json_string_if_the_body_is_json_but_not_a_string() {
             "test": true
           }
       }
-    "#);
+     "#).unwrap();
     let body = body_from_json(&json, &None);
     expect!(body).to(be_equal_to(OptionalBody::Present(s!("{\"test\":true}"))));
 }
 
 #[test]
 fn body_from_json_returns_empty_if_the_body_is_an_empty_string() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {},
           "body": ""
       }
-    "#);
+     "#).unwrap();
     let body = body_from_json(&json, &None);
     expect!(body).to(be_equal_to(OptionalBody::Empty));
 }
 
 #[test]
 fn body_from_json_returns_the_body_if_the_body_is_a_string() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {},
           "body": "<?xml version=\"1.0\"?> <body></body>"
       }
-    "#);
+     "#).unwrap();
     let body = body_from_json(&json, &None);
     expect!(body).to(be_equal_to(OptionalBody::Present(s!("<?xml version=\"1.0\"?> <body></body>"))));
 }
 
 #[test]
 fn body_from_json_returns_the_a_json_formatted_body_if_the_body_is_a_string_and_the_content_type_is_json() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {"Content-Type": "application/json"},
           "body": "This is actually a JSON string"
       }
-    "#);
+     "#).unwrap();
     let headers = headers_from_json(&json);
     let body = body_from_json(&json, &headers);
     expect!(body).to(be_equal_to(OptionalBody::Present(s!("\"This is actually a JSON string\""))));
@@ -1378,14 +1378,14 @@ fn body_from_json_returns_the_a_json_formatted_body_if_the_body_is_a_string_and_
 
 #[test]
 fn body_from_json_returns_the_body_if_the_content_type_is_json() {
-    let json = json!(r#"
+    let json : serde_json::Value = serde_json::from_str(r#"
       {
           "path": "/",
           "query": "",
           "headers": {"Content-Type": "application/json"},
           "body": "{\"test\":true}"
       }
-    "#);
+     "#).unwrap();
     let headers = headers_from_json(&json);
     let body = body_from_json(&json, &headers);
     expect!(body).to(be_equal_to(OptionalBody::Present(s!("{\"test\":true}"))));

--- a/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
@@ -9,102 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn unexpected_key_with_null_value() {
+fn array_in_different_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Unexpected phone number with null value",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_key_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected phone number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": "12345678"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected favourite colour with null value",
+        "comment": "Favourite colours in wrong order",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -123,7 +33,7 @@ fn unexpected_index_with_null_value() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","blue", null]
+              "favouriteColours": ["blue", "red"]
             }
           }
         }
@@ -143,12 +53,12 @@ fn unexpected_index_with_null_value() {
 }
 
 #[test]
-fn unexpected_index_with_not_null_value() {
+fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Unexpected favourite colour",
+        "comment": "Incorrect favourite colour",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -167,7 +77,7 @@ fn unexpected_index_with_not_null_value() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","blue","taupe"]
+              "favouriteColours": ["red","taupe"]
             }
           }
         }
@@ -187,304 +97,12 @@ fn unexpected_index_with_not_null_value() {
 }
 
 #[test]
-fn string_found_in_array_when_number_expected() {
+fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,2,3]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,"2",3]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_at_key_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be number but was string",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Plain text that matches",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_does_not_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Plain text that does not match",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named fred"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_in_array_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to be strings found a number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",2,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_at_key_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be string but was number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_in_array_when_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to be strings found a null",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_at_key_where_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
+        "comment": "Incorrect value at alligator name",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -493,94 +111,6 @@ fn null_found_at_key_where_not_null_expected() {
           "body": {
             "alligator":{
               "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_in_array_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to contain null, but not null found",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_at_key_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
             }
           }
         },
@@ -592,95 +122,6 @@ fn not_null_found_at_key_when_null_expected() {
           "body": {
             "alligator":{
               "name": "Fred"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_key() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Missing key alligator name",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "age": 3
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator": {
-              "age": 3
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_index() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Missing favorite colour",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator": {
-              "favouriteColours": ["red"]
             }
           }
         }
@@ -748,12 +189,12 @@ fn matches() {
 }
 
 #[test]
-fn different_value_found_at_key() {
+fn missing_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Incorrect value at alligator name",
+        "comment": "Missing favorite colour",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -761,7 +202,96 @@ fn different_value_found_at_key() {
           "headers": {},
           "body": {
             "alligator":{
-              "name": "Mary"
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator": {
+              "favouriteColours": ["red"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_key() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Missing key alligator name",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "age": 3
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator": {
+              "age": 3
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn not_null_found_at_key_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Name should be null",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
             }
           }
         },
@@ -792,12 +322,12 @@ fn different_value_found_at_key() {
 }
 
 #[test]
-fn different_value_found_at_index() {
+fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Incorrect favourite colour",
+        "comment": "Favourite colours expected to contain null, but not null found",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -805,7 +335,7 @@ fn different_value_found_at_index() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","blue"]
+              "favouriteNumbers": ["1",null,"3"]
             }
           }
         },
@@ -816,7 +346,7 @@ fn different_value_found_at_index() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","taupe"]
+              "favouriteNumbers": ["1","2","3"]
             }
           }
         }
@@ -836,12 +366,348 @@ fn different_value_found_at_index() {
 }
 
 #[test]
-fn array_in_different_order() {
+fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Favourite colours in wrong order",
+        "comment": "Name should be null",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_in_array_when_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite colours expected to be strings found a null",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_at_key_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be string but was number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_in_array_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite colours expected to be strings found a number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",2,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_does_not_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Plain text that does not match",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named fred"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Plain text that matches",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_at_key_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be number but was string",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_in_array_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,2,3]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,"2",3]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -860,7 +726,141 @@ fn array_in_different_order() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["blue", "red"]
+              "favouriteColours": ["red","blue","taupe"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour with null value",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue", null]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected phone number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": "12345678"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected phone number with null value",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": null
             }
           }
         }

--- a/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -40,14 +38,14 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -57,7 +55,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -85,14 +83,14 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -102,7 +100,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -129,14 +127,14 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -146,7 +144,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -173,14 +171,14 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -190,7 +188,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -217,14 +215,14 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -234,7 +232,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -261,14 +259,14 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -278,7 +276,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -297,14 +295,14 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -314,7 +312,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -333,14 +331,14 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -350,7 +348,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -377,14 +375,14 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -394,7 +392,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -421,14 +419,14 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -438,7 +436,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -465,14 +463,14 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -482,7 +480,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -509,14 +507,14 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -526,7 +524,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -553,14 +551,14 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -570,7 +568,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -597,14 +595,14 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -614,7 +612,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -642,14 +640,14 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -659,7 +657,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -686,14 +684,14 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -703,7 +701,7 @@ fn missing_index() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -734,14 +732,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -751,7 +749,7 @@ fn matches() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -778,14 +776,14 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -795,7 +793,7 @@ fn different_value_found_at_key() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -822,14 +820,14 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -839,7 +837,7 @@ fn different_value_found_at_index() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -866,14 +864,14 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -38,7 +39,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -55,7 +56,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -83,7 +84,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -100,7 +101,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -127,7 +128,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -144,7 +145,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -171,7 +172,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -188,7 +189,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -215,7 +216,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -232,7 +233,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -259,7 +260,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -276,7 +277,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -295,7 +296,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -312,7 +313,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -331,7 +332,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -348,7 +349,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -375,7 +376,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -392,7 +393,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -419,7 +420,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -436,7 +437,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -463,7 +464,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -480,7 +481,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -507,7 +508,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -524,7 +525,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -551,7 +552,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -568,7 +569,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -595,7 +596,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -612,7 +613,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -640,7 +641,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -657,7 +658,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -684,7 +685,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -701,7 +702,7 @@ fn missing_index() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -732,7 +733,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -749,7 +750,7 @@ fn matches() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -776,7 +777,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -793,7 +794,7 @@ fn different_value_found_at_key() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -820,7 +821,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -837,7 +838,7 @@ fn different_value_found_at_index() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -864,7 +865,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -33,14 +31,14 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -50,7 +48,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -69,14 +67,14 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -86,7 +84,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -107,14 +105,14 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -124,7 +122,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -147,14 +145,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -164,7 +162,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -185,14 +183,14 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -202,7 +200,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -223,14 +221,14 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -240,7 +238,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -258,14 +256,14 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
@@ -9,27 +9,24 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn whitespace_after_comma_different() {
+fn empty_headers() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Whitespace between comma separated headers does not matter",
+        "comment": "Empty headers match",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators,hippos"
-          }
+          "headers": {}
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators, hippos"
-          }
+          "headers": {}
         }
       }
     "#).unwrap();
@@ -47,25 +44,27 @@ fn whitespace_after_comma_different() {
 }
 
 #[test]
-fn unexpected_header_found() {
+fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Extra headers allowed",
+        "comment": "Header name is case insensitive",
         "expected" : {
-          "method": "POST",
-          "path": "/path",
-          "query": "",
-          "headers": {}
-        },
-        "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
             "Accept": "alligators"
           }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path",
+          "query": "",
+          "headers": {
+            "ACCEPT": "alligators"
+          }
         }
       }
     "#).unwrap();
@@ -83,18 +82,18 @@ fn unexpected_header_found() {
 }
 
 #[test]
-fn order_of_comma_separated_header_values_different() {
+fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
+        "comment": "Headers values are case sensitive",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "alligators, hippos"
+            "Accept": "alligators"
           }
         },
         "actual": {
@@ -102,7 +101,7 @@ fn order_of_comma_separated_header_values_different() {
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "hippos, alligators"
+            "Accept": "Alligators"
           }
         }
       }
@@ -161,18 +160,18 @@ fn matches() {
 }
 
 #[test]
-fn header_value_is_different_case() {
+fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Headers values are case sensitive",
+        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "alligators"
+            "Accept": "alligators, hippos"
           }
         },
         "actual": {
@@ -180,7 +179,7 @@ fn header_value_is_different_case() {
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "Alligators"
+            "Accept": "hippos, alligators"
           }
         }
       }
@@ -199,26 +198,24 @@ fn header_value_is_different_case() {
 }
 
 #[test]
-fn header_name_is_different_case() {
+fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Header name is case insensitive",
+        "comment": "Extra headers allowed",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators"
-          }
+          "headers": {}
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "ACCEPT": "alligators"
+            "Accept": "alligators"
           }
         }
       }
@@ -237,24 +234,27 @@ fn header_name_is_different_case() {
 }
 
 #[test]
-fn empty_headers() {
+fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Empty headers match",
+        "comment": "Whitespace between comma separated headers does not matter",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {}
-      
+          "headers": {
+            "Accept": "alligators,hippos"
+          }
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {}
+          "headers": {
+            "Accept": "alligators, hippos"
+          }
         }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/headers/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -31,7 +32,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -48,7 +49,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -67,7 +68,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -84,7 +85,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -105,7 +106,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -122,7 +123,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -145,7 +146,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -162,7 +163,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -183,7 +184,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -200,7 +201,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -221,7 +222,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -238,7 +239,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -256,7 +257,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
@@ -9,12 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn method_is_different_case() {
+fn different_method() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": true,
-        "comment": "Methods case does not matter",
+        "match": false,
+        "comment": "Methods is incorrect",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -22,7 +22,7 @@ fn method_is_different_case() {
           "headers": {}
         },
         "actual": {
-          "method": "post",
+          "method": "GET",
           "path": "/",
           "query": "",
           "headers": {}
@@ -79,12 +79,12 @@ fn matches() {
 }
 
 #[test]
-fn different_method() {
+fn method_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Methods is incorrect",
+        "match": true,
+        "comment": "Methods case does not matter",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -92,7 +92,7 @@ fn different_method() {
           "headers": {}
         },
         "actual": {
-          "method": "GET",
+          "method": "post",
           "path": "/",
           "query": "",
           "headers": {}

--- a/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -30,14 +28,14 @@ fn method_is_different_case() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -47,7 +45,7 @@ fn method_is_different_case() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -65,14 +63,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -82,7 +80,7 @@ fn matches() {
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -100,14 +98,14 @@ fn different_method() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/method/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -28,7 +29,7 @@ fn method_is_different_case() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -45,7 +46,7 @@ fn method_is_different_case() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -63,7 +64,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -80,7 +81,7 @@ fn matches() {
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -98,7 +99,7 @@ fn different_method() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v1/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod method;

--- a/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -29,7 +30,7 @@ fn unexpected_trailing_slash_in_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn unexpected_trailing_slash_in_path() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -65,7 +66,7 @@ fn missing_trailing_slash_in_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -101,7 +102,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -118,7 +119,7 @@ fn matches() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -137,7 +138,7 @@ fn incorrect_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -154,7 +155,7 @@ fn incorrect_path() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -173,7 +174,7 @@ fn forward_slash_found_when_empty_path_expected() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -190,7 +191,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -209,7 +210,7 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -31,14 +29,14 @@ fn unexpected_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn unexpected_trailing_slash_in_path() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -67,14 +65,14 @@ fn missing_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -103,14 +101,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -120,7 +118,7 @@ fn matches() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -139,14 +137,14 @@ fn incorrect_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -156,7 +154,7 @@ fn incorrect_path() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -175,14 +173,14 @@ fn forward_slash_found_when_empty_path_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -192,7 +190,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -211,14 +209,14 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/path/mod.rs
@@ -9,130 +9,22 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn unexpected_trailing_slash_in_path() {
+fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Path has unexpected trailing slash, trailing slashes can matter",
+        "comment": "Empty path found when forward slash expected",
         "expected" : {
           "method": "POST",
-          "path": "/path/to/something",
+          "path": "/",
           "query": "",
           "headers": {}
       
         },
         "actual": {
           "method": "POST",
-          "path": "/path/to/something/",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_trailing_slash_in_path() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Path is missing trailing slash, trailing slashes can matter",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something/",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Paths match",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn incorrect_path() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Paths do not match",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something/else",
+          "path": "",
           "query": "",
           "headers": {}
       
@@ -189,22 +81,130 @@ fn forward_slash_found_when_empty_path_expected() {
 }
 
 #[test]
-fn empty_path_found_when_forward_slash_expected() {
+fn incorrect_path() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Empty path found when forward slash expected",
+        "comment": "Paths do not match",
         "expected" : {
           "method": "POST",
-          "path": "/",
+          "path": "/path/to/something",
           "query": "",
           "headers": {}
       
         },
         "actual": {
           "method": "POST",
-          "path": "",
+          "path": "/path/to/something/else",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Paths match",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_trailing_slash_in_path() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Path is missing trailing slash, trailing slashes can matter",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something/",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_trailing_slash_in_path() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Path has unexpected trailing slash, trailing slashes can matter",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something/",
           "query": "",
           "headers": {}
       

--- a/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn trailing_amperand() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Query strings are matched using basic string equality, these are not equal. (not supported)",
@@ -31,14 +29,14 @@ fn trailing_amperand() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn trailing_amperand() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -67,14 +65,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn matches() {
 #[test]
 fn different_param_values() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -103,14 +101,14 @@ fn different_param_values() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -120,7 +118,7 @@ fn different_param_values() {
 #[test]
 fn different_param_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Query strings are matched using basic string equality, these are not equal. (Not supported)",
@@ -139,14 +137,14 @@ fn different_param_order() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
@@ -9,12 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn trailing_amperand() {
+fn different_param_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Query strings are matched using basic string equality, these are not equal. (not supported)",
+        "comment": "Query strings are matched using basic string equality, these are not equal. (Not supported)",
         "expected" : {
           "method": "GET",
           "path": "/path",
@@ -25,43 +25,7 @@ fn trailing_amperand() {
         "actual": {
           "method": "GET",
           "path": "/path",
-          "query": "alligator=Mary&hippo=John&",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Queries are the same",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John",
+          "query": "hippo=John&alligator=Mary",
           "headers": {}
       
         }
@@ -117,12 +81,12 @@ fn different_param_values() {
 }
 
 #[test]
-fn different_param_order() {
+fn matches() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Query strings are matched using basic string equality, these are not equal. (Not supported)",
+        "comment": "Queries are the same",
         "expected" : {
           "method": "GET",
           "path": "/path",
@@ -133,7 +97,43 @@ fn different_param_order() {
         "actual": {
           "method": "GET",
           "path": "/path",
-          "query": "hippo=John&alligator=Mary",
+          "query": "alligator=Mary&hippo=John",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn trailing_amperand() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Query strings are matched using basic string equality, these are not equal. (not supported)",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John&",
           "headers": {}
       
         }

--- a/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/request/query/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn trailing_amperand() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Query strings are matched using basic string equality, these are not equal. (not supported)",
@@ -29,7 +30,7 @@ fn trailing_amperand() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn trailing_amperand() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -65,7 +66,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn matches() {
 #[test]
 fn different_param_values() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -101,7 +102,7 @@ fn different_param_values() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -118,7 +119,7 @@ fn different_param_values() {
 #[test]
 fn different_param_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Query strings are matched using basic string equality, these are not equal. (Not supported)",
@@ -137,7 +138,7 @@ fn different_param_order() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -32,7 +33,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -50,7 +51,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -72,7 +73,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -90,7 +91,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -111,7 +112,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -129,7 +130,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -150,7 +151,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -168,7 +169,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -189,7 +190,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -207,7 +208,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -228,7 +229,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -246,7 +247,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -267,7 +268,7 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -285,7 +286,7 @@ fn property_name_is_different_case() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -298,7 +299,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -316,7 +317,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -329,7 +330,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -347,7 +348,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -367,7 +368,7 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -385,7 +386,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -406,7 +407,7 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -424,7 +425,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element recieved",
@@ -444,7 +445,7 @@ fn objects_in_array_first_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -462,7 +463,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -483,7 +484,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -501,7 +502,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -522,7 +523,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -540,7 +541,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -561,7 +562,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -579,7 +580,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -600,7 +601,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -618,7 +619,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -639,7 +640,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -657,7 +658,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -678,7 +679,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -696,7 +697,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -718,7 +719,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -736,7 +737,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -757,7 +758,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -775,7 +776,7 @@ fn missing_index() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -800,7 +801,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -818,7 +819,7 @@ fn matches() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -837,7 +838,7 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -855,7 +856,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -876,7 +877,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -894,7 +895,7 @@ fn different_value_found_at_key() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -915,7 +916,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -933,7 +934,7 @@ fn different_value_found_at_index() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -976,7 +977,7 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -994,7 +995,7 @@ fn deeply_nested_objects() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -1015,7 +1016,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -34,15 +32,15 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -52,7 +50,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -74,15 +72,15 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -92,7 +90,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -113,15 +111,15 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -131,7 +129,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -152,15 +150,15 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -170,7 +168,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -191,15 +189,15 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -209,7 +207,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -230,15 +228,15 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -248,7 +246,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -269,15 +267,15 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -287,7 +285,7 @@ fn property_name_is_different_case() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -300,15 +298,15 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -318,7 +316,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -331,15 +329,15 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -349,7 +347,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -369,15 +367,15 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -387,7 +385,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -408,15 +406,15 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -426,7 +424,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element recieved",
@@ -446,15 +444,15 @@ fn objects_in_array_first_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -464,7 +462,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -485,15 +483,15 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -503,7 +501,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -524,15 +522,15 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -542,7 +540,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -563,15 +561,15 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -581,7 +579,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -602,15 +600,15 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -620,7 +618,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -641,15 +639,15 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -659,7 +657,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -680,15 +678,15 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -698,7 +696,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -720,15 +718,15 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -738,7 +736,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -759,15 +757,15 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -777,7 +775,7 @@ fn missing_index() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -802,15 +800,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -820,7 +818,7 @@ fn matches() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -839,15 +837,15 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -857,7 +855,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -878,15 +876,15 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -896,7 +894,7 @@ fn different_value_found_at_key() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -917,15 +915,15 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -935,7 +933,7 @@ fn different_value_found_at_index() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -978,15 +976,15 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -996,7 +994,7 @@ fn deeply_nested_objects() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -1017,15 +1015,15 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/body/mod.rs
@@ -9,92 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn unexpected_key_with_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Unexpected phone number with null value",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_key_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Unexpected phone number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": "12345678"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_null_value() {
+fn array_in_different_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Unexpected favourite colour with null value",
+        "comment": "Favourite colours in wrong order",
         "expected" : {
           "headers": {},
           "body": {
@@ -107,811 +27,7 @@ fn unexpected_index_with_null_value() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","blue", null]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected favourite colour",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue","taupe"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_in_array_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,2,3]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,"2",3]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_at_key_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be number but was string",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn property_name_is_different_case() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Property names on objects are case sensitive",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "FavouriteColour": "red"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouritecolour": "red"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Plain text that matches",
-        "expected" : {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_does_not_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Plain text that does not match",
-        "expected" : {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named fred"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_second_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Property of second object matches, but unexpected element recieved",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 4},
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_no_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Array of objects, properties match on incorrect objects",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"},
-      		{"favouriteNumber": 2}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 4},
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_first_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Properties match but unexpected element recieved",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2},
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_in_array_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to be strings found a number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",2,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_at_key_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be string but was number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_in_array_when_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to be strings found a null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_at_key_where_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should not be null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_in_array_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to contain null, but not null found",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_at_key_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Fred"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_key() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Missing key alligator name",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "age": 3
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator": {
-              "age": 3
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_index() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Missing favorite colour",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator": {
-              "favouriteColours": ["red"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Responses match",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "feet": 4,
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4,
-              "name": "Mary",
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn keys_out_of_order_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Favourite number and favourite colours out of order",
-        "expected" : {
-          "headers": {},
-          "body": {
-      		"favouriteNumber": 7,
-              "favouriteColours": ["red","blue"]
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-              "favouriteColours": ["red","blue"],
-      		"favouriteNumber": 7
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn different_value_found_at_key() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Incorrect value at alligator name",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Fred"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn different_value_found_at_index() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Incorrect favourite colour",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","taupe"]
+              "favouriteColours": ["blue", "red"]
             }
           }
         }
@@ -993,12 +109,12 @@ fn deeply_nested_objects() {
 }
 
 #[test]
-fn array_in_different_order() {
+fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Favourite colours in wrong order",
+        "comment": "Incorrect favourite colour",
         "expected" : {
           "headers": {},
           "body": {
@@ -1011,7 +127,891 @@ fn array_in_different_order() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["blue", "red"]
+              "favouriteColours": ["red","taupe"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn different_value_found_at_key() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Incorrect value at alligator name",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Fred"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn keys_out_of_order_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Favourite number and favourite colours out of order",
+        "expected" : {
+          "headers": {},
+          "body": {
+      		"favouriteNumber": 7,
+              "favouriteColours": ["red","blue"]
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+              "favouriteColours": ["red","blue"],
+      		"favouriteNumber": 7
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Responses match",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "feet": 4,
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4,
+              "name": "Mary",
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_index() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Missing favorite colour",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator": {
+              "favouriteColours": ["red"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_key() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Missing key alligator name",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "age": 3
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator": {
+              "age": 3
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn not_null_found_at_key_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Name should be null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Fred"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn not_null_found_in_array_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to contain null, but not null found",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_at_key_where_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Name should not be null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_in_array_when_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to be strings found a null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_at_key_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be string but was number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_in_array_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to be strings found a number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",2,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_first_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Properties match but unexpected element recieved",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2},
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_no_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Array of objects, properties match on incorrect objects",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"},
+      		{"favouriteNumber": 2}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 4},
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_second_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Property of second object matches, but unexpected element recieved",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 4},
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_does_not_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Plain text that does not match",
+        "expected" : {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named fred"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Plain text that matches",
+        "expected" : {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn property_name_is_different_case() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Property names on objects are case sensitive",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "FavouriteColour": "red"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouritecolour": "red"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_at_key_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be number but was string",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_in_array_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,2,3]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,"2",3]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue","taupe"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour with null value",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue", null]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Unexpected phone number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": "12345678"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Unexpected phone number with null value",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": null
             }
           }
         }

--- a/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -25,7 +26,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -43,7 +44,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -56,7 +57,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -74,7 +75,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -89,7 +90,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -107,7 +108,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -124,7 +125,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -142,7 +143,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -157,7 +158,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -175,7 +176,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -190,7 +191,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -208,7 +209,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -220,7 +221,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
@@ -9,21 +9,18 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn whitespace_after_comma_different() {
+fn empty_headers() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Whitespace between comma separated headers does not matter",
+        "comment": "Empty headers match",
         "expected" : {
-          "headers": {
-            "Accept": "alligators,hippos"
-          }
+          "headers": {}
+      
         },
         "actual": {
-          "headers": {
-            "Accept": "alligators, hippos"
-          }
+          "headers": {}
         }
       }
     "#).unwrap();
@@ -42,19 +39,21 @@ fn whitespace_after_comma_different() {
 }
 
 #[test]
-fn unexpected_header_found() {
+fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Extra headers allowed",
+        "comment": "Header name is case insensitive",
         "expected" : {
-          "headers": {}
-        },
-        "actual": {
           "headers": {
             "Accept": "alligators"
           }
+        },
+        "actual": {
+          "headers": {
+            "ACCEPT": "alligators"
+          }
         }
       }
     "#).unwrap();
@@ -73,20 +72,20 @@ fn unexpected_header_found() {
 }
 
 #[test]
-fn order_of_comma_separated_header_values_different() {
+fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
+        "comment": "Headers values are case sensitive",
         "expected" : {
           "headers": {
-            "Accept": "alligators, hippos"
+            "Accept": "alligators"
           }
         },
         "actual": {
           "headers": {
-            "Accept": "hippos, alligators"
+            "Accept": "Alligators"
           }
         }
       }
@@ -141,20 +140,20 @@ fn matches() {
 }
 
 #[test]
-fn header_value_is_different_case() {
+fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Headers values are case sensitive",
+        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
         "expected" : {
           "headers": {
-            "Accept": "alligators"
+            "Accept": "alligators, hippos"
           }
         },
         "actual": {
           "headers": {
-            "Accept": "Alligators"
+            "Accept": "hippos, alligators"
           }
         }
       }
@@ -174,20 +173,18 @@ fn header_value_is_different_case() {
 }
 
 #[test]
-fn header_name_is_different_case() {
+fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Header name is case insensitive",
+        "comment": "Extra headers allowed",
         "expected" : {
-          "headers": {
-            "Accept": "alligators"
-          }
+          "headers": {}
         },
         "actual": {
           "headers": {
-            "ACCEPT": "alligators"
+            "Accept": "alligators"
           }
         }
       }
@@ -207,18 +204,21 @@ fn header_name_is_different_case() {
 }
 
 #[test]
-fn empty_headers() {
+fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Empty headers match",
+        "comment": "Whitespace between comma separated headers does not matter",
         "expected" : {
-          "headers": {}
-      
+          "headers": {
+            "Accept": "alligators,hippos"
+          }
         },
         "actual": {
-          "headers": {}
+          "headers": {
+            "Accept": "alligators, hippos"
+          }
         }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/headers/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -27,15 +25,15 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -45,7 +43,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -58,15 +56,15 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -76,7 +74,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -91,15 +89,15 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -109,7 +107,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -126,15 +124,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -144,7 +142,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -159,15 +157,15 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -177,7 +175,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -192,15 +190,15 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -210,7 +208,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -222,15 +220,15 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v1/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod status;

--- a/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
@@ -9,17 +9,17 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn matches() {
+fn different_status() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-      	"match": true,
-      	"comment": "Status matches",
+      	"match": false,
+      	"comment": "Status is incorrect",
       	"expected" : {
       		"status" : 202
       	},
       	"actual" : {
-      		"status" : 202
+      		"status" : 400
       	}
       }
     "#).unwrap();
@@ -38,17 +38,17 @@ fn matches() {
 }
 
 #[test]
-fn different_status() {
+fn matches() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-      	"match": false,
-      	"comment": "Status is incorrect",
+      	"match": true,
+      	"comment": "Status matches",
       	"expected" : {
       		"status" : 202
       	},
       	"actual" : {
-      		"status" : 400
+      		"status" : 202
       	}
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "Status matches",
@@ -23,15 +21,15 @@ fn matches() {
       		"status" : 202
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -41,7 +39,7 @@ fn matches() {
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": false,
       	"comment": "Status is incorrect",
@@ -52,15 +50,15 @@ fn different_status() {
       		"status" : 400
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1/response/status/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "Status matches",
@@ -21,7 +22,7 @@ fn matches() {
       		"status" : 202
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);
@@ -39,7 +40,7 @@ fn matches() {
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": false,
       	"comment": "Status is incorrect",
@@ -50,7 +51,7 @@ fn different_status() {
       		"status" : 400
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -39,14 +37,14 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -56,7 +54,7 @@ fn different_value_found_at_key() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -83,14 +81,14 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -100,7 +98,7 @@ fn array_in_different_order() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -128,14 +126,14 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -145,7 +143,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -173,14 +171,14 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -190,7 +188,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -217,14 +215,14 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -234,7 +232,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -261,14 +259,14 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -278,7 +276,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -305,14 +303,14 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -322,7 +320,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -349,14 +347,14 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -366,7 +364,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -385,14 +383,14 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -402,7 +400,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -421,14 +419,14 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -438,7 +436,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -465,14 +463,14 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -482,7 +480,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -509,14 +507,14 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -526,7 +524,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -553,14 +551,14 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -570,7 +568,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -597,14 +595,14 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -614,7 +612,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -633,14 +631,14 @@ fn null_body() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -650,7 +648,7 @@ fn null_body() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -668,14 +666,14 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -685,7 +683,7 @@ fn null_body_no_content_type() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -712,14 +710,14 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -729,7 +727,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -756,14 +754,14 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -773,7 +771,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -796,14 +794,14 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -813,7 +811,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -841,14 +839,14 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -858,7 +856,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -885,14 +883,14 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -902,7 +900,7 @@ fn missing_index() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -924,14 +922,14 @@ fn missing_body() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -941,7 +939,7 @@ fn missing_body() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -962,14 +960,14 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -979,7 +977,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -995,14 +993,14 @@ fn missing_body_found_when_empty_expected() {
           "query": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1012,7 +1010,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -1043,14 +1041,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1060,7 +1058,7 @@ fn matches() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -1079,14 +1077,14 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1096,7 +1094,7 @@ fn empty_body() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -1114,14 +1112,14 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1131,7 +1129,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -1158,14 +1156,14 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -37,7 +38,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -54,7 +55,7 @@ fn different_value_found_at_key() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -81,7 +82,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -98,7 +99,7 @@ fn array_in_different_order() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -126,7 +127,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -143,7 +144,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -171,7 +172,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -188,7 +189,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -215,7 +216,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -232,7 +233,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -259,7 +260,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -276,7 +277,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -303,7 +304,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -320,7 +321,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -347,7 +348,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -364,7 +365,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -383,7 +384,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -400,7 +401,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -419,7 +420,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -436,7 +437,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -463,7 +464,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -480,7 +481,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -507,7 +508,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -524,7 +525,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -551,7 +552,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -568,7 +569,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -595,7 +596,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -612,7 +613,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -631,7 +632,7 @@ fn null_body() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -648,7 +649,7 @@ fn null_body() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -666,7 +667,7 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -683,7 +684,7 @@ fn null_body_no_content_type() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -710,7 +711,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -727,7 +728,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -754,7 +755,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -771,7 +772,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -794,7 +795,7 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -811,7 +812,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -839,7 +840,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -856,7 +857,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -883,7 +884,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -900,7 +901,7 @@ fn missing_index() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -922,7 +923,7 @@ fn missing_body() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -939,7 +940,7 @@ fn missing_body() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -960,7 +961,7 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -977,7 +978,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -993,7 +994,7 @@ fn missing_body_found_when_empty_expected() {
           "query": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1010,7 +1011,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -1041,7 +1042,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1058,7 +1059,7 @@ fn matches() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -1077,7 +1078,7 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1094,7 +1095,7 @@ fn empty_body() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -1112,7 +1113,7 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1129,7 +1130,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -1156,7 +1157,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/body/mod.rs
@@ -9,50 +9,6 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn different_value_found_at_key() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Incorrect value at alligator name",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Fred"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
@@ -97,102 +53,12 @@ fn array_in_different_order() {
 }
 
 #[test]
-fn unexpected_key_with_null_value() {
+fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Unexpected phone number with null value",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_key_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected phone number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": "12345678"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected favourite colour with null value",
+        "comment": "Incorrect favourite colour",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -211,7 +77,7 @@ fn unexpected_index_with_null_value() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","blue", null]
+              "favouriteColours": ["red","taupe"]
             }
           }
         }
@@ -231,348 +97,12 @@ fn unexpected_index_with_null_value() {
 }
 
 #[test]
-fn unexpected_index_with_not_null_value() {
+fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Unexpected favourite colour",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue","taupe"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_in_array_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,2,3]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,"2",3]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_at_key_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be number but was string",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Plain text that matches",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_does_not_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Plain text that does not match",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named fred"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_in_array_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to be strings found a number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",2,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_at_key_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be string but was number",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_in_array_when_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to be strings found a null",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_at_key_where_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
+        "comment": "Incorrect value at alligator name",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -581,165 +111,6 @@ fn null_found_at_key_where_not_null_expected() {
           "body": {
             "alligator":{
               "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_body() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "NULL body",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_body_no_content_type() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "NULL body, no content-type",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "body": null
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_in_array_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite colours expected to contain null, but not null found",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_at_key_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
             }
           }
         },
@@ -770,18 +141,168 @@ fn not_null_found_at_key_when_null_expected() {
 }
 
 #[test]
-fn non_empty_body_found_when_empty_expected() {
+fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Non empty body found, when an empty body was expected",
+        "match": true,
+        "comment": "Empty body, no content-type",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "body": ""
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "application/json"},
+          "body": ""
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn empty_body() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Empty body",
         "expected" : {
           "method": "POST",
           "path": "/",
           "query": "",
           "headers": {"Content-Type": "application/json"},
+          "body": ""
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "application/json"},
+          "body": ""
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Requests match",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "feet": 4,
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4,
+              "name": "Mary",
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_body_found_when_empty_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Missing body found, when an empty body was expected",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
           "body": null
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": ""
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_body_no_content_type() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Missing body, no content-type",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": ""
         },
         "actual": {
           "method": "POST",
@@ -810,29 +331,23 @@ fn non_empty_body_found_when_empty_expected() {
 }
 
 #[test]
-fn missing_key() {
+fn missing_body() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Missing key alligator name",
+        "match": true,
+        "comment": "Missing body",
         "expected" : {
           "method": "POST",
           "path": "/",
           "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "age": 3
-            }
-          }
+          "headers": {"Content-Type": "application/json"}
         },
         "actual": {
           "method": "POST",
           "path": "/",
           "query": "",
-          "headers": {},
+          "headers": {"Content-Type": "application/json"},
           "body": {
             "alligator": {
               "age": 3
@@ -899,17 +414,63 @@ fn missing_index() {
 }
 
 #[test]
-fn missing_body() {
+fn missing_key() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": true,
-        "comment": "Missing body",
+        "match": false,
+        "comment": "Missing key alligator name",
         "expected" : {
           "method": "POST",
           "path": "/",
           "query": "",
-          "headers": {"Content-Type": "application/json"}
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "age": 3
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator": {
+              "age": 3
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn non_empty_body_found_when_empty_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Non empty body found, when an empty body was expected",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "application/json"},
+          "body": null
         },
         "actual": {
           "method": "POST",
@@ -938,25 +499,31 @@ fn missing_body() {
 }
 
 #[test]
-fn missing_body_no_content_type() {
+fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": true,
-        "comment": "Missing body, no content-type",
+        "match": false,
+        "comment": "Name should be null",
         "expected" : {
           "method": "POST",
           "path": "/",
-          "query": ""
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
         },
         "actual": {
           "method": "POST",
           "path": "/",
           "query": "",
-          "headers": {"Content-Type": "application/json"},
+          "headers": {},
           "body": {
-            "alligator": {
-              "age": 3
+            "alligator":{
+              "name": "Fred"
             }
           }
         }
@@ -976,12 +543,56 @@ fn missing_body_no_content_type() {
 }
 
 #[test]
-fn missing_body_found_when_empty_expected() {
+fn not_null_found_in_array_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite colours expected to contain null, but not null found",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Missing body found, when an empty body was expected",
+        "comment": "NULL body, no content-type",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -991,7 +602,9 @@ fn missing_body_found_when_empty_expected() {
         "actual": {
           "method": "POST",
           "path": "/",
-          "query": ""
+          "query": "",
+          "headers": {"Content-Type": "application/json"},
+          "body": null
         }
       }
     "#).unwrap();
@@ -1009,73 +622,25 @@ fn missing_body_found_when_empty_expected() {
 }
 
 #[test]
-fn matches() {
+fn null_body() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Requests match",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "feet": 4,
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4,
-              "name": "Mary",
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn empty_body() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Empty body",
+        "comment": "NULL body",
         "expected" : {
           "method": "POST",
           "path": "/",
           "query": "",
           "headers": {"Content-Type": "application/json"},
-          "body": ""
+          "body": null
         },
         "actual": {
           "method": "POST",
           "path": "/",
           "query": "",
           "headers": {"Content-Type": "application/json"},
-          "body": ""
+          "body": null
         }
       }
     "#).unwrap();
@@ -1093,47 +658,348 @@ fn empty_body() {
 }
 
 #[test]
-fn empty_body_no_content_type() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Empty body, no content-type",
-        "expected" : {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "body": ""
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/",
-          "query": "",
-          "headers": {"Content-Type": "application/json"},
-          "body": ""
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn different_value_found_at_index() {
+fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Incorrect favourite colour",
+        "comment": "Name should be null",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_in_array_when_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite colours expected to be strings found a null",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_at_key_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be string but was number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_in_array_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite colours expected to be strings found a number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",2,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_does_not_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Plain text that does not match",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named fred"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Plain text that matches",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_at_key_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be number but was string",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_in_array_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,2,3]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,"2",3]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -1152,7 +1018,141 @@ fn different_value_found_at_index() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","taupe"]
+              "favouriteColours": ["red","blue","taupe"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour with null value",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue", null]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected phone number",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": "12345678"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected phone number with null value",
+        "expected" : {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/",
+          "query": "",
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": null
             }
           }
         }

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
@@ -9,27 +9,24 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn whitespace_after_comma_different() {
+fn empty_headers() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Whitespace between comma separated headers does not matter",
+        "comment": "Empty headers match",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators,hippos"
-          }
+          "headers": {}
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators, hippos"
-          }
+          "headers": {}
         }
       }
     "#).unwrap();
@@ -47,25 +44,27 @@ fn whitespace_after_comma_different() {
 }
 
 #[test]
-fn unexpected_header_found() {
+fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Extra headers allowed",
+        "comment": "Header name is case insensitive",
         "expected" : {
-          "method": "POST",
-          "path": "/path",
-          "query": "",
-          "headers": {}
-        },
-        "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
             "Accept": "alligators"
           }
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path",
+          "query": "",
+          "headers": {
+            "ACCEPT": "alligators"
+          }
         }
       }
     "#).unwrap();
@@ -83,18 +82,18 @@ fn unexpected_header_found() {
 }
 
 #[test]
-fn order_of_comma_separated_header_values_different() {
+fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
+        "comment": "Headers values are case sensitive",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "alligators, hippos"
+            "Accept": "alligators"
           }
         },
         "actual": {
@@ -102,7 +101,7 @@ fn order_of_comma_separated_header_values_different() {
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "hippos, alligators"
+            "Accept": "Alligators"
           }
         }
       }
@@ -161,18 +160,18 @@ fn matches() {
 }
 
 #[test]
-fn header_value_is_different_case() {
+fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Headers values are case sensitive",
+        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "alligators"
+            "Accept": "alligators, hippos"
           }
         },
         "actual": {
@@ -180,7 +179,7 @@ fn header_value_is_different_case() {
           "path": "/path",
           "query": "",
           "headers": {
-            "Accept": "Alligators"
+            "Accept": "hippos, alligators"
           }
         }
       }
@@ -199,26 +198,24 @@ fn header_value_is_different_case() {
 }
 
 #[test]
-fn header_name_is_different_case() {
+fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Header name is case insensitive",
+        "comment": "Extra headers allowed",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {
-            "Accept": "alligators"
-          }
+          "headers": {}
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
           "headers": {
-            "ACCEPT": "alligators"
+            "Accept": "alligators"
           }
         }
       }
@@ -237,24 +234,27 @@ fn header_name_is_different_case() {
 }
 
 #[test]
-fn empty_headers() {
+fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Empty headers match",
+        "comment": "Whitespace between comma separated headers does not matter",
         "expected" : {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {}
-      
+          "headers": {
+            "Accept": "alligators,hippos"
+          }
         },
         "actual": {
           "method": "POST",
           "path": "/path",
           "query": "",
-          "headers": {}
+          "headers": {
+            "Accept": "alligators, hippos"
+          }
         }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -33,14 +31,14 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -50,7 +48,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -69,14 +67,14 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -86,7 +84,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -107,14 +105,14 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -124,7 +122,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -147,14 +145,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -164,7 +162,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -185,14 +183,14 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -202,7 +200,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -223,14 +221,14 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -240,7 +238,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -258,14 +256,14 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/headers/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -31,7 +32,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -48,7 +49,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -67,7 +68,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -84,7 +85,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -105,7 +106,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -122,7 +123,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -145,7 +146,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -162,7 +163,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -183,7 +184,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -200,7 +201,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -221,7 +222,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -238,7 +239,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -256,7 +257,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
@@ -9,12 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn method_is_different_case() {
+fn different_method() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": true,
-        "comment": "Methods case does not matter",
+        "match": false,
+        "comment": "Methods is incorrect",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -22,7 +22,7 @@ fn method_is_different_case() {
           "headers": {}
         },
         "actual": {
-          "method": "post",
+          "method": "GET",
           "path": "/",
           "query": "",
           "headers": {}
@@ -79,12 +79,12 @@ fn matches() {
 }
 
 #[test]
-fn different_method() {
+fn method_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Methods is incorrect",
+        "match": true,
+        "comment": "Methods case does not matter",
         "expected" : {
           "method": "POST",
           "path": "/",
@@ -92,7 +92,7 @@ fn different_method() {
           "headers": {}
         },
         "actual": {
-          "method": "GET",
+          "method": "post",
           "path": "/",
           "query": "",
           "headers": {}

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -28,7 +29,7 @@ fn method_is_different_case() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -45,7 +46,7 @@ fn method_is_different_case() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -63,7 +64,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -80,7 +81,7 @@ fn matches() {
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -98,7 +99,7 @@ fn different_method() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/method/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -30,14 +28,14 @@ fn method_is_different_case() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -47,7 +45,7 @@ fn method_is_different_case() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -65,14 +63,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -82,7 +80,7 @@ fn matches() {
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -100,14 +98,14 @@ fn different_method() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod method;

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
@@ -9,130 +9,22 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn unexpected_trailing_slash_in_path() {
+fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Path has unexpected trailing slash, trailing slashes can matter",
+        "comment": "Empty path found when forward slash expected",
         "expected" : {
           "method": "POST",
-          "path": "/path/to/something",
+          "path": "/",
           "query": "",
           "headers": {}
       
         },
         "actual": {
           "method": "POST",
-          "path": "/path/to/something/",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_trailing_slash_in_path() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Path is missing trailing slash, trailing slashes can matter",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something/",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Paths match",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn incorrect_path() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Paths do not match",
-        "expected" : {
-          "method": "POST",
-          "path": "/path/to/something",
-          "query": "",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "POST",
-          "path": "/path/to/something/else",
+          "path": "",
           "query": "",
           "headers": {}
       
@@ -189,22 +81,130 @@ fn forward_slash_found_when_empty_path_expected() {
 }
 
 #[test]
-fn empty_path_found_when_forward_slash_expected() {
+fn incorrect_path() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Empty path found when forward slash expected",
+        "comment": "Paths do not match",
         "expected" : {
           "method": "POST",
-          "path": "/",
+          "path": "/path/to/something",
           "query": "",
           "headers": {}
       
         },
         "actual": {
           "method": "POST",
-          "path": "",
+          "path": "/path/to/something/else",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Paths match",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_trailing_slash_in_path() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Path is missing trailing slash, trailing slashes can matter",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something/",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_trailing_slash_in_path() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Path has unexpected trailing slash, trailing slashes can matter",
+        "expected" : {
+          "method": "POST",
+          "path": "/path/to/something",
+          "query": "",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "POST",
+          "path": "/path/to/something/",
           "query": "",
           "headers": {}
       

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -29,7 +30,7 @@ fn unexpected_trailing_slash_in_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn unexpected_trailing_slash_in_path() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -65,7 +66,7 @@ fn missing_trailing_slash_in_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -101,7 +102,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -118,7 +119,7 @@ fn matches() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -137,7 +138,7 @@ fn incorrect_path() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -154,7 +155,7 @@ fn incorrect_path() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -173,7 +174,7 @@ fn forward_slash_found_when_empty_path_expected() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -190,7 +191,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -209,7 +210,7 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/path/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -31,14 +29,14 @@ fn unexpected_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn unexpected_trailing_slash_in_path() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -67,14 +65,14 @@ fn missing_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -103,14 +101,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -120,7 +118,7 @@ fn matches() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -139,14 +137,14 @@ fn incorrect_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -156,7 +154,7 @@ fn incorrect_path() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -175,14 +173,14 @@ fn forward_slash_found_when_empty_path_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -192,7 +190,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -211,14 +209,14 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn unexpected_param() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is not expected",
@@ -29,7 +30,7 @@ fn unexpected_param() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn unexpected_param() {
 #[test]
 fn trailing_ampersand() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Trailing amperands can be ignored",
@@ -65,7 +66,7 @@ fn trailing_ampersand() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn trailing_ampersand() {
 #[test]
 fn same_parameter_multiple_times() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same - multiple values are in same order",
@@ -100,7 +101,7 @@ fn same_parameter_multiple_times() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -117,7 +118,7 @@ fn same_parameter_multiple_times() {
 #[test]
 fn same_parameter_multiple_times_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - values are in different order",
@@ -135,7 +136,7 @@ fn same_parameter_multiple_times_in_different_order() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -152,7 +153,7 @@ fn same_parameter_multiple_times_in_different_order() {
 #[test]
 fn same_parameter_different_values() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
@@ -171,7 +172,7 @@ fn same_parameter_different_values() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -188,7 +189,7 @@ fn same_parameter_different_values() {
 #[test]
 fn missing_params() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is missing",
@@ -207,7 +208,7 @@ fn missing_params() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -224,7 +225,7 @@ fn missing_params() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -243,7 +244,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -260,7 +261,7 @@ fn matches() {
 #[test]
 fn matches_with_equals_in_the_query_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are equivalent",
@@ -279,7 +280,7 @@ fn matches_with_equals_in_the_query_value() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -296,7 +297,7 @@ fn matches_with_equals_in_the_query_value() {
 #[test]
 fn different_params() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -315,7 +316,7 @@ fn different_params() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -332,7 +333,7 @@ fn different_params() {
 #[test]
 fn different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same but in different key order",
@@ -351,7 +352,7 @@ fn different_order() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn unexpected_param() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is not expected",
@@ -31,14 +29,14 @@ fn unexpected_param() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn unexpected_param() {
 #[test]
 fn trailing_ampersand() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Trailing amperands can be ignored",
@@ -67,14 +65,14 @@ fn trailing_ampersand() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn trailing_ampersand() {
 #[test]
 fn same_parameter_multiple_times() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same - multiple values are in same order",
@@ -102,14 +100,14 @@ fn same_parameter_multiple_times() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -119,7 +117,7 @@ fn same_parameter_multiple_times() {
 #[test]
 fn same_parameter_multiple_times_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - values are in different order",
@@ -137,14 +135,14 @@ fn same_parameter_multiple_times_in_different_order() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -154,7 +152,7 @@ fn same_parameter_multiple_times_in_different_order() {
 #[test]
 fn same_parameter_different_values() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
@@ -173,14 +171,14 @@ fn same_parameter_different_values() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -190,7 +188,7 @@ fn same_parameter_different_values() {
 #[test]
 fn missing_params() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is missing",
@@ -209,14 +207,14 @@ fn missing_params() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -226,7 +224,7 @@ fn missing_params() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -245,14 +243,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -262,7 +260,7 @@ fn matches() {
 #[test]
 fn matches_with_equals_in_the_query_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are equivalent",
@@ -281,14 +279,14 @@ fn matches_with_equals_in_the_query_value() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -298,7 +296,7 @@ fn matches_with_equals_in_the_query_value() {
 #[test]
 fn different_params() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -317,14 +315,14 @@ fn different_params() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -334,7 +332,7 @@ fn different_params() {
 #[test]
 fn different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same but in different key order",
@@ -353,14 +351,14 @@ fn different_order() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/request/query/mod.rs
@@ -9,12 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn unexpected_param() {
+fn different_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Queries are not the same - elephant is not expected",
+        "match": true,
+        "comment": "Queries are the same but in different key order",
         "expected" : {
           "method": "GET",
           "path": "/path",
@@ -25,257 +25,7 @@ fn unexpected_param() {
         "actual": {
           "method": "GET",
           "path": "/path",
-          "query": "alligator=Mary&hippo=John&elephant=unexpected",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn trailing_ampersand() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Trailing amperands can be ignored",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John&",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn same_parameter_multiple_times() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Queries are the same - multiple values are in same order",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=alligator&animal=hippo&animal=elephant&hippo=Fred",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=alligator&hippo=Fred&animal=hippo&animal=elephant",
-          "headers": {}
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn same_parameter_multiple_times_in_different_order() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Queries are not the same - values are in different order",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=alligator&animal=hippo&animal=elephant",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=hippo&animal=alligator&animal=elephant",
-          "headers": {}
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn same_parameter_different_values() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=alligator&animal=hippo",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "animal=alligator&animal=elephant",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_params() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Queries are not the same - elephant is missing",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=Fred&elephant=missing",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=Fred",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Queries are the same",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "alligator=Mary&hippo=John",
-          "headers": {}
-      
-        }
-      }
-    "#).unwrap();
-
-    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    if pact_match.as_bool().unwrap() {
-       expect!(match_request(expected, actual)).to(be_empty());
-    } else {
-       expect!(match_request(expected, actual)).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches_with_equals_in_the_query_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Queries are equivalent",
-        "expected" : {
-          "method": "GET",
-          "path": "/path",
-          "query": "options=delete.topic.enable=true&broker=1",
-          "headers": {}
-      
-        },
-        "actual": {
-          "method": "GET",
-          "path": "/path",
-          "query": "options=delete.topic.enable%3Dtrue&broker=1",
+          "query": "hippo=John&alligator=Mary",
           "headers": {}
       
         }
@@ -331,12 +81,48 @@ fn different_params() {
 }
 
 #[test]
-fn different_order() {
+fn matches_with_equals_in_the_query_value() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Queries are the same but in different key order",
+        "comment": "Queries are equivalent",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "options=delete.topic.enable=true&broker=1",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "options=delete.topic.enable%3Dtrue&broker=1",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Queries are the same",
         "expected" : {
           "method": "GET",
           "path": "/path",
@@ -347,7 +133,221 @@ fn different_order() {
         "actual": {
           "method": "GET",
           "path": "/path",
-          "query": "hippo=John&alligator=Mary",
+          "query": "alligator=Mary&hippo=John",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_params() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Queries are not the same - elephant is missing",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=Fred&elephant=missing",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=Fred",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn same_parameter_different_values() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=alligator&animal=hippo",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=alligator&animal=elephant",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn same_parameter_multiple_times_in_different_order() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Queries are not the same - values are in different order",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=alligator&animal=hippo&animal=elephant",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=hippo&animal=alligator&animal=elephant",
+          "headers": {}
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn same_parameter_multiple_times() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Queries are the same - multiple values are in same order",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=alligator&animal=hippo&animal=elephant&hippo=Fred",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "animal=alligator&hippo=Fred&animal=hippo&animal=elephant",
+          "headers": {}
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn trailing_ampersand() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Trailing amperands can be ignored",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John&",
+          "headers": {}
+      
+        }
+      }
+    "#).unwrap();
+
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
+       expect!(match_request(expected, actual)).to(be_empty());
+    } else {
+       expect!(match_request(expected, actual)).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_param() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Queries are not the same - elephant is not expected",
+        "expected" : {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John",
+          "headers": {}
+      
+        },
+        "actual": {
+          "method": "GET",
+          "path": "/path",
+          "query": "alligator=Mary&hippo=John&elephant=unexpected",
           "headers": {}
       
         }

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -32,7 +33,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -50,7 +51,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -71,7 +72,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -89,7 +90,7 @@ fn missing_index() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -106,7 +107,7 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -124,7 +125,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -149,7 +150,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -167,7 +168,7 @@ fn matches() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -180,7 +181,7 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -198,7 +199,7 @@ fn empty_body() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -219,7 +220,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -237,7 +238,7 @@ fn different_value_found_at_key() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -280,7 +281,7 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -298,7 +299,7 @@ fn deeply_nested_objects() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -319,7 +320,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -337,7 +338,7 @@ fn array_in_different_order() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -359,7 +360,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -377,7 +378,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -399,7 +400,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -417,7 +418,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -438,7 +439,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -456,7 +457,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -477,7 +478,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -495,7 +496,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -516,7 +517,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -534,7 +535,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -555,7 +556,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -573,7 +574,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -594,7 +595,7 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -612,7 +613,7 @@ fn property_name_is_different_case() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -625,7 +626,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -643,7 +644,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -656,7 +657,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -674,7 +675,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -694,7 +695,7 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -712,7 +713,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -733,7 +734,7 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -751,7 +752,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element recieved",
@@ -771,7 +772,7 @@ fn objects_in_array_first_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -789,7 +790,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -810,7 +811,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -828,7 +829,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -849,7 +850,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -867,7 +868,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -888,7 +889,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -906,7 +907,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -927,7 +928,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -945,7 +946,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -958,7 +959,7 @@ fn null_body() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -976,7 +977,7 @@ fn null_body() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -988,7 +989,7 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1006,7 +1007,7 @@ fn null_body_no_content_type() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -1027,7 +1028,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1045,7 +1046,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1066,7 +1067,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1084,7 +1085,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1103,7 +1104,7 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1121,7 +1122,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1139,7 +1140,7 @@ fn missing_body() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1157,7 +1158,7 @@ fn missing_body() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1167,7 +1168,7 @@ fn missing_body_found_when_empty_expected() {
         "actual": {
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1185,7 +1186,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -1204,7 +1205,7 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1222,7 +1223,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -1234,7 +1235,7 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -1252,7 +1253,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -1273,7 +1274,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -34,15 +32,15 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -52,7 +50,7 @@ fn missing_key() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -73,15 +71,15 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -91,7 +89,7 @@ fn missing_index() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -108,15 +106,15 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -126,7 +124,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -151,15 +149,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -169,7 +167,7 @@ fn matches() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -182,15 +180,15 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -200,7 +198,7 @@ fn empty_body() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -221,15 +219,15 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -239,7 +237,7 @@ fn different_value_found_at_key() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -282,15 +280,15 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -300,7 +298,7 @@ fn deeply_nested_objects() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -321,15 +319,15 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -339,7 +337,7 @@ fn array_in_different_order() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -361,15 +359,15 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -379,7 +377,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -401,15 +399,15 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -419,7 +417,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -440,15 +438,15 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -458,7 +456,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -479,15 +477,15 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -497,7 +495,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -518,15 +516,15 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -536,7 +534,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -557,15 +555,15 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -575,7 +573,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -596,15 +594,15 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -614,7 +612,7 @@ fn property_name_is_different_case() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -627,15 +625,15 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -645,7 +643,7 @@ fn plain_text_that_matches() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -658,15 +656,15 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -676,7 +674,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -696,15 +694,15 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -714,7 +712,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -735,15 +733,15 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -753,7 +751,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element recieved",
@@ -773,15 +771,15 @@ fn objects_in_array_first_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -791,7 +789,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -812,15 +810,15 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -830,7 +828,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -851,15 +849,15 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -869,7 +867,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -890,15 +888,15 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -908,7 +906,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -929,15 +927,15 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -947,7 +945,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -960,15 +958,15 @@ fn null_body() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -978,7 +976,7 @@ fn null_body() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -990,15 +988,15 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1008,7 +1006,7 @@ fn null_body_no_content_type() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -1029,15 +1027,15 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1047,7 +1045,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1068,15 +1066,15 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1086,7 +1084,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1105,15 +1103,15 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1123,7 +1121,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1141,15 +1139,15 @@ fn missing_body() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1159,7 +1157,7 @@ fn missing_body() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1169,15 +1167,15 @@ fn missing_body_found_when_empty_expected() {
         "actual": {
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1187,7 +1185,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -1206,15 +1204,15 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1224,7 +1222,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -1236,15 +1234,15 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1254,7 +1252,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -1275,15 +1273,15 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/body/mod.rs
@@ -9,52 +9,12 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn missing_key() {
+fn array_in_different_order() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Missing key alligator name",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "age": 3
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator": {
-              "age": 3
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_index() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Missing favorite colour",
+        "comment": "Favourite colours in wrong order",
         "expected" : {
           "headers": {},
           "body": {
@@ -66,156 +26,8 @@ fn missing_index() {
         "actual": {
           "headers": {},
           "body": {
-            "alligator": {
-              "favouriteColours": ["red"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn missing_body_no_content_type() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Missing body, no content-type",
-        "expected" : {
-        },
-        "actual": {
-          "headers": {"Content-Type": "application/json"},
-          "body": {
             "alligator":{
-              "feet": 4,
-              "name": "Mary",
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Responses match",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "feet": 4,
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4,
-              "name": "Mary",
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn empty_body() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Empty body",
-        "expected" : {
-          "headers": {"Content-Type": "application/json"},
-          "body": ""
-        },
-        "actual": {
-          "headers": {"Content-Type": "application/json"},
-          "body": ""
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn different_value_found_at_key() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Incorrect value at alligator name",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Fred"
+              "favouriteColours": ["blue", "red"]
             }
           }
         }
@@ -297,12 +109,12 @@ fn deeply_nested_objects() {
 }
 
 #[test]
-fn array_in_different_order() {
+fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Favourite colours in wrong order",
+        "comment": "Incorrect favourite colour",
         "expected" : {
           "headers": {},
           "body": {
@@ -315,7 +127,7 @@ fn array_in_different_order() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["blue", "red"]
+              "favouriteColours": ["red","taupe"]
             }
           }
         }
@@ -336,725 +148,17 @@ fn array_in_different_order() {
 }
 
 #[test]
-fn unexpected_key_with_null_value() {
+fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": true,
-        "comment": "Unexpected phone number with null value",
+        "match": false,
+        "comment": "Incorrect value at alligator name",
         "expected" : {
           "headers": {},
           "body": {
             "alligator":{
               "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_key_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Unexpected phone number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary",
-              "phoneNumber": "12345678"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected favourite colour with null value",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue", null]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn unexpected_index_with_not_null_value() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Unexpected favourite colour",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteColours": ["red","blue","taupe"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_in_array_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,2,3]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": [1,"2",3]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn string_found_at_key_when_number_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be number but was string",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn property_name_is_different_case() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Property names on objects are case sensitive",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "FavouriteColour": "red"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouritecolour": "red"
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Plain text that matches",
-        "expected" : {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn plain_text_that_does_not_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Plain text that does not match",
-        "expected" : {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named mary"
-        },
-        "actual": {
-          "headers": { "Content-Type": "text/plain" },
-          "body": "alligator named fred"
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_second_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Property of second object matches, but unexpected element recieved",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 4},
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_no_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Array of objects, properties match on incorrect objects",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"},
-      		{"favouriteNumber": 2}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 4},
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn objects_in_array_first_matches() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Properties match but unexpected element recieved",
-        "expected" : {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red"}
-      	]
-        },
-        "actual": {
-          "headers": {},
-          "body": [
-      		{"favouriteColor": "red",
-      		"favouriteNumber": 2},
-      		{"favouriteColor": "blue",
-      		"favouriteNumber": 2}
-      	]
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_in_array_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to be strings found a number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",2,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn number_found_at_key_when_string_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Number of feet expected to be string but was number",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": "4"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "feet": 4
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_in_array_when_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to be strings found a null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_found_at_key_where_not_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should not be null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": "Mary"
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_body() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "NULL body",
-        "expected" : {
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        },
-        "actual": {
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn null_body_no_content_type() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "NULL body, no content-type",
-        "expected" : {
-          "body": null
-        },
-        "actual": {
-          "headers": {"Content-Type": "application/json"},
-          "body": null
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_in_array_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Favourite numbers expected to contain null, but not null found",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1",null,"3"]
-            }
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "favouriteNumbers": ["1","2","3"]
-            }
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn not_null_found_at_key_when_null_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": false,
-        "comment": "Name should be null",
-        "expected" : {
-          "headers": {},
-          "body": {
-            "alligator":{
-              "name": null
             }
           }
         },
@@ -1083,15 +187,182 @@ fn not_null_found_at_key_when_null_expected() {
 }
 
 #[test]
-fn non_empty_body_found_when_empty_expected() {
+fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-        "match": false,
-        "comment": "Non empty body found, when an empty body was expected",
+        "match": true,
+        "comment": "Empty body, no content-type",
+        "expected" : {
+          "body": ""
+        },
+        "actual": {
+          "headers": {"Content-Type": "application/json"},
+          "body": ""
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn empty_body() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Empty body",
         "expected" : {
           "headers": {"Content-Type": "application/json"},
+          "body": ""
+        },
+        "actual": {
+          "headers": {"Content-Type": "application/json"},
+          "body": ""
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn keys_out_of_order_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Favourite number and favourite colours out of order",
+        "expected" : {
+          "headers": {},
+          "body": {
+      		"favouriteNumber": 7,
+              "favouriteColours": ["red","blue"]
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+              "favouriteColours": ["red","blue"],
+      		"favouriteNumber": 7
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Responses match",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "feet": 4,
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4,
+              "name": "Mary",
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_body_found_when_empty_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Missing body found, when an empty body was expected",
+        "expected" : {
           "body": null
+        },
+        "actual": {
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_body_no_content_type() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Missing body, no content-type",
+        "expected" : {
         },
         "actual": {
           "headers": {"Content-Type": "application/json"},
@@ -1156,107 +427,717 @@ fn missing_body() {
 }
 
 #[test]
-fn missing_body_found_when_empty_expected() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Missing body found, when an empty body was expected",
-        "expected" : {
-          "body": null
-        },
-        "actual": {
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn keys_out_of_order_match() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Favourite number and favourite colours out of order",
-        "expected" : {
-          "headers": {},
-          "body": {
-      		"favouriteNumber": 7,
-              "favouriteColours": ["red","blue"]
-          }
-        },
-        "actual": {
-          "headers": {},
-          "body": {
-              "favouriteColours": ["red","blue"],
-      		"favouriteNumber": 7
-          }
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn empty_body_no_content_type() {
-    env_logger::init().unwrap_or(());
-    let pact : serde_json::Value = serde_json::from_str(r#"
-      {
-        "match": true,
-        "comment": "Empty body, no content-type",
-        "expected" : {
-          "body": ""
-        },
-        "actual": {
-          "headers": {"Content-Type": "application/json"},
-          "body": ""
-        }
-      }
-    "#).unwrap();
-
-    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", expected);
-    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
-    println!("{:?}", actual);
-    let pact_match = pact.get("match").unwrap();
-    let result = match_response(expected, actual);
-    if pact_match.as_bool().unwrap() {
-       expect!(result).to(be_empty());
-    } else {
-       expect!(result).to_not(be_empty());
-    }
-}
-
-#[test]
-fn different_value_found_at_index() {
+fn missing_index() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Incorrect favourite colour",
+        "comment": "Missing favorite colour",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator": {
+              "favouriteColours": ["red"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn missing_key() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Missing key alligator name",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "age": 3
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator": {
+              "age": 3
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn non_empty_body_found_when_empty_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Non empty body found, when an empty body was expected",
+        "expected" : {
+          "headers": {"Content-Type": "application/json"},
+          "body": null
+        },
+        "actual": {
+          "headers": {"Content-Type": "application/json"},
+          "body": {
+            "alligator":{
+              "feet": 4,
+              "name": "Mary",
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn not_null_found_at_key_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Name should be null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Fred"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn not_null_found_in_array_when_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to contain null, but not null found",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_body_no_content_type() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "NULL body, no content-type",
+        "expected" : {
+          "body": null
+        },
+        "actual": {
+          "headers": {"Content-Type": "application/json"},
+          "body": null
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_body() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "NULL body",
+        "expected" : {
+          "headers": {"Content-Type": "application/json"},
+          "body": null
+        },
+        "actual": {
+          "headers": {"Content-Type": "application/json"},
+          "body": null
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_at_key_where_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Name should not be null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": null
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn null_found_in_array_when_not_null_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to be strings found a null",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",null,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_at_key_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be string but was number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn number_found_in_array_when_string_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite numbers expected to be strings found a number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1","2","3"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": ["1",2,"3"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_first_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Properties match but unexpected element recieved",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2},
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_no_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Array of objects, properties match on incorrect objects",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"},
+      		{"favouriteNumber": 2}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 4},
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn objects_in_array_second_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Property of second object matches, but unexpected element recieved",
+        "expected" : {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "red"}
+      	]
+        },
+        "actual": {
+          "headers": {},
+          "body": [
+      		{"favouriteColor": "blue",
+      		"favouriteNumber": 4},
+      		{"favouriteColor": "red",
+      		"favouriteNumber": 2}
+      	]
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_does_not_match() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Plain text that does not match",
+        "expected" : {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named fred"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn plain_text_that_matches() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Plain text that matches",
+        "expected" : {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        },
+        "actual": {
+          "headers": { "Content-Type": "text/plain" },
+          "body": "alligator named mary"
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn property_name_is_different_case() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Property names on objects are case sensitive",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "FavouriteColour": "red"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouritecolour": "red"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_at_key_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Number of feet expected to be number but was string",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": 4
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "feet": "4"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn string_found_in_array_when_number_expected() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,2,3]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteNumbers": [1,"2",3]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour",
         "expected" : {
           "headers": {},
           "body": {
@@ -1269,7 +1150,126 @@ fn different_value_found_at_index() {
           "headers": {},
           "body": {
             "alligator":{
-              "favouriteColours": ["red","taupe"]
+              "favouriteColours": ["red","blue","taupe"]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_index_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": false,
+        "comment": "Unexpected favourite colour with null value",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue"]
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "favouriteColours": ["red","blue", null]
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_not_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Unexpected phone number",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": "12345678"
+            }
+          }
+        }
+      }
+    "#).unwrap();
+
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", expected);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
+    println!("{:?}", actual);
+    let pact_match = pact.get("match").unwrap();
+    let result = match_response(expected, actual);
+    if pact_match.as_bool().unwrap() {
+       expect!(result).to(be_empty());
+    } else {
+       expect!(result).to_not(be_empty());
+    }
+}
+
+#[test]
+fn unexpected_key_with_null_value() {
+    env_logger::init().unwrap_or(());
+    let pact : serde_json::Value = serde_json::from_str(r#"
+      {
+        "match": true,
+        "comment": "Unexpected phone number with null value",
+        "expected" : {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary"
+            }
+          }
+        },
+        "actual": {
+          "headers": {},
+          "body": {
+            "alligator":{
+              "name": "Mary",
+              "phoneNumber": null
             }
           }
         }

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
@@ -9,21 +9,18 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn whitespace_after_comma_different() {
+fn empty_headers() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Whitespace between comma separated headers does not matter",
+        "comment": "Empty headers match",
         "expected" : {
-          "headers": {
-            "Accept": "alligators,hippos"
-          }
+          "headers": {}
+      
         },
         "actual": {
-          "headers": {
-            "Accept": "alligators, hippos"
-          }
+          "headers": {}
         }
       }
     "#).unwrap();
@@ -42,19 +39,21 @@ fn whitespace_after_comma_different() {
 }
 
 #[test]
-fn unexpected_header_found() {
+fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Extra headers allowed",
+        "comment": "Header name is case insensitive",
         "expected" : {
-          "headers": {}
-        },
-        "actual": {
           "headers": {
             "Accept": "alligators"
           }
+        },
+        "actual": {
+          "headers": {
+            "ACCEPT": "alligators"
+          }
         }
       }
     "#).unwrap();
@@ -73,20 +72,20 @@ fn unexpected_header_found() {
 }
 
 #[test]
-fn order_of_comma_separated_header_values_different() {
+fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
+        "comment": "Headers values are case sensitive",
         "expected" : {
           "headers": {
-            "Accept": "alligators, hippos"
+            "Accept": "alligators"
           }
         },
         "actual": {
           "headers": {
-            "Accept": "hippos, alligators"
+            "Accept": "Alligators"
           }
         }
       }
@@ -141,20 +140,20 @@ fn matches() {
 }
 
 #[test]
-fn header_value_is_different_case() {
+fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
-        "comment": "Headers values are case sensitive",
+        "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
         "expected" : {
           "headers": {
-            "Accept": "alligators"
+            "Accept": "alligators, hippos"
           }
         },
         "actual": {
           "headers": {
-            "Accept": "Alligators"
+            "Accept": "hippos, alligators"
           }
         }
       }
@@ -174,20 +173,18 @@ fn header_value_is_different_case() {
 }
 
 #[test]
-fn header_name_is_different_case() {
+fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Header name is case insensitive",
+        "comment": "Extra headers allowed",
         "expected" : {
-          "headers": {
-            "Accept": "alligators"
-          }
+          "headers": {}
         },
         "actual": {
           "headers": {
-            "ACCEPT": "alligators"
+            "Accept": "alligators"
           }
         }
       }
@@ -207,18 +204,21 @@ fn header_name_is_different_case() {
 }
 
 #[test]
-fn empty_headers() {
+fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
-        "comment": "Empty headers match",
+        "comment": "Whitespace between comma separated headers does not matter",
         "expected" : {
-          "headers": {}
-      
+          "headers": {
+            "Accept": "alligators,hippos"
+          }
         },
         "actual": {
-          "headers": {}
+          "headers": {
+            "Accept": "alligators, hippos"
+          }
         }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -25,7 +26,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -43,7 +44,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -56,7 +57,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -74,7 +75,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -89,7 +90,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -107,7 +108,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -124,7 +125,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -142,7 +143,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -157,7 +158,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -175,7 +176,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -190,7 +191,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -208,7 +209,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -220,7 +221,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/headers/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -27,15 +25,15 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -45,7 +43,7 @@ fn whitespace_after_comma_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -58,15 +56,15 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -76,7 +74,7 @@ fn unexpected_header_found() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -91,15 +89,15 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -109,7 +107,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -126,15 +124,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -144,7 +142,7 @@ fn matches() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -159,15 +157,15 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -177,7 +175,7 @@ fn header_value_is_different_case() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -192,15 +190,15 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -210,7 +208,7 @@ fn header_name_is_different_case() {
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -222,15 +220,15 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod status;

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
@@ -9,17 +9,17 @@ use expectest::prelude::*;
 use serde_json;
 
 #[test]
-fn matches() {
+fn different_status() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-          "match": true,
-          "comment": "Status matches",
+          "match": false,
+          "comment": "Status is incorrect",
           "expected": {
               "status": 202
           },
           "actual": {
-              "status": 202
+              "status": 400
           }
       }
     "#).unwrap();
@@ -38,17 +38,17 @@ fn matches() {
 }
 
 #[test]
-fn different_status() {
+fn matches() {
     env_logger::init().unwrap_or(());
     let pact : serde_json::Value = serde_json::from_str(r#"
       {
-          "match": false,
-          "comment": "Status is incorrect",
+          "match": true,
+          "comment": "Status matches",
           "expected": {
               "status": 202
           },
           "actual": {
-              "status": 400
+              "status": 202
           }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
           "match": true,
           "comment": "Status matches",
@@ -21,7 +22,7 @@ fn matches() {
               "status": 202
           }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
@@ -39,7 +40,7 @@ fn matches() {
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
           "match": false,
           "comment": "Status is incorrect",
@@ -50,7 +51,7 @@ fn different_status() {
               "status": 400
           }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v1_1/response/status/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
           "match": true,
           "comment": "Status matches",
@@ -23,15 +21,15 @@ fn matches() {
               "status": 202
           }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -41,7 +39,7 @@ fn matches() {
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
           "match": false,
           "comment": "Status is incorrect",
@@ -52,15 +50,15 @@ fn different_status() {
               "status": 400
           }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V1_1);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V1_1);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V1_1);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn array_at_top_level_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -29,7 +30,7 @@ fn array_at_top_level_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><rogger dob=\"06/10/2015\" name=\"Rogger the Dogger\" id=\"1014753708\" timestamp=\"2015-06-10T20:41:37\"/><cat dob=\"06/10/2015\" name=\"Cat in the Hat\" id=\"8858030303\" timestamp=\"2015-06-10T20:41:37\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn array_at_top_level_xml() {
 #[test]
 fn array_at_top_level() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -91,7 +92,7 @@ fn array_at_top_level() {
           ]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -108,7 +109,7 @@ fn array_at_top_level() {
 #[test]
 fn array_in_different_order_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Favourite colours in wrong order",
@@ -127,7 +128,7 @@ fn array_in_different_order_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>blue</favouriteColour><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -144,7 +145,7 @@ fn array_in_different_order_xml() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -171,7 +172,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -188,7 +189,7 @@ fn array_in_different_order() {
 #[test]
 fn array_size_less_than_required_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Array must have at least 2 elements",
@@ -210,7 +211,7 @@ fn array_size_less_than_required_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator name=\"Mary\"/></animals>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -227,7 +228,7 @@ fn array_size_less_than_required_xml() {
 #[test]
 fn array_size_less_than_required() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Array must have at least 2 elements",
@@ -261,7 +262,7 @@ fn array_size_less_than_required() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -278,7 +279,7 @@ fn array_size_less_than_required() {
 #[test]
 fn array_with_at_least_one_element_matching_by_example_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Tag with at least one element match",
@@ -302,7 +303,7 @@ fn array_with_at_least_one_element_matching_by_example_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator name=\"Mary\"/><alligator name=\"Susan\"/></animals>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -319,7 +320,7 @@ fn array_with_at_least_one_element_matching_by_example_xml() {
 #[test]
 fn array_with_at_least_one_element_matching_by_example() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Types and regular expressions match",
@@ -356,7 +357,7 @@ fn array_with_at_least_one_element_matching_by_example() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -373,7 +374,7 @@ fn array_with_at_least_one_element_matching_by_example() {
 #[test]
 fn array_with_at_least_one_element_not_matching_example_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Wrong type for name key",
@@ -410,7 +411,7 @@ fn array_with_at_least_one_element_not_matching_example_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -427,7 +428,7 @@ fn array_with_at_least_one_element_not_matching_example_type() {
 #[test]
 fn array_with_nested_array_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Nested arrays do not match, age is wrong type",
@@ -470,7 +471,7 @@ fn array_with_nested_array_that_does_not_match() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -487,7 +488,7 @@ fn array_with_nested_array_that_does_not_match() {
 #[test]
 fn array_with_nested_array_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Nested arrays match",
@@ -539,7 +540,7 @@ fn array_with_nested_array_that_matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -556,7 +557,7 @@ fn array_with_nested_array_that_matches() {
 #[test]
 fn array_with_regular_expression_in_element_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Types and regular expressions match",
@@ -581,7 +582,7 @@ fn array_with_regular_expression_in_element_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator phoneNumber=\"333\"/><alligator phoneNumber=\"983479823479283478923\"/></animals>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -598,7 +599,7 @@ fn array_with_regular_expression_in_element_xml() {
 #[test]
 fn array_with_regular_expression_in_element() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Types and regular expressions match",
@@ -636,7 +637,7 @@ fn array_with_regular_expression_in_element() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -653,7 +654,7 @@ fn array_with_regular_expression_in_element() {
 #[test]
 fn array_with_regular_expression_that_does_not_match_in_element_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Types and regular expressions match",
@@ -678,7 +679,7 @@ fn array_with_regular_expression_that_does_not_match_in_element_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator phoneNumber=\"123\"/><alligator phoneNumber=\"abc\"/></animals>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -695,7 +696,7 @@ fn array_with_regular_expression_that_does_not_match_in_element_xml() {
 #[test]
 fn array_with_regular_expression_that_does_not_match_in_element() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Types and regular expressions match",
@@ -733,7 +734,7 @@ fn array_with_regular_expression_that_does_not_match_in_element() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -750,7 +751,7 @@ fn array_with_regular_expression_that_does_not_match_in_element() {
 #[test]
 fn different_value_found_at_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Incorrect favourite colour",
@@ -769,7 +770,7 @@ fn different_value_found_at_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -786,7 +787,7 @@ fn different_value_found_at_index_xml() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -813,7 +814,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -830,7 +831,7 @@ fn different_value_found_at_index() {
 #[test]
 fn different_value_found_at_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Incorrect value at alligator name",
@@ -849,7 +850,7 @@ fn different_value_found_at_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Fred\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -866,7 +867,7 @@ fn different_value_found_at_key_xml() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -893,7 +894,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -910,7 +911,7 @@ fn different_value_found_at_key() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -928,7 +929,7 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -945,7 +946,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -964,7 +965,7 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -981,7 +982,7 @@ fn empty_body() {
 #[test]
 fn empty_found_at_key_where_not_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Name should not be empty",
@@ -1000,7 +1001,7 @@ fn empty_found_at_key_where_not_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1017,7 +1018,7 @@ fn empty_found_at_key_where_not_empty_expected_xml() {
 #[test]
 fn matches_with_regex_with_bracket_notation_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1039,7 +1040,7 @@ fn matches_with_regex_with_bracket_notation_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><two str=\"saldfhksajdhffdskkjh\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1056,7 +1057,7 @@ fn matches_with_regex_with_bracket_notation_xml() {
 #[test]
 fn matches_with_regex_with_bracket_notation() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1086,7 +1087,7 @@ fn matches_with_regex_with_bracket_notation() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1103,7 +1104,7 @@ fn matches_with_regex_with_bracket_notation() {
 #[test]
 fn matches_with_regex_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1127,7 +1128,7 @@ fn matches_with_regex_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Harry\" feet=\"4\"><favouriteColours><favouriteColour>blue</favouriteColour><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1144,7 +1145,7 @@ fn matches_with_regex_xml() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1180,7 +1181,7 @@ fn matches_with_regex() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1197,7 +1198,7 @@ fn matches_with_regex() {
 #[test]
 fn matches_with_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match with same type",
@@ -1232,7 +1233,7 @@ fn matches_with_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1249,7 +1250,7 @@ fn matches_with_type() {
 #[test]
 fn matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Requests match",
@@ -1268,7 +1269,7 @@ fn matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator feet=\"4\" name=\"Mary\"><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1285,7 +1286,7 @@ fn matches_xml() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -1316,7 +1317,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1333,7 +1334,7 @@ fn matches() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1349,7 +1350,7 @@ fn missing_body_found_when_empty_expected() {
           "query": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1366,7 +1367,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -1387,7 +1388,7 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1404,7 +1405,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1426,7 +1427,7 @@ fn missing_body() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1443,7 +1444,7 @@ fn missing_body() {
 #[test]
 fn missing_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Missing favorite colour",
@@ -1462,7 +1463,7 @@ fn missing_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1479,7 +1480,7 @@ fn missing_index_xml() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1506,7 +1507,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1523,7 +1524,7 @@ fn missing_index() {
 #[test]
 fn missing_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Missing key alligator name",
@@ -1542,7 +1543,7 @@ fn missing_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator age=\"3\"></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1559,7 +1560,7 @@ fn missing_key_xml() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -1587,7 +1588,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1604,7 +1605,7 @@ fn missing_key() {
 #[test]
 fn no_body_no_content_type_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML No body, no content-type",
@@ -1621,7 +1622,7 @@ fn no_body_no_content_type_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1638,7 +1639,7 @@ fn no_body_no_content_type_xml() {
 #[test]
 fn no_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "No body, no content-type",
@@ -1659,7 +1660,7 @@ fn no_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1676,7 +1677,7 @@ fn no_body_no_content_type() {
 #[test]
 fn no_body_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Missing body",
@@ -1694,7 +1695,7 @@ fn no_body_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1711,7 +1712,7 @@ fn no_body_xml() {
 #[test]
 fn no_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1733,7 +1734,7 @@ fn no_body() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1750,7 +1751,7 @@ fn no_body() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1773,7 +1774,7 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1790,7 +1791,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn not_empty_found_at_key_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Name should be empty",
@@ -1809,7 +1810,7 @@ fn not_empty_found_at_key_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1826,7 +1827,7 @@ fn not_empty_found_at_key_when_empty_expected_xml() {
 #[test]
 fn not_empty_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to contain empty, but non-empty found",
@@ -1845,7 +1846,7 @@ fn not_empty_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber>2</favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1862,7 +1863,7 @@ fn not_empty_found_in_array_when_empty_expected_xml() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1889,7 +1890,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1906,7 +1907,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -1933,7 +1934,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1950,7 +1951,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -1968,7 +1969,7 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1985,7 +1986,7 @@ fn null_body_no_content_type() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -2004,7 +2005,7 @@ fn null_body() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2021,7 +2022,7 @@ fn null_body() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -2048,7 +2049,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2065,7 +2066,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -2092,7 +2093,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2109,7 +2110,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -2136,7 +2137,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2153,7 +2154,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -2180,7 +2181,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2197,7 +2198,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -2216,7 +2217,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2233,7 +2234,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -2252,7 +2253,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2269,7 +2270,7 @@ fn plain_text_that_matches() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -2296,7 +2297,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2313,7 +2314,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -2340,7 +2341,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2357,7 +2358,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn unexpected_index_with_missing_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Unexpected favourite colour with empty value",
@@ -2376,7 +2377,7 @@ fn unexpected_index_with_missing_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour></favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2393,7 +2394,7 @@ fn unexpected_index_with_missing_value_xml() {
 #[test]
 fn unexpected_index_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Unexpected favourite colour",
@@ -2412,7 +2413,7 @@ fn unexpected_index_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2429,7 +2430,7 @@ fn unexpected_index_with_non_empty_value_xml() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -2456,7 +2457,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2473,7 +2474,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -2500,7 +2501,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2517,7 +2518,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_key_with_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Unexpected phone number with empty value",
@@ -2536,7 +2537,7 @@ fn unexpected_key_with_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2553,7 +2554,7 @@ fn unexpected_key_with_empty_value_xml() {
 #[test]
 fn unexpected_key_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Unexpected phone number",
@@ -2572,7 +2573,7 @@ fn unexpected_key_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"12345678\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2589,7 +2590,7 @@ fn unexpected_key_with_non_empty_value_xml() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -2617,7 +2618,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2634,7 +2635,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -2662,7 +2663,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2679,7 +2680,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn value_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to be strings found an empty value",
@@ -2698,7 +2699,7 @@ fn value_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber></favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/request/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn array_at_top_level_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -31,14 +29,14 @@ fn array_at_top_level_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><rogger dob=\"06/10/2015\" name=\"Rogger the Dogger\" id=\"1014753708\" timestamp=\"2015-06-10T20:41:37\"/><cat dob=\"06/10/2015\" name=\"Cat in the Hat\" id=\"8858030303\" timestamp=\"2015-06-10T20:41:37\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn array_at_top_level_xml() {
 #[test]
 fn array_at_top_level() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -93,14 +91,14 @@ fn array_at_top_level() {
           ]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -110,7 +108,7 @@ fn array_at_top_level() {
 #[test]
 fn array_in_different_order_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Favourite colours in wrong order",
@@ -129,14 +127,14 @@ fn array_in_different_order_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>blue</favouriteColour><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -146,7 +144,7 @@ fn array_in_different_order_xml() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -173,14 +171,14 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -190,7 +188,7 @@ fn array_in_different_order() {
 #[test]
 fn array_size_less_than_required_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Array must have at least 2 elements",
@@ -212,14 +210,14 @@ fn array_size_less_than_required_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator name=\"Mary\"/></animals>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -229,7 +227,7 @@ fn array_size_less_than_required_xml() {
 #[test]
 fn array_size_less_than_required() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Array must have at least 2 elements",
@@ -263,14 +261,14 @@ fn array_size_less_than_required() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -280,7 +278,7 @@ fn array_size_less_than_required() {
 #[test]
 fn array_with_at_least_one_element_matching_by_example_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Tag with at least one element match",
@@ -304,14 +302,14 @@ fn array_with_at_least_one_element_matching_by_example_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator name=\"Mary\"/><alligator name=\"Susan\"/></animals>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -321,7 +319,7 @@ fn array_with_at_least_one_element_matching_by_example_xml() {
 #[test]
 fn array_with_at_least_one_element_matching_by_example() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Types and regular expressions match",
@@ -358,14 +356,14 @@ fn array_with_at_least_one_element_matching_by_example() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -375,7 +373,7 @@ fn array_with_at_least_one_element_matching_by_example() {
 #[test]
 fn array_with_at_least_one_element_not_matching_example_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Wrong type for name key",
@@ -412,14 +410,14 @@ fn array_with_at_least_one_element_not_matching_example_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -429,7 +427,7 @@ fn array_with_at_least_one_element_not_matching_example_type() {
 #[test]
 fn array_with_nested_array_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Nested arrays do not match, age is wrong type",
@@ -472,14 +470,14 @@ fn array_with_nested_array_that_does_not_match() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -489,7 +487,7 @@ fn array_with_nested_array_that_does_not_match() {
 #[test]
 fn array_with_nested_array_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Nested arrays match",
@@ -541,14 +539,14 @@ fn array_with_nested_array_that_matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -558,7 +556,7 @@ fn array_with_nested_array_that_matches() {
 #[test]
 fn array_with_regular_expression_in_element_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Types and regular expressions match",
@@ -583,14 +581,14 @@ fn array_with_regular_expression_in_element_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator phoneNumber=\"333\"/><alligator phoneNumber=\"983479823479283478923\"/></animals>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -600,7 +598,7 @@ fn array_with_regular_expression_in_element_xml() {
 #[test]
 fn array_with_regular_expression_in_element() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Types and regular expressions match",
@@ -638,14 +636,14 @@ fn array_with_regular_expression_in_element() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -655,7 +653,7 @@ fn array_with_regular_expression_in_element() {
 #[test]
 fn array_with_regular_expression_that_does_not_match_in_element_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Types and regular expressions match",
@@ -680,14 +678,14 @@ fn array_with_regular_expression_that_does_not_match_in_element_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><animals><alligator phoneNumber=\"123\"/><alligator phoneNumber=\"abc\"/></animals>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -697,7 +695,7 @@ fn array_with_regular_expression_that_does_not_match_in_element_xml() {
 #[test]
 fn array_with_regular_expression_that_does_not_match_in_element() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Types and regular expressions match",
@@ -735,14 +733,14 @@ fn array_with_regular_expression_that_does_not_match_in_element() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -752,7 +750,7 @@ fn array_with_regular_expression_that_does_not_match_in_element() {
 #[test]
 fn different_value_found_at_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Incorrect favourite colour",
@@ -771,14 +769,14 @@ fn different_value_found_at_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -788,7 +786,7 @@ fn different_value_found_at_index_xml() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -815,14 +813,14 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -832,7 +830,7 @@ fn different_value_found_at_index() {
 #[test]
 fn different_value_found_at_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Incorrect value at alligator name",
@@ -851,14 +849,14 @@ fn different_value_found_at_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Fred\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -868,7 +866,7 @@ fn different_value_found_at_key_xml() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -895,14 +893,14 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -912,7 +910,7 @@ fn different_value_found_at_key() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -930,14 +928,14 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -947,7 +945,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -966,14 +964,14 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -983,7 +981,7 @@ fn empty_body() {
 #[test]
 fn empty_found_at_key_where_not_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Name should not be empty",
@@ -1002,14 +1000,14 @@ fn empty_found_at_key_where_not_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1019,7 +1017,7 @@ fn empty_found_at_key_where_not_empty_expected_xml() {
 #[test]
 fn matches_with_regex_with_bracket_notation_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1041,14 +1039,14 @@ fn matches_with_regex_with_bracket_notation_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><two str=\"saldfhksajdhffdskkjh\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1058,7 +1056,7 @@ fn matches_with_regex_with_bracket_notation_xml() {
 #[test]
 fn matches_with_regex_with_bracket_notation() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1088,14 +1086,14 @@ fn matches_with_regex_with_bracket_notation() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1105,7 +1103,7 @@ fn matches_with_regex_with_bracket_notation() {
 #[test]
 fn matches_with_regex_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1129,14 +1127,14 @@ fn matches_with_regex_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Harry\" feet=\"4\"><favouriteColours><favouriteColour>blue</favouriteColour><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1146,7 +1144,7 @@ fn matches_with_regex_xml() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1182,14 +1180,14 @@ fn matches_with_regex() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1199,7 +1197,7 @@ fn matches_with_regex() {
 #[test]
 fn matches_with_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match with same type",
@@ -1234,14 +1232,14 @@ fn matches_with_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1251,7 +1249,7 @@ fn matches_with_type() {
 #[test]
 fn matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Requests match",
@@ -1270,14 +1268,14 @@ fn matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator feet=\"4\" name=\"Mary\"><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1287,7 +1285,7 @@ fn matches_xml() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match",
@@ -1318,14 +1316,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1335,7 +1333,7 @@ fn matches() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1351,14 +1349,14 @@ fn missing_body_found_when_empty_expected() {
           "query": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1368,7 +1366,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -1389,14 +1387,14 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1406,7 +1404,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1428,14 +1426,14 @@ fn missing_body() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1445,7 +1443,7 @@ fn missing_body() {
 #[test]
 fn missing_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Missing favorite colour",
@@ -1464,14 +1462,14 @@ fn missing_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1481,7 +1479,7 @@ fn missing_index_xml() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1508,14 +1506,14 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1525,7 +1523,7 @@ fn missing_index() {
 #[test]
 fn missing_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Missing key alligator name",
@@ -1544,14 +1542,14 @@ fn missing_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator age=\"3\"></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1561,7 +1559,7 @@ fn missing_key_xml() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -1589,14 +1587,14 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1606,7 +1604,7 @@ fn missing_key() {
 #[test]
 fn no_body_no_content_type_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML No body, no content-type",
@@ -1623,14 +1621,14 @@ fn no_body_no_content_type_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1640,7 +1638,7 @@ fn no_body_no_content_type_xml() {
 #[test]
 fn no_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "No body, no content-type",
@@ -1661,14 +1659,14 @@ fn no_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1678,7 +1676,7 @@ fn no_body_no_content_type() {
 #[test]
 fn no_body_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Missing body",
@@ -1696,14 +1694,14 @@ fn no_body_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1713,7 +1711,7 @@ fn no_body_xml() {
 #[test]
 fn no_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1735,14 +1733,14 @@ fn no_body() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1752,7 +1750,7 @@ fn no_body() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1775,14 +1773,14 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1792,7 +1790,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn not_empty_found_at_key_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Name should be empty",
@@ -1811,14 +1809,14 @@ fn not_empty_found_at_key_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1828,7 +1826,7 @@ fn not_empty_found_at_key_when_empty_expected_xml() {
 #[test]
 fn not_empty_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to contain empty, but non-empty found",
@@ -1847,14 +1845,14 @@ fn not_empty_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber>2</favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1864,7 +1862,7 @@ fn not_empty_found_in_array_when_empty_expected_xml() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1891,14 +1889,14 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1908,7 +1906,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to contain null, but not null found",
@@ -1935,14 +1933,14 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1952,7 +1950,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -1970,14 +1968,14 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -1987,7 +1985,7 @@ fn null_body_no_content_type() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -2006,14 +2004,14 @@ fn null_body() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2023,7 +2021,7 @@ fn null_body() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -2050,14 +2048,14 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2067,7 +2065,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a null",
@@ -2094,14 +2092,14 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2111,7 +2109,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -2138,14 +2136,14 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2155,7 +2153,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours expected to be strings found a number",
@@ -2182,14 +2180,14 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2199,7 +2197,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -2218,14 +2216,14 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2235,7 +2233,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -2254,14 +2252,14 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2271,7 +2269,7 @@ fn plain_text_that_matches() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -2298,14 +2296,14 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2315,7 +2313,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -2342,14 +2340,14 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2359,7 +2357,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn unexpected_index_with_missing_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Unexpected favourite colour with empty value",
@@ -2378,14 +2376,14 @@ fn unexpected_index_with_missing_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour></favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2395,7 +2393,7 @@ fn unexpected_index_with_missing_value_xml() {
 #[test]
 fn unexpected_index_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Unexpected favourite colour",
@@ -2414,14 +2412,14 @@ fn unexpected_index_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2431,7 +2429,7 @@ fn unexpected_index_with_non_empty_value_xml() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -2458,14 +2456,14 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2475,7 +2473,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -2502,14 +2500,14 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2519,7 +2517,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_key_with_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Unexpected phone number with empty value",
@@ -2538,14 +2536,14 @@ fn unexpected_key_with_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2555,7 +2553,7 @@ fn unexpected_key_with_empty_value_xml() {
 #[test]
 fn unexpected_key_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Unexpected phone number",
@@ -2574,14 +2572,14 @@ fn unexpected_key_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"12345678\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2591,7 +2589,7 @@ fn unexpected_key_with_non_empty_value_xml() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number",
@@ -2619,14 +2617,14 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2636,7 +2634,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected phone number with null value",
@@ -2664,14 +2662,14 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -2681,7 +2679,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn value_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to be strings found an empty value",
@@ -2700,14 +2698,14 @@ fn value_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber></favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/headers/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -28,7 +29,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -45,7 +46,7 @@ fn empty_headers() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -66,7 +67,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -83,7 +84,7 @@ fn header_name_is_different_case() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -104,7 +105,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -121,7 +122,7 @@ fn header_value_is_different_case() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match with regexp",
@@ -145,7 +146,7 @@ fn matches_with_regex() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -162,7 +163,7 @@ fn matches_with_regex() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -185,7 +186,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -202,7 +203,7 @@ fn matches() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -223,7 +224,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -240,7 +241,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -259,7 +260,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -276,7 +277,7 @@ fn unexpected_header_found() {
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -297,7 +298,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/request/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/headers/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty headers match",
@@ -30,14 +28,14 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -47,7 +45,7 @@ fn empty_headers() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -68,14 +66,14 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -85,7 +83,7 @@ fn header_name_is_different_case() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -106,14 +104,14 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -123,7 +121,7 @@ fn header_value_is_different_case() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match with regexp",
@@ -147,14 +145,14 @@ fn matches_with_regex() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -164,7 +162,7 @@ fn matches_with_regex() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -187,14 +185,14 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -204,7 +202,7 @@ fn matches() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -225,14 +223,14 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -242,7 +240,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -261,14 +259,14 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -278,7 +276,7 @@ fn unexpected_header_found() {
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -299,14 +297,14 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/method/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -30,14 +28,14 @@ fn different_method() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -47,7 +45,7 @@ fn different_method() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -65,14 +63,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -82,7 +80,7 @@ fn matches() {
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -100,14 +98,14 @@ fn method_is_different_case() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/request/method/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/method/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn different_method() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Methods is incorrect",
@@ -28,7 +29,7 @@ fn different_method() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -45,7 +46,7 @@ fn different_method() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods match",
@@ -63,7 +64,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -80,7 +81,7 @@ fn matches() {
 #[test]
 fn method_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Methods case does not matter",
@@ -98,7 +99,7 @@ fn method_is_different_case() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v2/request/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod method;

--- a/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -31,14 +29,14 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn empty_path_found_when_forward_slash_expected() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -67,14 +65,14 @@ fn forward_slash_found_when_empty_path_expected() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -103,14 +101,14 @@ fn incorrect_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -120,7 +118,7 @@ fn incorrect_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -139,14 +137,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -156,7 +154,7 @@ fn matches() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -175,14 +173,14 @@ fn missing_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -192,7 +190,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -211,14 +209,14 @@ fn unexpected_trailing_slash_in_path() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
@@ -56,14 +56,14 @@ fn forward_slash_found_when_empty_path_expected() {
           "path": "",
           "query": "",
           "headers": {}
-
+      
         },
         "actual": {
           "method": "POST",
           "path": "/",
           "query": "",
           "headers": {}
-
+      
         }
       }
     "#).unwrap();
@@ -92,14 +92,14 @@ fn incorrect_path() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something/else",
           "query": "",
           "headers": {}
-
+      
         }
       }
     "#).unwrap();
@@ -128,14 +128,14 @@ fn matches() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-
+      
         }
       }
     "#).unwrap();
@@ -164,14 +164,14 @@ fn missing_trailing_slash_in_path() {
           "path": "/path/to/something/",
           "query": "",
           "headers": {}
-
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-
+      
         }
       }
     "#).unwrap();
@@ -200,14 +200,14 @@ fn unexpected_trailing_slash_in_path() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-
+      
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something/",
           "query": "",
           "headers": {}
-
+      
         }
       }
     "#).unwrap();

--- a/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/path/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn empty_path_found_when_forward_slash_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Empty path found when forward slash expected",
@@ -29,7 +30,7 @@ fn empty_path_found_when_forward_slash_expected() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn empty_path_found_when_forward_slash_expected() {
 #[test]
 fn forward_slash_found_when_empty_path_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Foward slash found when empty path expected",
@@ -55,17 +56,17 @@ fn forward_slash_found_when_empty_path_expected() {
           "path": "",
           "query": "",
           "headers": {}
-      
+
         },
         "actual": {
           "method": "POST",
           "path": "/",
           "query": "",
           "headers": {}
-      
+
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn forward_slash_found_when_empty_path_expected() {
 #[test]
 fn incorrect_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Paths do not match",
@@ -91,17 +92,17 @@ fn incorrect_path() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-      
+
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something/else",
           "query": "",
           "headers": {}
-      
+
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -118,7 +119,7 @@ fn incorrect_path() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Paths match",
@@ -127,17 +128,17 @@ fn matches() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-      
+
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-      
+
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -154,7 +155,7 @@ fn matches() {
 #[test]
 fn missing_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path is missing trailing slash, trailing slashes can matter",
@@ -163,17 +164,17 @@ fn missing_trailing_slash_in_path() {
           "path": "/path/to/something/",
           "query": "",
           "headers": {}
-      
+
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-      
+
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -190,7 +191,7 @@ fn missing_trailing_slash_in_path() {
 #[test]
 fn unexpected_trailing_slash_in_path() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Path has unexpected trailing slash, trailing slashes can matter",
@@ -199,17 +200,17 @@ fn unexpected_trailing_slash_in_path() {
           "path": "/path/to/something",
           "query": "",
           "headers": {}
-      
+
         },
         "actual": {
           "method": "POST",
           "path": "/path/to/something/",
           "query": "",
           "headers": {}
-      
+
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/query/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_request;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same but in different key order",
@@ -29,7 +30,7 @@ fn different_order() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -46,7 +47,7 @@ fn different_order() {
 #[test]
 fn different_params() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -65,7 +66,7 @@ fn different_params() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -82,7 +83,7 @@ fn different_params() {
 #[test]
 fn matches_with_equals_in_the_query_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are equivalent",
@@ -101,7 +102,7 @@ fn matches_with_equals_in_the_query_value() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -118,7 +119,7 @@ fn matches_with_equals_in_the_query_value() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -137,7 +138,7 @@ fn matches() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -154,7 +155,7 @@ fn matches() {
 #[test]
 fn missing_params() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is missing",
@@ -173,7 +174,7 @@ fn missing_params() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -190,7 +191,7 @@ fn missing_params() {
 #[test]
 fn same_parameter_different_values() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
@@ -209,7 +210,7 @@ fn same_parameter_different_values() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -226,7 +227,7 @@ fn same_parameter_different_values() {
 #[test]
 fn same_parameter_multiple_times_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - values are in different order",
@@ -244,7 +245,7 @@ fn same_parameter_multiple_times_in_different_order() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -261,7 +262,7 @@ fn same_parameter_multiple_times_in_different_order() {
 #[test]
 fn same_parameter_multiple_times() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Queries are the same - multiple values are in same order",
@@ -279,7 +280,7 @@ fn same_parameter_multiple_times() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -296,7 +297,7 @@ fn same_parameter_multiple_times() {
 #[test]
 fn trailing_ampersand() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Trailing amperands can be ignored",
@@ -315,7 +316,7 @@ fn trailing_ampersand() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -332,7 +333,7 @@ fn trailing_ampersand() {
 #[test]
 fn unexpected_param() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is not expected",
@@ -351,7 +352,7 @@ fn unexpected_param() {
       
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/request/query/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/request/query/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_request;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same but in different key order",
@@ -31,14 +29,14 @@ fn different_order() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -48,7 +46,7 @@ fn different_order() {
 #[test]
 fn different_params() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - hippo is Fred instead of John",
@@ -67,14 +65,14 @@ fn different_params() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -84,7 +82,7 @@ fn different_params() {
 #[test]
 fn matches_with_equals_in_the_query_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are equivalent",
@@ -103,14 +101,14 @@ fn matches_with_equals_in_the_query_value() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -120,7 +118,7 @@ fn matches_with_equals_in_the_query_value() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same",
@@ -139,14 +137,14 @@ fn matches() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -156,7 +154,7 @@ fn matches() {
 #[test]
 fn missing_params() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is missing",
@@ -175,14 +173,14 @@ fn missing_params() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -192,7 +190,7 @@ fn missing_params() {
 #[test]
 fn same_parameter_different_values() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - animals are alligator, hippo versus alligator, elephant",
@@ -211,14 +209,14 @@ fn same_parameter_different_values() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -228,7 +226,7 @@ fn same_parameter_different_values() {
 #[test]
 fn same_parameter_multiple_times_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - values are in different order",
@@ -246,14 +244,14 @@ fn same_parameter_multiple_times_in_different_order() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -263,7 +261,7 @@ fn same_parameter_multiple_times_in_different_order() {
 #[test]
 fn same_parameter_multiple_times() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Queries are the same - multiple values are in same order",
@@ -281,14 +279,14 @@ fn same_parameter_multiple_times() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -298,7 +296,7 @@ fn same_parameter_multiple_times() {
 #[test]
 fn trailing_ampersand() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Trailing amperands can be ignored",
@@ -317,14 +315,14 @@ fn trailing_ampersand() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());
@@ -334,7 +332,7 @@ fn trailing_ampersand() {
 #[test]
 fn unexpected_param() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Queries are not the same - elephant is not expected",
@@ -353,14 +351,14 @@ fn unexpected_param() {
       
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Request::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Request::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Request::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Request::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
-    if pact_match.as_boolean().unwrap() {
+    let pact_match = pact.get("match").unwrap();
+    if pact_match.as_bool().unwrap() {
        expect!(match_request(expected, actual)).to(be_empty());
     } else {
        expect!(match_request(expected, actual)).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/body/mod.rs
@@ -5,14 +5,12 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn additional_property_with_type_matcher_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "additional property with type matcher wildcards that don't match",
@@ -40,15 +38,15 @@ fn additional_property_with_type_matcher_that_does_not_match() {
           }    
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -58,7 +56,7 @@ fn additional_property_with_type_matcher_that_does_not_match() {
 #[test]
 fn additional_property_with_type_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "additional property with type matcher wildcards",
@@ -86,15 +84,15 @@ fn additional_property_with_type_matcher() {
           }    
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -104,7 +102,7 @@ fn additional_property_with_type_matcher() {
 #[test]
 fn array_at_top_level_with_matchers_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -131,15 +129,15 @@ fn array_at_top_level_with_matchers_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person dob=\"11/06/2015\" name=\"Bob The Builder\" id=\"1234567890\" timestamp=\"2000-06-10T20:41:37\"/><cat dob=\"12/10/2000\" name=\"Slinky Malinky\" id=\"6677889900\" timestamp=\"2015-06-10T22:98:78\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -149,7 +147,7 @@ fn array_at_top_level_with_matchers_xml() {
 #[test]
 fn array_at_top_level_with_matchers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -211,15 +209,15 @@ fn array_at_top_level_with_matchers() {
           ]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -229,7 +227,7 @@ fn array_at_top_level_with_matchers() {
 #[test]
 fn array_at_top_level_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -242,15 +240,15 @@ fn array_at_top_level_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><rogger dob=\"06/10/2015\" name=\"Rogger the Dogger\" id=\"1014753708\" timestamp=\"2015-06-10T20:41:37\"/><cat dob=\"06/10/2015\" name=\"Cat in the Hat\" id=\"8858030303\" timestamp=\"2015-06-10T20:41:37\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -260,7 +258,7 @@ fn array_at_top_level_xml() {
 #[test]
 fn array_at_top_level() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -299,15 +297,15 @@ fn array_at_top_level() {
           ]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -317,7 +315,7 @@ fn array_at_top_level() {
 #[test]
 fn array_in_different_order_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Favourite colours in wrong order",
@@ -330,15 +328,15 @@ fn array_in_different_order_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><blue/><red/></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -348,7 +346,7 @@ fn array_in_different_order_xml() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -369,15 +367,15 @@ fn array_in_different_order() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -387,7 +385,7 @@ fn array_in_different_order() {
 #[test]
 fn array_with_regex_matcher_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML array with regex matcher",
@@ -408,15 +406,15 @@ fn array_with_regex_matcher_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><myDates><date>01/11/2010</date><date>15/12/2014</date><date>30/06/2015</date></myDates>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -426,7 +424,7 @@ fn array_with_regex_matcher_xml() {
 #[test]
 fn array_with_regex_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "array with regex matcher",
@@ -457,15 +455,15 @@ fn array_with_regex_matcher() {
           }    
         }
       }   
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -475,7 +473,7 @@ fn array_with_regex_matcher() {
 #[test]
 fn array_with_type_matcher_mismatch_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML array with type matcher mismatch",
@@ -493,15 +491,15 @@ fn array_with_type_matcher_mismatch_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person>Fred</person><person>Fred</person><cat>Fred</cat></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -511,7 +509,7 @@ fn array_with_type_matcher_mismatch_xml() {
 #[test]
 fn array_with_type_matcher_mismatch() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "array with type matcher mismatch",
@@ -539,15 +537,15 @@ fn array_with_type_matcher_mismatch() {
           }    
         }
       }   
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -557,7 +555,7 @@ fn array_with_type_matcher_mismatch() {
 #[test]
 fn array_with_type_matcher_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "array with type matcher",
@@ -578,15 +576,15 @@ fn array_with_type_matcher_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person>Fred</person><person>George</person><person>Cat</person></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -596,7 +594,7 @@ fn array_with_type_matcher_xml() {
 #[test]
 fn array_with_type_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "array with type matcher",
@@ -627,15 +625,15 @@ fn array_with_type_matcher() {
           }    
         }
       }   
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -645,7 +643,7 @@ fn array_with_type_matcher() {
 #[test]
 fn deeply_nested_objects_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "XML Comparisons should work even on nested objects",
@@ -658,15 +656,15 @@ fn deeply_nested_objects_xml() {
       		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><object1 color=\"red\"><object2><object4><object5 name=\"Mary\" gender=\"F\"><friends><friend>Fred</friend><friend>John</friend></friends></object5><object6 phoneNumber=\"1234567890\"/></object4></object2></object1>"
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -676,7 +674,7 @@ fn deeply_nested_objects_xml() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -719,15 +717,15 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -737,7 +735,7 @@ fn deeply_nested_objects() {
 #[test]
 fn different_value_found_at_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Incorrect favourite colour",
@@ -750,15 +748,15 @@ fn different_value_found_at_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>purple</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -768,7 +766,7 @@ fn different_value_found_at_index_xml() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -789,15 +787,15 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -807,7 +805,7 @@ fn different_value_found_at_index() {
 #[test]
 fn different_value_found_at_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Incorrect value at alligator name",
@@ -820,15 +818,15 @@ fn different_value_found_at_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Fred\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -838,7 +836,7 @@ fn different_value_found_at_key_xml() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -859,15 +857,15 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -877,7 +875,7 @@ fn different_value_found_at_key() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -889,15 +887,15 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -907,7 +905,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -920,15 +918,15 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -938,7 +936,7 @@ fn empty_body() {
 #[test]
 fn keys_out_of_order_match_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Favourite number and favourite colours out of order",
@@ -951,15 +949,15 @@ fn keys_out_of_order_match_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator favouriteColours=\"red, blue\" favouriteNumber=\"7\" />"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -969,7 +967,7 @@ fn keys_out_of_order_match_xml() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -988,15 +986,15 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1006,7 +1004,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn matches_with_regex_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1022,15 +1020,15 @@ fn matches_with_regex_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Harry\" feet=\"4\" favouriteNumber=\"7\" favouriteColours=\"red, blue\" />"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1040,7 +1038,7 @@ fn matches_with_regex_xml() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1068,15 +1066,15 @@ fn matches_with_regex() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1086,7 +1084,7 @@ fn matches_with_regex() {
 #[test]
 fn matches_with_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Response match with same type",
@@ -1115,15 +1113,15 @@ fn matches_with_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1133,7 +1131,7 @@ fn matches_with_type() {
 #[test]
 fn matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -1146,15 +1144,15 @@ fn matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator feet=\"4\" name=\"Mary\"><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1164,7 +1162,7 @@ fn matches_xml() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -1189,15 +1187,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1207,7 +1205,7 @@ fn matches() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1217,15 +1215,15 @@ fn missing_body_found_when_empty_expected() {
         "actual": {
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1235,7 +1233,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -1252,15 +1250,15 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1270,7 +1268,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Missing body",
@@ -1282,15 +1280,15 @@ fn missing_body_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1300,7 +1298,7 @@ fn missing_body_xml() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1318,15 +1316,15 @@ fn missing_body() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1336,7 +1334,7 @@ fn missing_body() {
 #[test]
 fn missing_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1349,15 +1347,15 @@ fn missing_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1367,7 +1365,7 @@ fn missing_index_xml() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1388,15 +1386,15 @@ fn missing_index() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1406,7 +1404,7 @@ fn missing_index() {
 #[test]
 fn missing_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Missing key alligator name",
@@ -1419,15 +1417,15 @@ fn missing_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator age=\"3\"></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1437,7 +1435,7 @@ fn missing_key_xml() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -1459,15 +1457,15 @@ fn missing_key() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1477,7 +1475,7 @@ fn missing_key() {
 #[test]
 fn no_body_no_content_type_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML No body, no content-type",
@@ -1488,15 +1486,15 @@ fn no_body_no_content_type_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1506,7 +1504,7 @@ fn no_body_no_content_type_xml() {
 #[test]
 fn no_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "No body, no content-type",
@@ -1523,15 +1521,15 @@ fn no_body_no_content_type() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1541,7 +1539,7 @@ fn no_body_no_content_type() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1560,15 +1558,15 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1578,7 +1576,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1599,15 +1597,15 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1617,7 +1615,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -1638,15 +1636,15 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1656,7 +1654,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -1668,15 +1666,15 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1686,7 +1684,7 @@ fn null_body_no_content_type() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -1699,15 +1697,15 @@ fn null_body() {
           "body": null
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1717,7 +1715,7 @@ fn null_body() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -1738,15 +1736,15 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1756,7 +1754,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -1777,15 +1775,15 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1795,7 +1793,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -1816,15 +1814,15 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1834,7 +1832,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -1855,15 +1853,15 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1873,7 +1871,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn objects_in_array_first_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Properties match but unexpected element received",
@@ -1886,15 +1884,15 @@ fn objects_in_array_first_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1904,7 +1902,7 @@ fn objects_in_array_first_matches_xml() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element received",
@@ -1930,15 +1928,15 @@ fn objects_in_array_first_matches() {
           ]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1948,7 +1946,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn objects_in_array_no_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Array of objects, properties match on incorrect objects",
@@ -1961,15 +1959,15 @@ fn objects_in_array_no_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -1979,7 +1977,7 @@ fn objects_in_array_no_matches_xml() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -2000,15 +1998,15 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2018,7 +2016,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_second_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Property of second object matches, but unexpected element received",
@@ -2031,15 +2029,15 @@ fn objects_in_array_second_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2049,7 +2047,7 @@ fn objects_in_array_second_matches_xml() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -2069,15 +2067,15 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2087,7 +2085,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_type_matching_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML objects in array type matching",
@@ -2111,15 +2109,15 @@ fn objects_in_array_type_matching_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person name=\"Peter Peterson\" age=\"22\" gender=\"Male\"/><person name=\"John Johnston\" age=\"64\"/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2129,7 +2127,7 @@ fn objects_in_array_type_matching_xml() {
 #[test]
 fn objects_in_array_type_matching() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "objects in array type matching",
@@ -2160,15 +2158,15 @@ fn objects_in_array_type_matching() {
           }]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2178,7 +2176,7 @@ fn objects_in_array_type_matching() {
 #[test]
 fn objects_in_array_with_type_mismatching_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML objects in array with type mismatching",
@@ -2199,15 +2197,15 @@ fn objects_in_array_with_type_mismatching_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person name=\"Peter Peterson\" age=\"22\" gender=\"Male\"/><person/></people>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2217,7 +2215,7 @@ fn objects_in_array_with_type_mismatching_xml() {
 #[test]
 fn objects_in_array_with_type_mismatching() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "objects in array with type mismatching",
@@ -2245,15 +2243,15 @@ fn objects_in_array_with_type_mismatching() {
           }, {}]
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2263,7 +2261,7 @@ fn objects_in_array_with_type_mismatching() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -2276,15 +2274,15 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2294,7 +2292,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -2307,15 +2305,15 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2325,7 +2323,7 @@ fn plain_text_that_matches() {
 #[test]
 fn property_name_is_different_case_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Property names on objects are case sensitive",
@@ -2338,15 +2336,15 @@ fn property_name_is_different_case_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator favouritecolour=\"red\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2356,7 +2354,7 @@ fn property_name_is_different_case_xml() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -2377,15 +2375,15 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2395,7 +2393,7 @@ fn property_name_is_different_case() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -2416,15 +2414,15 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2434,7 +2432,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -2455,15 +2453,15 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2473,7 +2471,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn unexpected_index_with_missing_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Unexpected favourite colour with missing value",
@@ -2486,15 +2484,15 @@ fn unexpected_index_with_missing_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour></favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2504,7 +2502,7 @@ fn unexpected_index_with_missing_value_xml() {
 #[test]
 fn unexpected_index_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Unexpected favourite colour",
@@ -2517,15 +2515,15 @@ fn unexpected_index_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2535,7 +2533,7 @@ fn unexpected_index_with_non_empty_value_xml() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -2556,15 +2554,15 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2574,7 +2572,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -2595,15 +2593,15 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2613,7 +2611,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_key_with_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Unexpected phone number with empty value",
@@ -2626,15 +2624,15 @@ fn unexpected_key_with_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2644,7 +2642,7 @@ fn unexpected_key_with_empty_value_xml() {
 #[test]
 fn unexpected_key_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "XML Unexpected phone number",
@@ -2657,15 +2655,15 @@ fn unexpected_key_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"12345678\"/>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2675,7 +2673,7 @@ fn unexpected_key_with_non_empty_value_xml() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -2697,15 +2695,15 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2715,7 +2713,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -2737,15 +2735,15 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -2755,7 +2753,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn value_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to contain empty, but non-empty found",
@@ -2768,15 +2766,15 @@ fn value_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber>2</favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/response/body/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/body/mod.rs
@@ -6,11 +6,12 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn additional_property_with_type_matcher_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "additional property with type matcher wildcards that don't match",
@@ -38,7 +39,7 @@ fn additional_property_with_type_matcher_that_does_not_match() {
           }    
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -56,7 +57,7 @@ fn additional_property_with_type_matcher_that_does_not_match() {
 #[test]
 fn additional_property_with_type_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "additional property with type matcher wildcards",
@@ -84,7 +85,7 @@ fn additional_property_with_type_matcher() {
           }    
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -102,7 +103,7 @@ fn additional_property_with_type_matcher() {
 #[test]
 fn array_at_top_level_with_matchers_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -129,7 +130,7 @@ fn array_at_top_level_with_matchers_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person dob=\"11/06/2015\" name=\"Bob The Builder\" id=\"1234567890\" timestamp=\"2000-06-10T20:41:37\"/><cat dob=\"12/10/2000\" name=\"Slinky Malinky\" id=\"6677889900\" timestamp=\"2015-06-10T22:98:78\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -147,7 +148,7 @@ fn array_at_top_level_with_matchers_xml() {
 #[test]
 fn array_at_top_level_with_matchers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -209,7 +210,7 @@ fn array_at_top_level_with_matchers() {
           ]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -227,7 +228,7 @@ fn array_at_top_level_with_matchers() {
 #[test]
 fn array_at_top_level_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML top level array matches",
@@ -240,7 +241,7 @@ fn array_at_top_level_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><rogger dob=\"06/10/2015\" name=\"Rogger the Dogger\" id=\"1014753708\" timestamp=\"2015-06-10T20:41:37\"/><cat dob=\"06/10/2015\" name=\"Cat in the Hat\" id=\"8858030303\" timestamp=\"2015-06-10T20:41:37\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -258,7 +259,7 @@ fn array_at_top_level_xml() {
 #[test]
 fn array_at_top_level() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "top level array matches",
@@ -297,7 +298,7 @@ fn array_at_top_level() {
           ]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -315,7 +316,7 @@ fn array_at_top_level() {
 #[test]
 fn array_in_different_order_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Favourite colours in wrong order",
@@ -328,7 +329,7 @@ fn array_in_different_order_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><blue/><red/></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -346,7 +347,7 @@ fn array_in_different_order_xml() {
 #[test]
 fn array_in_different_order() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite colours in wrong order",
@@ -367,7 +368,7 @@ fn array_in_different_order() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -385,7 +386,7 @@ fn array_in_different_order() {
 #[test]
 fn array_with_regex_matcher_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML array with regex matcher",
@@ -406,7 +407,7 @@ fn array_with_regex_matcher_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><myDates><date>01/11/2010</date><date>15/12/2014</date><date>30/06/2015</date></myDates>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -424,7 +425,7 @@ fn array_with_regex_matcher_xml() {
 #[test]
 fn array_with_regex_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "array with regex matcher",
@@ -455,7 +456,7 @@ fn array_with_regex_matcher() {
           }    
         }
       }   
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -473,7 +474,7 @@ fn array_with_regex_matcher() {
 #[test]
 fn array_with_type_matcher_mismatch_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML array with type matcher mismatch",
@@ -491,7 +492,7 @@ fn array_with_type_matcher_mismatch_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person>Fred</person><person>Fred</person><cat>Fred</cat></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -509,7 +510,7 @@ fn array_with_type_matcher_mismatch_xml() {
 #[test]
 fn array_with_type_matcher_mismatch() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "array with type matcher mismatch",
@@ -537,7 +538,7 @@ fn array_with_type_matcher_mismatch() {
           }    
         }
       }   
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -555,7 +556,7 @@ fn array_with_type_matcher_mismatch() {
 #[test]
 fn array_with_type_matcher_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "array with type matcher",
@@ -576,7 +577,7 @@ fn array_with_type_matcher_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person>Fred</person><person>George</person><person>Cat</person></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -594,7 +595,7 @@ fn array_with_type_matcher_xml() {
 #[test]
 fn array_with_type_matcher() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "array with type matcher",
@@ -625,7 +626,7 @@ fn array_with_type_matcher() {
           }    
         }
       }   
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -643,7 +644,7 @@ fn array_with_type_matcher() {
 #[test]
 fn deeply_nested_objects_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "XML Comparisons should work even on nested objects",
@@ -656,7 +657,7 @@ fn deeply_nested_objects_xml() {
       		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><object1 color=\"red\"><object2><object4><object5 name=\"Mary\" gender=\"F\"><friends><friend>Fred</friend><friend>John</friend></friends></object5><object6 phoneNumber=\"1234567890\"/></object4></object2></object1>"
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -674,7 +675,7 @@ fn deeply_nested_objects_xml() {
 #[test]
 fn deeply_nested_objects() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "Comparisons should work even on nested objects",
@@ -717,7 +718,7 @@ fn deeply_nested_objects() {
       		}
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -735,7 +736,7 @@ fn deeply_nested_objects() {
 #[test]
 fn different_value_found_at_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Incorrect favourite colour",
@@ -748,7 +749,7 @@ fn different_value_found_at_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>purple</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -766,7 +767,7 @@ fn different_value_found_at_index_xml() {
 #[test]
 fn different_value_found_at_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect favourite colour",
@@ -787,7 +788,7 @@ fn different_value_found_at_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -805,7 +806,7 @@ fn different_value_found_at_index() {
 #[test]
 fn different_value_found_at_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Incorrect value at alligator name",
@@ -818,7 +819,7 @@ fn different_value_found_at_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Fred\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -836,7 +837,7 @@ fn different_value_found_at_key_xml() {
 #[test]
 fn different_value_found_at_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Incorrect value at alligator name",
@@ -857,7 +858,7 @@ fn different_value_found_at_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -875,7 +876,7 @@ fn different_value_found_at_key() {
 #[test]
 fn empty_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body, no content-type",
@@ -887,7 +888,7 @@ fn empty_body_no_content_type() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -905,7 +906,7 @@ fn empty_body_no_content_type() {
 #[test]
 fn empty_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Empty body",
@@ -918,7 +919,7 @@ fn empty_body() {
           "body": ""
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -936,7 +937,7 @@ fn empty_body() {
 #[test]
 fn keys_out_of_order_match_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Favourite number and favourite colours out of order",
@@ -949,7 +950,7 @@ fn keys_out_of_order_match_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator favouriteColours=\"red, blue\" favouriteNumber=\"7\" />"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -967,7 +968,7 @@ fn keys_out_of_order_match_xml() {
 #[test]
 fn keys_out_of_order_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Favourite number and favourite colours out of order",
@@ -986,7 +987,7 @@ fn keys_out_of_order_match() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1004,7 +1005,7 @@ fn keys_out_of_order_match() {
 #[test]
 fn matches_with_regex_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Requests match with regex",
@@ -1020,7 +1021,7 @@ fn matches_with_regex_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Harry\" feet=\"4\" favouriteNumber=\"7\" favouriteColours=\"red, blue\" />"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1038,7 +1039,7 @@ fn matches_with_regex_xml() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Requests match with regex",
@@ -1066,7 +1067,7 @@ fn matches_with_regex() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1084,7 +1085,7 @@ fn matches_with_regex() {
 #[test]
 fn matches_with_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Response match with same type",
@@ -1113,7 +1114,7 @@ fn matches_with_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1131,7 +1132,7 @@ fn matches_with_type() {
 #[test]
 fn matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -1144,7 +1145,7 @@ fn matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator feet=\"4\" name=\"Mary\"><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1162,7 +1163,7 @@ fn matches_xml() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Responses match",
@@ -1187,7 +1188,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1205,7 +1206,7 @@ fn matches() {
 #[test]
 fn missing_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body found, when an empty body was expected",
@@ -1215,7 +1216,7 @@ fn missing_body_found_when_empty_expected() {
         "actual": {
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1233,7 +1234,7 @@ fn missing_body_found_when_empty_expected() {
 #[test]
 fn missing_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body, no content-type",
@@ -1250,7 +1251,7 @@ fn missing_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1268,7 +1269,7 @@ fn missing_body_no_content_type() {
 #[test]
 fn missing_body_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Missing body",
@@ -1280,7 +1281,7 @@ fn missing_body_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1298,7 +1299,7 @@ fn missing_body_xml() {
 #[test]
 fn missing_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Missing body",
@@ -1316,7 +1317,7 @@ fn missing_body() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1334,7 +1335,7 @@ fn missing_body() {
 #[test]
 fn missing_index_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1347,7 +1348,7 @@ fn missing_index_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1365,7 +1366,7 @@ fn missing_index_xml() {
 #[test]
 fn missing_index() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing favorite colour",
@@ -1386,7 +1387,7 @@ fn missing_index() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1404,7 +1405,7 @@ fn missing_index() {
 #[test]
 fn missing_key_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Missing key alligator name",
@@ -1417,7 +1418,7 @@ fn missing_key_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator age=\"3\"></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1435,7 +1436,7 @@ fn missing_key_xml() {
 #[test]
 fn missing_key() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Missing key alligator name",
@@ -1457,7 +1458,7 @@ fn missing_key() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1475,7 +1476,7 @@ fn missing_key() {
 #[test]
 fn no_body_no_content_type_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML No body, no content-type",
@@ -1486,7 +1487,7 @@ fn no_body_no_content_type_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1504,7 +1505,7 @@ fn no_body_no_content_type_xml() {
 #[test]
 fn no_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "No body, no content-type",
@@ -1521,7 +1522,7 @@ fn no_body_no_content_type() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1539,7 +1540,7 @@ fn no_body_no_content_type() {
 #[test]
 fn non_empty_body_found_when_empty_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Non empty body found, when an empty body was expected",
@@ -1558,7 +1559,7 @@ fn non_empty_body_found_when_empty_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1576,7 +1577,7 @@ fn non_empty_body_found_when_empty_expected() {
 #[test]
 fn not_null_found_at_key_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should be null",
@@ -1597,7 +1598,7 @@ fn not_null_found_at_key_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1615,7 +1616,7 @@ fn not_null_found_at_key_when_null_expected() {
 #[test]
 fn not_null_found_in_array_when_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to contain null, but not null found",
@@ -1636,7 +1637,7 @@ fn not_null_found_in_array_when_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1654,7 +1655,7 @@ fn not_null_found_in_array_when_null_expected() {
 #[test]
 fn null_body_no_content_type() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body, no content-type",
@@ -1666,7 +1667,7 @@ fn null_body_no_content_type() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1684,7 +1685,7 @@ fn null_body_no_content_type() {
 #[test]
 fn null_body() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "NULL body",
@@ -1697,7 +1698,7 @@ fn null_body() {
           "body": null
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1715,7 +1716,7 @@ fn null_body() {
 #[test]
 fn null_found_at_key_where_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Name should not be null",
@@ -1736,7 +1737,7 @@ fn null_found_at_key_where_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1754,7 +1755,7 @@ fn null_found_at_key_where_not_null_expected() {
 #[test]
 fn null_found_in_array_when_not_null_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a null",
@@ -1775,7 +1776,7 @@ fn null_found_in_array_when_not_null_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1793,7 +1794,7 @@ fn null_found_in_array_when_not_null_expected() {
 #[test]
 fn number_found_at_key_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be string but was number",
@@ -1814,7 +1815,7 @@ fn number_found_at_key_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1832,7 +1833,7 @@ fn number_found_at_key_when_string_expected() {
 #[test]
 fn number_found_in_array_when_string_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite numbers expected to be strings found a number",
@@ -1853,7 +1854,7 @@ fn number_found_in_array_when_string_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1871,7 +1872,7 @@ fn number_found_in_array_when_string_expected() {
 #[test]
 fn objects_in_array_first_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Properties match but unexpected element received",
@@ -1884,7 +1885,7 @@ fn objects_in_array_first_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1902,7 +1903,7 @@ fn objects_in_array_first_matches_xml() {
 #[test]
 fn objects_in_array_first_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Properties match but unexpected element received",
@@ -1928,7 +1929,7 @@ fn objects_in_array_first_matches() {
           ]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1946,7 +1947,7 @@ fn objects_in_array_first_matches() {
 #[test]
 fn objects_in_array_no_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Array of objects, properties match on incorrect objects",
@@ -1959,7 +1960,7 @@ fn objects_in_array_no_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -1977,7 +1978,7 @@ fn objects_in_array_no_matches_xml() {
 #[test]
 fn objects_in_array_no_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Array of objects, properties match on incorrect objects",
@@ -1998,7 +1999,7 @@ fn objects_in_array_no_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2016,7 +2017,7 @@ fn objects_in_array_no_matches() {
 #[test]
 fn objects_in_array_second_matches_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Property of second object matches, but unexpected element received",
@@ -2029,7 +2030,7 @@ fn objects_in_array_second_matches_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person favouriteColour=\"blue\" favouriteNumber=\"4\"/><person favouriteColour=\"red\" favouriteNumber=\"2\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2047,7 +2048,7 @@ fn objects_in_array_second_matches_xml() {
 #[test]
 fn objects_in_array_second_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property of second object matches, but unexpected element recieved",
@@ -2067,7 +2068,7 @@ fn objects_in_array_second_matches() {
       	]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2085,7 +2086,7 @@ fn objects_in_array_second_matches() {
 #[test]
 fn objects_in_array_type_matching_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML objects in array type matching",
@@ -2109,7 +2110,7 @@ fn objects_in_array_type_matching_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person name=\"Peter Peterson\" age=\"22\" gender=\"Male\"/><person name=\"John Johnston\" age=\"64\"/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2127,7 +2128,7 @@ fn objects_in_array_type_matching_xml() {
 #[test]
 fn objects_in_array_type_matching() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "objects in array type matching",
@@ -2158,7 +2159,7 @@ fn objects_in_array_type_matching() {
           }]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2176,7 +2177,7 @@ fn objects_in_array_type_matching() {
 #[test]
 fn objects_in_array_with_type_mismatching_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML objects in array with type mismatching",
@@ -2197,7 +2198,7 @@ fn objects_in_array_with_type_mismatching_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><people><person name=\"Peter Peterson\" age=\"22\" gender=\"Male\"/><person/></people>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2215,7 +2216,7 @@ fn objects_in_array_with_type_mismatching_xml() {
 #[test]
 fn objects_in_array_with_type_mismatching() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "objects in array with type mismatching",
@@ -2243,7 +2244,7 @@ fn objects_in_array_with_type_mismatching() {
           }, {}]
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2261,7 +2262,7 @@ fn objects_in_array_with_type_mismatching() {
 #[test]
 fn plain_text_that_does_not_match() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Plain text that does not match",
@@ -2274,7 +2275,7 @@ fn plain_text_that_does_not_match() {
           "body": "alligator named fred"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2292,7 +2293,7 @@ fn plain_text_that_does_not_match() {
 #[test]
 fn plain_text_that_matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Plain text that matches",
@@ -2305,7 +2306,7 @@ fn plain_text_that_matches() {
           "body": "alligator named mary"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2323,7 +2324,7 @@ fn plain_text_that_matches() {
 #[test]
 fn property_name_is_different_case_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Property names on objects are case sensitive",
@@ -2336,7 +2337,7 @@ fn property_name_is_different_case_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator favouritecolour=\"red\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2354,7 +2355,7 @@ fn property_name_is_different_case_xml() {
 #[test]
 fn property_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Property names on objects are case sensitive",
@@ -2375,7 +2376,7 @@ fn property_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2393,7 +2394,7 @@ fn property_name_is_different_case() {
 #[test]
 fn string_found_at_key_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Number of feet expected to be number but was string",
@@ -2414,7 +2415,7 @@ fn string_found_at_key_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2432,7 +2433,7 @@ fn string_found_at_key_when_number_expected() {
 #[test]
 fn string_found_in_array_when_number_expected() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Favourite Numbers expected to be numbers, but 2 is a string",
@@ -2453,7 +2454,7 @@ fn string_found_in_array_when_number_expected() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2471,7 +2472,7 @@ fn string_found_in_array_when_number_expected() {
 #[test]
 fn unexpected_index_with_missing_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Unexpected favourite colour with missing value",
@@ -2484,7 +2485,7 @@ fn unexpected_index_with_missing_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour></favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2502,7 +2503,7 @@ fn unexpected_index_with_missing_value_xml() {
 #[test]
 fn unexpected_index_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Unexpected favourite colour",
@@ -2515,7 +2516,7 @@ fn unexpected_index_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteColours><favouriteColour>red</favouriteColour><favouriteColour>blue</favouriteColour><favouriteColour>taupe</favouriteColour></favouriteColours></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2533,7 +2534,7 @@ fn unexpected_index_with_non_empty_value_xml() {
 #[test]
 fn unexpected_index_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour",
@@ -2554,7 +2555,7 @@ fn unexpected_index_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2572,7 +2573,7 @@ fn unexpected_index_with_not_null_value() {
 #[test]
 fn unexpected_index_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Unexpected favourite colour with null value",
@@ -2593,7 +2594,7 @@ fn unexpected_index_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2611,7 +2612,7 @@ fn unexpected_index_with_null_value() {
 #[test]
 fn unexpected_key_with_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Unexpected phone number with empty value",
@@ -2624,7 +2625,7 @@ fn unexpected_key_with_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2642,7 +2643,7 @@ fn unexpected_key_with_empty_value_xml() {
 #[test]
 fn unexpected_key_with_non_empty_value_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "XML Unexpected phone number",
@@ -2655,7 +2656,7 @@ fn unexpected_key_with_non_empty_value_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator name=\"Mary\" phoneNumber=\"12345678\"/>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2673,7 +2674,7 @@ fn unexpected_key_with_non_empty_value_xml() {
 #[test]
 fn unexpected_key_with_not_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number",
@@ -2695,7 +2696,7 @@ fn unexpected_key_with_not_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2713,7 +2714,7 @@ fn unexpected_key_with_not_null_value() {
 #[test]
 fn unexpected_key_with_null_value() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Unexpected phone number with null value",
@@ -2735,7 +2736,7 @@ fn unexpected_key_with_null_value() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -2753,7 +2754,7 @@ fn unexpected_key_with_null_value() {
 #[test]
 fn value_found_in_array_when_empty_expected_xml() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "XML Favourite numbers expected to contain empty, but non-empty found",
@@ -2766,7 +2767,7 @@ fn value_found_in_array_when_empty_expected_xml() {
           "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator><favouriteNumbers><favouriteNumber>1</favouriteNumber><favouriteNumber>2</favouriteNumber><favouriteNumber>3</favouriteNumber></favouriteNumbers></alligator>"
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
@@ -4,15 +4,14 @@ use pact_matching::models::*;
 use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
-#[allow(unused_imports)]
-use rustc_serialize::json::Json;
+use serde_json;
 #[allow(unused_imports)]
 use expectest::prelude::*;
 
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
         {
         "match": true,
         "comment": "Empty headers match",
@@ -24,15 +23,15 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -42,7 +41,7 @@ fn empty_headers() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -57,15 +56,15 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -75,7 +74,7 @@ fn header_name_is_different_case() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -90,15 +89,15 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -108,7 +107,7 @@ fn header_value_is_different_case() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match with regex",
@@ -129,15 +128,15 @@ fn matches_with_regex() {
         }
       }
               
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -147,7 +146,7 @@ fn matches_with_regex() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -164,15 +163,15 @@ fn matches() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -182,7 +181,7 @@ fn matches() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -197,15 +196,15 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -215,7 +214,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -228,15 +227,15 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -246,7 +245,7 @@ fn unexpected_header_found() {
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -261,15 +260,15 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
@@ -11,7 +11,7 @@ use expectest::prelude::*;
 #[test]
 fn empty_headers() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
         {
         "match": true,
         "comment": "Empty headers match",
@@ -23,7 +23,7 @@ fn empty_headers() {
           "headers": {}
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -41,7 +41,7 @@ fn empty_headers() {
 #[test]
 fn header_name_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Header name is case insensitive",
@@ -56,7 +56,7 @@ fn header_name_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -74,7 +74,7 @@ fn header_name_is_different_case() {
 #[test]
 fn header_value_is_different_case() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Headers values are case sensitive",
@@ -89,7 +89,7 @@ fn header_value_is_different_case() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -107,7 +107,7 @@ fn header_value_is_different_case() {
 #[test]
 fn matches_with_regex() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match with regex",
@@ -128,7 +128,7 @@ fn matches_with_regex() {
         }
       }
               
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -146,7 +146,7 @@ fn matches_with_regex() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Headers match",
@@ -163,7 +163,7 @@ fn matches() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -181,7 +181,7 @@ fn matches() {
 #[test]
 fn order_of_comma_separated_header_values_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Comma separated headers out of order, order can matter http://tools.ietf.org/html/rfc2616",
@@ -196,7 +196,7 @@ fn order_of_comma_separated_header_values_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -214,7 +214,7 @@ fn order_of_comma_separated_header_values_different() {
 #[test]
 fn unexpected_header_found() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Extra headers allowed",
@@ -227,7 +227,7 @@ fn unexpected_header_found() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -245,7 +245,7 @@ fn unexpected_header_found() {
 #[test]
 fn whitespace_after_comma_different() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": true,
         "comment": "Whitespace between comma separated headers does not matter",
@@ -260,7 +260,7 @@ fn whitespace_after_comma_different() {
           }
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/headers/mod.rs
@@ -4,9 +4,9 @@ use pact_matching::models::*;
 use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
-use serde_json;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn empty_headers() {

--- a/rust/pact_matching/tests/spec_testcases/v2/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/mod.rs
@@ -5,8 +5,6 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
 mod body;
 mod headers;

--- a/rust/pact_matching/tests/spec_testcases/v2/response/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/mod.rs
@@ -6,6 +6,7 @@ use env_logger;
 use pact_matching::match_response;
 #[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 mod body;
 mod headers;
 mod status;

--- a/rust/pact_matching/tests/spec_testcases/v2/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/status/mod.rs
@@ -5,14 +5,13 @@ use env_logger;
 #[allow(unused_imports)]
 use pact_matching::match_response;
 #[allow(unused_imports)]
-use rustc_serialize::json::Json;
-#[allow(unused_imports)]
 use expectest::prelude::*;
+use serde_json;
 
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
         "match": false,
         "comment": "Status is incorrect",
@@ -23,15 +22,15 @@ fn different_status() {
           "status": 400
         }
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());
@@ -41,7 +40,7 @@ fn different_status() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = Json::from_str(r#"
+    let pact = json!(r#"
       {
       	"match": true,
       	"comment": "Status matches",
@@ -52,15 +51,15 @@ fn matches() {
       		"status" : 202
       	}
       }
-    "#).unwrap();
+    "#);
 
-    let expected = Response::from_json(&pact.find("expected").unwrap(), &PactSpecification::V2);
+    let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
-    let actual = Response::from_json(&pact.find("actual").unwrap(), &PactSpecification::V2);
+    let actual = Response::from_json(&pact.get("actual").unwrap(), &PactSpecification::V2);
     println!("{:?}", actual);
-    let pact_match = pact.find("match").unwrap();
+    let pact_match = pact.get("match").unwrap();
     let result = match_response(expected, actual);
-    if pact_match.as_boolean().unwrap() {
+    if pact_match.as_bool().unwrap() {
        expect!(result).to(be_empty());
     } else {
        expect!(result).to_not(be_empty());

--- a/rust/pact_matching/tests/spec_testcases/v2/response/status/mod.rs
+++ b/rust/pact_matching/tests/spec_testcases/v2/response/status/mod.rs
@@ -11,7 +11,7 @@ use serde_json;
 #[test]
 fn different_status() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
         "match": false,
         "comment": "Status is incorrect",
@@ -22,7 +22,7 @@ fn different_status() {
           "status": 400
         }
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);
@@ -40,7 +40,7 @@ fn different_status() {
 #[test]
 fn matches() {
     env_logger::init().unwrap_or(());
-    let pact = json!(r#"
+    let pact : serde_json::Value = serde_json::from_str(r#"
       {
       	"match": true,
       	"comment": "Status matches",
@@ -51,7 +51,7 @@ fn matches() {
       		"status" : 202
       	}
       }
-    "#);
+    "#).unwrap();
 
     let expected = Response::from_json(&pact.get("expected").unwrap(), &PactSpecification::V2);
     println!("{:?}", expected);

--- a/rust/pact_matching/tests/tests.rs
+++ b/rust/pact_matching/tests/tests.rs
@@ -1,15 +1,14 @@
 #[macro_use] extern crate pact_matching;
-extern crate rustc_serialize;
 #[macro_use(expect)] extern crate expectest;
 #[macro_use] extern crate p_macro;
 extern crate env_logger;
+#[macro_use] extern crate serde_json;
 
 mod spec_testcases;
 
 use pact_matching::models::*;
 use std::path::Path;
 use expectest::prelude::*;
-use rustc_serialize::json::Json;
 use std::fs::File;
 
 #[test]
@@ -20,14 +19,14 @@ fn test_load_pact() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification")).to(be_none());
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -44,14 +43,14 @@ fn test_load_test_pact() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -68,33 +67,33 @@ fn test_load_pact_encoded_query() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
 
-            let pact_interactions = pact_json.find("interactions").unwrap().as_array().unwrap();
-            let pact_interactions_from_file = pact_json_from_file.find("interactions").unwrap().as_array().unwrap();
+            let pact_interactions = pact_json.get("interactions").unwrap().as_array().unwrap();
+            let pact_interactions_from_file = pact_json_from_file.get("interactions").unwrap().as_array().unwrap();
             expect(pact_interactions.len()).to(be_equal_to(pact_interactions_from_file.len()));
 
             for (pact_interaction, file_interaction) in pact_interactions.iter().zip(pact_interactions_from_file.iter()) {
-                expect(pact_interaction.find("providerState")).to(be_equal_to(file_interaction.find("providerState")));
-                expect(pact_interaction.find("description")).to(be_equal_to(file_interaction.find("description")));
-                expect(pact_interaction.find("response")).to(be_equal_to(file_interaction.find("response")));
+                expect(pact_interaction.get("providerState")).to(be_equal_to(file_interaction.get("providerState")));
+                expect(pact_interaction.get("description")).to(be_equal_to(file_interaction.get("description")));
+                expect(pact_interaction.get("response")).to(be_equal_to(file_interaction.get("response")));
 
-                let pact_request = pact_interaction.find("request").unwrap();
-                let file_request = file_interaction.find("request").unwrap();
-                expect(pact_request.find("method")).to(be_equal_to(file_request.find("method")));
-                expect(pact_request.find("path")).to(be_equal_to(file_request.find("path")));
-                expect(pact_request.find("headers")).to(be_equal_to(file_request.find("headers")));
-                expect(pact_request.find("body")).to(be_equal_to(file_request.find("body")));
-                expect(pact_request.find("matchers")).to(be_equal_to(file_request.find("matchers")));
-                expect(pact_request.find("query").unwrap().to_string().to_uppercase()).to(
-                    be_equal_to(file_request.find("query").unwrap().to_string().to_uppercase()));
+                let pact_request = pact_interaction.get("request").unwrap();
+                let file_request = file_interaction.get("request").unwrap();
+                expect(pact_request.get("method")).to(be_equal_to(file_request.get("method")));
+                expect(pact_request.get("path")).to(be_equal_to(file_request.get("path")));
+                expect(pact_request.get("headers")).to(be_equal_to(file_request.get("headers")));
+                expect(pact_request.get("body")).to(be_equal_to(file_request.get("body")));
+                expect(pact_request.get("matchers")).to(be_equal_to(file_request.get("matchers")));
+                expect(pact_request.get("query").unwrap().to_string().to_uppercase()).to(
+                    be_equal_to(file_request.get("query").unwrap().to_string().to_uppercase()));
             }
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -111,33 +110,33 @@ fn test_load_test_pact_lowercase_method() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
 
-            let pact_interactions = pact_json.find("interactions").unwrap().as_array().unwrap();
-            let pact_interactions_from_file = pact_json_from_file.find("interactions").unwrap().as_array().unwrap();
+            let pact_interactions = pact_json.get("interactions").unwrap().as_array().unwrap();
+            let pact_interactions_from_file = pact_json_from_file.get("interactions").unwrap().as_array().unwrap();
             expect(pact_interactions.len()).to(be_equal_to(pact_interactions_from_file.len()));
 
             for (pact_interaction, file_interaction) in pact_interactions.iter().zip(pact_interactions_from_file.iter()) {
-                expect(pact_interaction.find("providerState")).to(be_equal_to(file_interaction.find("providerState")));
-                expect(pact_interaction.find("description")).to(be_equal_to(file_interaction.find("description")));
-                expect(pact_interaction.find("response")).to(be_equal_to(file_interaction.find("response")));
+                expect(pact_interaction.get("providerState")).to(be_equal_to(file_interaction.get("providerState")));
+                expect(pact_interaction.get("description")).to(be_equal_to(file_interaction.get("description")));
+                expect(pact_interaction.get("response")).to(be_equal_to(file_interaction.get("response")));
 
-                let pact_request = pact_interaction.find("request").unwrap();
-                let file_request = file_interaction.find("request").unwrap();
-                expect(pact_request.find("method").unwrap().to_string()).to(be_equal_to(file_request.find("method").unwrap().to_string().to_uppercase()));
-                expect(pact_request.find("path")).to(be_equal_to(file_request.find("path")));
-                expect(pact_request.find("headers")).to(be_equal_to(file_request.find("headers")));
-                expect(pact_request.find("body")).to(be_equal_to(file_request.find("body")));
-                expect(pact_request.find("matchers")).to(be_equal_to(file_request.find("matchers")));
+                let pact_request = pact_interaction.get("request").unwrap();
+                let file_request = file_interaction.get("request").unwrap();
+                expect(pact_request.get("method").unwrap().to_string()).to(be_equal_to(file_request.get("method").unwrap().to_string().to_uppercase()));
+                expect(pact_request.get("path")).to(be_equal_to(file_request.get("path")));
+                expect(pact_request.get("headers")).to(be_equal_to(file_request.get("headers")));
+                expect(pact_request.get("body")).to(be_equal_to(file_request.get("body")));
+                expect(pact_request.get("matchers")).to(be_equal_to(file_request.get("matchers")));
                 // This is a V3 pact, so we can't load the query string
-                expect(pact_request.find("query")).to(be_none());
+                expect(pact_request.get("query")).to(be_none());
             }
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("3.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -154,11 +153,11 @@ fn test_load_test_pact_no_bodies() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             for pact_interaction in pact.interactions.clone() {
                 expect(pact_interaction.request.body).to(be_equal_to(OptionalBody::Missing));
@@ -166,7 +165,7 @@ fn test_load_test_pact_no_bodies() {
             }
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -183,14 +182,14 @@ fn test_load_test_pact_no_metadata() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification")).to(be_none());
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -207,14 +206,14 @@ fn test_load_test_pact_no_spec_version() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification")).to(be_none());
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -231,14 +230,14 @@ fn test_load_test_pact_no_version() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("null"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -256,14 +255,14 @@ fn test_load_test_pact_query_old_format() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -280,14 +279,14 @@ fn test_load_test_pact_with_bodies() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -304,14 +303,14 @@ fn test_load_v2_pact() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -328,33 +327,33 @@ fn test_load_v2_pact_query() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
 
-            let pact_interactions = pact_json.find("interactions").unwrap().as_array().unwrap();
-            let pact_interactions_from_file = pact_json_from_file.find("interactions").unwrap().as_array().unwrap();
+            let pact_interactions = pact_json.get("interactions").unwrap().as_array().unwrap();
+            let pact_interactions_from_file = pact_json_from_file.get("interactions").unwrap().as_array().unwrap();
             expect(pact_interactions.len()).to(be_equal_to(pact_interactions_from_file.len()));
 
             for (pact_interaction, file_interaction) in pact_interactions.iter().zip(pact_interactions_from_file.iter()) {
-                expect(pact_interaction.find("providerState")).to(be_equal_to(file_interaction.find("providerState")));
-                expect(pact_interaction.find("description")).to(be_equal_to(file_interaction.find("description")));
-                expect(pact_interaction.find("response")).to(be_equal_to(file_interaction.find("response")));
+                expect(pact_interaction.get("providerState")).to(be_equal_to(file_interaction.get("providerState")));
+                expect(pact_interaction.get("description")).to(be_equal_to(file_interaction.get("description")));
+                expect(pact_interaction.get("response")).to(be_equal_to(file_interaction.get("response")));
 
-                let pact_request = pact_interaction.find("request").unwrap();
-                let file_request = file_interaction.find("request").unwrap();
-                expect(pact_request.find("method")).to(be_equal_to(file_request.find("method")));
-                expect(pact_request.find("path")).to(be_equal_to(file_request.find("path")));
-                expect(pact_request.find("headers")).to(be_equal_to(file_request.find("headers")));
-                expect(pact_request.find("body")).to(be_equal_to(file_request.find("body")));
-                expect(pact_request.find("matchers")).to(be_equal_to(file_request.find("matchers")));
-                expect(pact_request.find("query").unwrap().to_string().to_uppercase()).to(
-                    be_equal_to(file_request.find("query").unwrap().to_string().to_uppercase()));
+                let pact_request = pact_interaction.get("request").unwrap();
+                let file_request = file_interaction.get("request").unwrap();
+                expect(pact_request.get("method")).to(be_equal_to(file_request.get("method")));
+                expect(pact_request.get("path")).to(be_equal_to(file_request.get("path")));
+                expect(pact_request.get("headers")).to(be_equal_to(file_request.get("headers")));
+                expect(pact_request.get("body")).to(be_equal_to(file_request.get("body")));
+                expect(pact_request.get("matchers")).to(be_equal_to(file_request.get("matchers")));
+                expect(pact_request.get("query").unwrap().to_string().to_uppercase()).to(
+                    be_equal_to(file_request.get("query").unwrap().to_string().to_uppercase()));
             }
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -371,14 +370,14 @@ fn test_load_test_pact_matcherst() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
-            expect(pact_json.find("interactions")).to(be_equal_to(pact_json_from_file.find("interactions")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
+            expect(pact_json.get("interactions")).to(be_equal_to(pact_json_from_file.get("interactions")));
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));
@@ -395,39 +394,39 @@ fn test_load_test_pact_matchers_old_format() {
     match pact_result {
         Ok(ref pact) => {
             let mut f = File::open(pact_file).unwrap();
-            let pact_json_from_file = Json::from_reader(&mut f).unwrap();
+            let pact_json_from_file : serde_json::Value = serde_json::de::from_reader(&mut f).unwrap();
             let pact_json = pact.to_json();
-            expect(pact_json.find("consumer")).to(be_equal_to(pact_json_from_file.find("consumer")));
-            expect(pact_json.find("provider")).to(be_equal_to(pact_json_from_file.find("provider")));
+            expect(pact_json.get("consumer")).to(be_equal_to(pact_json_from_file.get("consumer")));
+            expect(pact_json.get("provider")).to(be_equal_to(pact_json_from_file.get("provider")));
 
-            let pact_interactions = pact_json.find("interactions").unwrap().as_array().unwrap();
-            let pact_interactions_from_file = pact_json_from_file.find("interactions").unwrap().as_array().unwrap();
+            let pact_interactions = pact_json.get("interactions").unwrap().as_array().unwrap();
+            let pact_interactions_from_file = pact_json_from_file.get("interactions").unwrap().as_array().unwrap();
             expect(pact_interactions.len()).to(be_equal_to(pact_interactions_from_file.len()));
 
             for (pact_interaction, file_interaction) in pact_interactions.iter().zip(pact_interactions_from_file.iter()) {
-                expect(pact_interaction.find("providerState")).to(be_equal_to(file_interaction.find("providerState")));
-                expect(pact_interaction.find("description")).to(be_equal_to(file_interaction.find("description")));
+                expect(pact_interaction.get("providerState")).to(be_equal_to(file_interaction.get("providerState")));
+                expect(pact_interaction.get("description")).to(be_equal_to(file_interaction.get("description")));
 
-                let pact_request = pact_interaction.find("request").unwrap();
-                let file_request = file_interaction.find("request").unwrap();
-                expect(pact_request.find("method")).to(be_equal_to(file_request.find("method")));
-                expect(pact_request.find("path")).to(be_equal_to(file_request.find("path")));
-                expect(pact_request.find("headers")).to(be_equal_to(file_request.find("headers")));
-                expect(pact_request.find("body")).to(be_equal_to(file_request.find("body")));
-                expect(pact_request.find("matchers")).to(be_equal_to(file_request.find("matchers")));
-                expect(pact_request.find("query").unwrap().to_string().to_uppercase()).to(
-                    be_equal_to(file_request.find("query").unwrap().to_string().to_uppercase()));
+                let pact_request = pact_interaction.get("request").unwrap();
+                let file_request = file_interaction.get("request").unwrap();
+                expect(pact_request.get("method")).to(be_equal_to(file_request.get("method")));
+                expect(pact_request.get("path")).to(be_equal_to(file_request.get("path")));
+                expect(pact_request.get("headers")).to(be_equal_to(file_request.get("headers")));
+                expect(pact_request.get("body")).to(be_equal_to(file_request.get("body")));
+                expect(pact_request.get("matchers")).to(be_equal_to(file_request.get("matchers")));
+                expect(pact_request.get("query").unwrap().to_string().to_uppercase()).to(
+                    be_equal_to(file_request.get("query").unwrap().to_string().to_uppercase()));
 
-                let pact_response = pact_interaction.find("response").unwrap();
-                let file_response = file_interaction.find("response").unwrap();
-                expect(pact_response.find("status")).to(be_equal_to(file_response.find("status")));
-                expect(pact_response.find("headers")).to(be_equal_to(file_response.find("headers")));
-                expect(pact_response.find("body")).to(be_equal_to(file_response.find("body")));
-                expect(pact_response.find("matchers")).to(be_equal_to(file_response.find("matchers")));
+                let pact_response = pact_interaction.get("response").unwrap();
+                let file_response = file_interaction.get("response").unwrap();
+                expect(pact_response.get("status")).to(be_equal_to(file_response.get("status")));
+                expect(pact_response.get("headers")).to(be_equal_to(file_response.get("headers")));
+                expect(pact_response.get("body")).to(be_equal_to(file_response.get("body")));
+                expect(pact_response.get("matchers")).to(be_equal_to(file_response.get("matchers")));
             }
 
             expect(pact.metadata.get("pact-specification").unwrap().get("version")).to(be_some().value("2.0.0"));
-            let metadata = pact_json.find("metadata").unwrap().as_object().unwrap();
+            let metadata = pact_json.get("metadata").unwrap().as_object().unwrap();
             let expected_keys : Vec<String> = vec![s!("pact-jvm"), s!("pact-rust"), s!("pact-specification")];
             expect(metadata.keys().cloned().collect::<Vec<String>>()).to(be_equal_to(expected_keys));
             expect(metadata.get("pact-specification").unwrap().to_string()).to(be_equal_to(s!("{\"version\":\"2.0.0\"}")));


### PR DESCRIPTION
Migration of rustc_serialize to serde for json (de)serialisation in pact.

Removal of rustc_serialize has been completed for `pact-matching` but has not been completed yet for the other pact modules.