### PR TITLE
Fix v3 Message Provider States

### DIFF
--- a/rust/pact_matching/src/models/matchingrules.rs
+++ b/rust/pact_matching/src/models/matchingrules.rs
@@ -416,6 +416,7 @@ impl Hash for Category {
 
 /// Data structure for representing a collection of matchers
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
+#[serde(transparent)]
 pub struct MatchingRules {
     /// Categories of matching rules
     pub rules: HashMap<String, Category>

--- a/rust/pact_matching/src/models/message.rs
+++ b/rust/pact_matching/src/models/message.rs
@@ -13,7 +13,7 @@ pub struct Message {
     /// Description of this message interaction. This needs to be unique in the pact file.
     pub description: String,
     /// Optional provider state for the interaction.
-    /// See http://docs.pact.io/documentation/provider_states.html for more info on provider states.
+    /// See https://docs.pact.io/getting_started/provider_states for more info on provider states.
     pub provider_state: Option<String>,
     /// The contents of the message
     pub contents: OptionalBody,

--- a/rust/pact_matching/src/models/message.rs
+++ b/rust/pact_matching/src/models/message.rs
@@ -94,7 +94,10 @@ mod tests {
         }"#;
         let message = Message::from_json(0, &serde_json::from_str(message_json).unwrap(), &PactSpecification::V3).unwrap();
         expect!(message.description).to(be_equal_to("String"));
-        expect!(message.provider_state).to(be_some().value("provider state"));
+        expect!(message.provider_states).to(be_equal_to(vec![ProviderState {
+            name: s!("provider state"),
+            params: hashmap!(),
+        }]));
         expect!(message.matching_rules.rules.iter()).to(be_empty());
     }
 
@@ -112,7 +115,7 @@ mod tests {
         let message_json = r#"{
         }"#;
         let message = Message::from_json(0, &serde_json::from_str(message_json).unwrap(), &PactSpecification::V3).unwrap();
-        expect!(message.provider_state).to(be_none());
+        expect!(message.provider_states.iter()).to(be_empty());
         expect!(message.matching_rules.rules.iter()).to(be_empty());
     }
 
@@ -122,7 +125,7 @@ mod tests {
             "providerState": null
         }"#;
         let message = Message::from_json(0, &serde_json::from_str(message_json).unwrap(), &PactSpecification::V3).unwrap();
-        expect!(message.provider_state).to(be_none());
+        expect!(message.provider_states.iter()).to(be_empty());
     }
 
     #[test]

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -836,7 +836,7 @@ pub struct Interaction {
     /// Description of this interaction. This needs to be unique in the pact file.
     pub description: String,
     /// Optional provider states for the interaction.
-    /// See http://docs.pact.io/documentation/provider_states.html for more info on provider states.
+    /// See https://docs.pact.io/getting_started/provider_states for more info on provider states.
     pub provider_states: Vec<provider_states::ProviderState>,
     /// Request of the interaction
     pub request: Request,

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -134,6 +134,7 @@ impl Provider {
 /// Enum that defines the four main states that a body of a request and response can be in a pact
 /// file.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
 pub enum OptionalBody {
     /// A body is missing if it is not present in the pact file
     Missing,

--- a/rust/pact_matching/src/models/provider_states.rs
+++ b/rust/pact_matching/src/models/provider_states.rs
@@ -1,5 +1,5 @@
 //! `provider_states` module contains all the logic for dealing with provider states.
-//! See http://docs.pact.io/documentation/provider_states.html for more info on provider states.
+//! See https://docs.pact.io/getting_started/provider_states for more info on provider states.
 
 use std::collections::HashMap;
 use serde::{Serialize, Deserialize};


### PR DESCRIPTION
The v3 spec moves from `providerState` to `providerStates`, but the `Message` implementation in the Rust reference uses the old version. This fixes that, fixes broken documentation links, updates tests to the corrected API, and attempts to at least partially correct the broken auto-derived `Serialize` and `Deserialize` impls (see commit description on that commit for more info).

## Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.