### PR TITLE
feat: return version of the mock server via FFI

### DIFF
--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -74,20 +74,12 @@ use crate::handles::InteractionPart;
 pub mod handles;
 pub mod bodies;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
 
 /// Get the current library version
-///
-/// **NOTE:** The string for the result is allocated on the heap, and will have to be freed
-/// by the caller using free_string
-///
-/// # Errors
-///
-/// An empty string indicates an error determining the current crate version
 #[no_mangle]
-pub extern fn version() -> *mut c_char {
-  let s = CString::new(VERSION).unwrap_or_default();
-  s.into_raw()
+pub extern "C" fn version() -> *const c_char {
+  VERSION.as_ptr() as *const c_char
 }
 
 /// Initialise the mock server library, can provide an environment variable name to use to

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -74,6 +74,22 @@ use crate::handles::InteractionPart;
 pub mod handles;
 pub mod bodies;
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+/// Get the current library version
+///
+/// **NOTE:** The string for the result is allocated on the heap, and will have to be freed
+/// by the caller using free_string
+///
+/// # Errors
+///
+/// An empty string indicates an error determining the current crate version
+#[no_mangle]
+pub extern fn version() -> *mut c_char {
+  let s = CString::new(VERSION).unwrap_or_default();
+  s.into_raw()
+}
+
 /// Initialise the mock server library, can provide an environment variable name to use to
 /// set the log levels.
 ///


### PR DESCRIPTION
Adds a `*char version()` c interface to the mock server FFI, for use with detecting compatible client versions.

NOTE: I originally added it as a `*const  c_char` but it then required freeing via the usual c call. I think this consistency is nicer.