### PR TITLE
Fix RequestFilterExecutor w/ verify_provider

### DIFF
--- a/rust/pact_verifier/src/callback_executors.rs
+++ b/rust/pact_verifier/src/callback_executors.rs
@@ -4,6 +4,7 @@ use pact_matching::models::Request;
 
 /// Trait for executors that call request filters
 pub trait RequestFilterExecutor {
+  /// Filters requests based on some criteria.
   fn call(&self, request: &Request) -> Request;
 }
 
@@ -17,7 +18,7 @@ pub struct NullRequestFilterExecutor {
 }
 
 impl RequestFilterExecutor for NullRequestFilterExecutor {
-  fn call(&self, request: &Request) -> Request {
+  fn call(&self, _request: &Request) -> Request {
     unimplemented!("NullRequestFilterExecutor should never be called")
   }
 }

--- a/rust/pact_verifier/src/callback_executors.rs
+++ b/rust/pact_verifier/src/callback_executors.rs
@@ -9,7 +9,12 @@ pub trait RequestFilterExecutor {
 
 /// A "null" request filter executor, which does nothing, but permits
 /// bypassing of typechecking issues where no filter should be applied.
-pub struct NullRequestFilterExecutor;
+pub struct NullRequestFilterExecutor {
+  // This field is added (and is private) to guarantee that this struct
+  // is never instantiated accidentally, and is instead only able to be
+  // used for type-level programming.
+  _private_field: (),
+}
 
 impl RequestFilterExecutor for NullRequestFilterExecutor {
   fn call(&self, request: &Request) -> Request {

--- a/rust/pact_verifier/src/callback_executors.rs
+++ b/rust/pact_verifier/src/callback_executors.rs
@@ -6,3 +6,13 @@ use pact_matching::models::Request;
 pub trait RequestFilterExecutor {
   fn call(&self, request: &Request) -> Request;
 }
+
+/// A "null" request filter executor, which does nothing, but permits
+/// bypassing of typechecking issues where no filter should be applied.
+pub struct NullRequestFilterExecutor;
+
+impl RequestFilterExecutor for NullRequestFilterExecutor {
+  fn call(&self, request: &Request) -> Request {
+    unimplemented!("NullRequestFilterExecutor should never be called")
+  }
+}

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -25,6 +25,7 @@ use crate::pact_broker::{publish_verification_results, TestResult, Link};
 use maplit::*;
 use futures::stream::*;
 use callback_executors::RequestFilterExecutor;
+pub use callback_executors::NullRequestFilterExecutor;
 
 /// Source for loading pacts
 #[derive(Debug, Clone)]

--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -200,7 +200,8 @@ fn publish_result_does_nothing_if_not_from_broker() {
       let options = super::VerificationOptions {
         publish: true,
         provider_version: None,
-        build_url: None
+        build_url: None,
+        request_filter: None::<Box<super::NullRequestFilterExecutor>>,
       };
       super::publish_result(&vec![], &PactSource::File("/tmp/test".into()), &options).await;
     })
@@ -227,7 +228,8 @@ async fn publish_successful_result_to_broker() {
   let options = super::VerificationOptions {
     publish: true,
     provider_version: Some("1".into()),
-    build_url: None
+    build_url: None,
+    request_filter: None::<Box<super::NullRequestFilterExecutor>>,
   };
   let links = vec![
     Link {

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -480,7 +480,7 @@ async fn handle_command_args() -> Result<(), i32> {
                 publish: matches.is_present("publish"),
                 provider_version: matches.value_of("provider-version").map(|v| v.to_string()),
                 build_url: matches.value_of("build-url").map(|v| v.to_string()),
-                request_filter: None
+                request_filter: None::<Box<NullRequestFilterExecutor>>
             };
 
             if verify_provider(


### PR DESCRIPTION
This fixes a compilation failure in `pact_verifier_cli` due to a typechecking issue with a `None` variant of an `Option<F> where F: RequestFilterExecutor` by introducing a `NullRequestFilterExecutor` and annotating the `None` variant to have the type `Option<Box<NullRequestFilterExecutor>>`. This allows the crate to compile as expected, and does not change behavior.

Note that if `NullRequestFilterExecutor` is ever attempted to be called (unlike the current usage, where it is solely used as a type annotation) it will panic the current thread.

## Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.