### PR TITLE
Make pact_verifier_cli actually runnable by using tokio::main

### DIFF
--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -24,7 +24,7 @@ maplit = "0.1.3"
 lazy_static = "0.1.15"
 rand = "0.3"
 regex = "0.1"
-tokio = { version = "0.2.9", features = ["rt-core"] }
+tokio = { version = "0.2.9", features = ["rt-core", "macros"] }
 
 [dev-dependencies]
 quickcheck = "0.2"

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -209,8 +209,9 @@ use std::error::Error;
 use regex::Regex;
 use pact_matching::models::http_utils::HttpAuth;
 
-fn main() {
-    match handle_command_args() {
+#[tokio::main]
+async fn main() {
+    match handle_command_args().await {
         Ok(_) => (),
         Err(err) => std::process::exit(err)
     }
@@ -291,7 +292,7 @@ fn interaction_filter(matches: &ArgMatches) -> FilterInfo {
     }
 }
 
-fn handle_command_args() -> Result<(), i32> {
+async fn handle_command_args() -> Result<(), i32> {
     let args: Vec<String> = env::args().collect();
     let program = args[0].clone();
 
@@ -481,20 +482,13 @@ fn handle_command_args() -> Result<(), i32> {
                 build_url: matches.value_of("build-url").map(|v| v.to_string())
             };
 
-            let mut runtime = tokio::runtime::Builder::new()
-                .basic_scheduler()
-                .build()
-                .unwrap();
-
-            if runtime.block_on(
-                verify_provider(
-                    &provider,
-                    source,
-                    &filter,
-                    &matches.values_of_lossy("filter-consumer").unwrap_or(vec![]),
-                    &options,
-                )
-            ) {
+            if verify_provider(
+                &provider,
+                source,
+                &filter,
+                &matches.values_of_lossy("filter-consumer").unwrap_or(vec![]),
+                &options,
+            ).await {
                 Ok(())
             } else {
                 Err(2)


### PR DESCRIPTION
I [commented](https://github.com/pact-foundation/pact-reference/pull/55#issuecomment-575983245) on the `pact_verifier_cli` problem you found. You're right, I had not actually tested running that executable. Here's what I believe is the fix. I have no deep explanation of how the fix works, it's just the first thing I thought of, and it seems to work.