### PR TITLE
fix json body matcher so root value strings and key value pairs are both valid

### DIFF
--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -337,6 +337,13 @@ fn headers_to_json(headers: &HashMap<String, String>) -> Value {
     }))
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JsonParsable {
+    JsonStringValue(String),
+    KeyValue(HashMap<String, Value>)
+}
+
 fn body_from_json(request: &Value, fieldname: &str, headers: &Option<HashMap<String, String>>) -> OptionalBody {
     let content_type = match headers {
         &Some(ref h) => match h.iter().find(|kv| kv.0.to_lowercase() == s!("content-type")) {
@@ -359,7 +366,7 @@ fn body_from_json(request: &Value, fieldname: &str, headers: &Option<HashMap<Str
                 } else {
                   let content_type = content_type.unwrap_or(s!("text/plain"));
                   if JSON_CONTENT_TYPE.is_match(&content_type) {
-                    match serde_json::from_str::<HashMap<String, Value>>(&s) {
+                    match serde_json::from_str::<JsonParsable>(&s) {
                       Ok(_) => OptionalBody::Present(s.clone().into()),
                       Err(_) => OptionalBody::Present(format!("\"{}\"", s).into())
                     }

--- a/rust/pact_matching/src/models/tests.rs
+++ b/rust/pact_matching/src/models/tests.rs
@@ -1365,6 +1365,36 @@ fn body_from_json_returns_the_body_if_the_body_is_a_string() {
 }
 
 #[test]
+fn body_from_text_plain_type_returns_the_same_formatted_body() {
+    let json : serde_json::Value = serde_json::from_str(r#"
+      {
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "text/plain"},
+          "body": "\"This is a string\""
+      }
+     "#).unwrap();
+    let headers = headers_from_json(&json);
+    let body = body_from_json(&json, "body", &headers);
+    expect!(body).to(be_equal_to(OptionalBody::Present("\"This is a string\"".into())));
+}
+
+#[test]
+fn body_from_text_html_type_returns_the_same_formatted_body() {
+    let json : serde_json::Value = serde_json::from_str(r#"
+      {
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "text/html"},
+          "body": "\"This is a string\""
+      }
+     "#).unwrap();
+    let headers = headers_from_json(&json);
+    let body = body_from_json(&json, "body", &headers);
+    expect!(body).to(be_equal_to(OptionalBody::Present("\"This is a string\"".into())));
+}
+
+#[test]
 fn body_from_json_returns_the_a_json_formatted_body_if_the_body_is_a_string_and_the_content_type_is_json() {
     let json : serde_json::Value = serde_json::from_str(r#"
       {
@@ -1372,6 +1402,21 @@ fn body_from_json_returns_the_a_json_formatted_body_if_the_body_is_a_string_and_
           "query": "",
           "headers": {"Content-Type": "application/json"},
           "body": "This is actually a JSON string"
+      }
+     "#).unwrap();
+    let headers = headers_from_json(&json);
+    let body = body_from_json(&json, "body", &headers);
+    expect!(body).to(be_equal_to(OptionalBody::Present("\"This is actually a JSON string\"".into())));
+}
+
+#[test]
+fn body_from_json_returns_the_a_json_formatted_body_if_the_body_is_a_valid_json_string_and_the_content_type_is_json() {
+    let json : serde_json::Value = serde_json::from_str(r#"
+      {
+          "path": "/",
+          "query": "",
+          "headers": {"Content-Type": "application/json"},
+          "body": "\"This is actually a JSON string\""
       }
      "#).unwrap();
     let headers = headers_from_json(&json);

--- a/rust/pact_matching/tests/test_pact_root_string_json.json
+++ b/rust/pact_matching/tests/test_pact_root_string_json.json
@@ -1,0 +1,25 @@
+{
+  "provider": {
+    "name": "Alice Service"
+  },
+  "consumer": {
+    "name": "Consumer"
+  },
+  "interactions": [
+    {
+      "description": "a retrieve Mallory request",
+      "request": {
+        "method": "GET",
+        "path": "/mallory",
+        "query": "name=ron&status=good"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "\"That is some good Mallory.\""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When using JSON root value strings, the pact_matching library adds extra quotes to the string even if it already has them. 

Previous behaviour:
"example1" -> "\\\"example1\\\""
"\\\"example2\\\"" -> "\\\"\\\"example2\\"\\\""

This fix has just allowed both Strings and key-value HashMaps to pass as valid JSON.