### PR TITLE
Set content-type header in message request to provider

### DIFF
--- a/rust/pact_verifier/src/messages.rs
+++ b/rust/pact_verifier/src/messages.rs
@@ -30,6 +30,9 @@ pub async fn verify_message_from_provider<F: RequestFilterExecutor>(
   let message_request = Request {
     method: "POST".into(),
     body: OptionalBody::Present(request_body.to_string().as_bytes().to_vec(), Some("application/json".into())),
+    headers: Some(hashmap! {
+        "Content-Type".to_string() => vec!["application/json".to_string()]
+    }),
     .. Request::default()
   };
   match make_provider_request(provider, &message_request, options, client).await {


### PR DESCRIPTION
This is a minor change that sets the `Content-Type` http header to `application-json` when sending POST requests to the provider to run the verification process against its messages.

The lack of that header caused some (albeit minor) annoyances in one of our projects, as the library we used to expose the verification endpoint would not automatically parse the body of the request when the header is missing.

I found no tests relevant to this behavior, therefore I only tested this change manually. Please let me know if I missed anything.

Also, I haven't found any guidelines for contributing, so in case I did anything wrong please let me know :)
Thanks!
