### PR TITLE
Teach Travis CI to cache Cargo dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_script:
   - rustup component add clippy
 script:
   - cd rust && make -B
+cache: cargo


### PR DESCRIPTION
Currently, Travis CI is slowed down by needing to re-process dependencies every time it runs. Per the [Travis documentation](https://docs.travis-ci.com/user/languages/rust/#dependency-management), adding `cache: cargo` to the `.travis.yml` file will reuse dependencies and should speed up CI runs.

# Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.