### PR TITLE
fix: write_pact_file  always serialising a v3 pacts

### DIFF
--- a/rust/pact_mock_server/src/mock_server.rs
+++ b/rust/pact_mock_server/src/mock_server.rs
@@ -168,7 +168,7 @@ impl MockServer {
         // this concurrently?
         let _file_lock = PACT_FILE_MUTEX.lock().unwrap();
 
-        match self.pact.write_pact(filename.as_path(), PactSpecification::V3) {
+        match self.pact.write_pact(filename.as_path(), self.pact.spec_version()) {
             Ok(_) => Ok(()),
             Err(err) => {
                 log::warn!("Failed to write pact to file - {}", err);


### PR DESCRIPTION
Writes the pact with the current Pact version, instead of hard coding to V3.