### PR TITLE
Avoid deprecated Error::description in favor of Display trait

### DIFF
--- a/rust/pact_verifier/src/provider_client.rs
+++ b/rust/pact_verifier/src/provider_client.rs
@@ -3,7 +3,6 @@ use pact_matching::models::*;
 use pact_matching::models::matchingrules::*;
 use pact_matching::models::generators::*;
 use pact_matching::s;
-use std::error::Error;
 use std::collections::hash_map::HashMap;
 use std::convert::TryFrom;
 use futures::future::*;
@@ -183,7 +182,7 @@ pub async fn make_state_change_request(
     },
     Err(err) => {
       debug!("State change request failed with error {}", err);
-      Err(ProviderClientError::ResponseError(err.description().into()))
+      Err(ProviderClientError::ResponseError(format!("{}", err)))
     }
   }
 }

--- a/rust/pact_verifier/src/provider_client.rs
+++ b/rust/pact_verifier/src/provider_client.rs
@@ -182,7 +182,7 @@ pub async fn make_state_change_request(
     },
     Err(err) => {
       debug!("State change request failed with error {}", err);
-      Err(ProviderClientError::ResponseError(format!("{}", err)))
+      Err(ProviderClientError::ResponseError(err.to_string()))
     }
   }
 }

--- a/rust/pact_verifier_cli/src/args.rs
+++ b/rust/pact_verifier_cli/src/args.rs
@@ -1,6 +1,5 @@
 use clap::{App, AppSettings, Arg};
 use regex::Regex;
-use std::error::Error;
 
 fn integer_value(v: String) -> Result<(), String> {
   v.parse::<u16>().map(|_| ()).map_err(|e| format!("'{}' is not a valid port value: {}", v, e) )
@@ -98,7 +97,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .use_delimiter(false)
       .validator(|val| Regex::new(&val)
         .map(|_| ())
-        .map_err(|err| format!("'{}' is an invalid filter value: {}", val, err.description())))
+        .map_err(|err| format!("'{}' is an invalid filter value: {}", val, err)))
       .help("Only validate interactions whose descriptions match this filter"))
     .arg(Arg::with_name("filter-state")
       .long("filter-state")
@@ -107,7 +106,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .conflicts_with("filter-no-state")
       .validator(|val| Regex::new(&val)
         .map(|_| ())
-        .map_err(|err| format!("'{}' is an invalid filter value: {}", val, err.description())))
+        .map_err(|err| format!("'{}' is an invalid filter value: {}", val, err)))
       .help("Only validate interactions whose provider states match this filter"))
     .arg(Arg::with_name("filter-no-state")
       .long("filter-no-state")


### PR DESCRIPTION
`Error::description` is deprecated as of Rust 1.42:
https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#error:description-is-deprecated

## Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.