### PR TITLE
Fix pack_mock_server C api and usage

### DIFF
--- a/javascript/lib/simple_pact.js
+++ b/javascript/lib/simple_pact.js
@@ -6,7 +6,7 @@ const url = require('url');
 
 var dll = '../../rust/target/debug/libpact_mock_server_ffi';
 var lib = ffi.Library(path.join(__dirname, dll), {
-  create_mock_server: ['int32', ['string', 'int32']],
+  create_mock_server: ['int32', ['string', 'string']],
   mock_server_matched: ['bool', ['int32']],
   cleanup_mock_server: ['bool', ['int32']]
 });
@@ -45,8 +45,8 @@ var pact = "{\n" +
   "}\n" +
 "}\n";
 
-var port = lib.create_mock_server(pact, 0);
-console.log("Mock server port=" + port);
+var port = lib.create_mock_server(pact, '127.0.0.1:0');
+console.log('Mock server port=' + port);
 
 var options = {
   hostname: 'localhost',

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -75,7 +75,7 @@ use pact_mock_server::server_manager::ServerManager;
 /// | -5 | The address is not valid |
 ///
 #[no_mangle]
-pub extern fn create_mock_server_ffi(pact_str: *const c_char, addr_str: *const c_char) -> i32 {
+pub extern fn create_mock_server(pact_str: *const c_char, addr_str: *const c_char) -> i32 {
     env_logger::init();
 
     let result = catch_unwind(|| {


### PR DESCRIPTION
This PR remove the "_ffi" suffix from `create_mock_server` that seems to be readd.
This PR also fix broken usage (javascript and c examples).