### PR TITLE
fix: request headers generated unexpected differences 

### DIFF
--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -807,8 +807,8 @@ impl Request {
         if self.query != other.query {
             differences.push((DifferenceType::QueryParameters, format!("Request query {:?} != {:?}", self.query, other.query)));
         }
-        let keys = self.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default();
-        let other_keys = other.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default();
+        let keys = self.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default().sort();
+        let other_keys = other.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default().sort();
         if keys != other_keys {
             differences.push((DifferenceType::Headers, format!("Request headers {:?} != {:?}", self.headers, other.headers)));
         }

--- a/rust/pact_matching/src/models/mod.rs
+++ b/rust/pact_matching/src/models/mod.rs
@@ -807,8 +807,10 @@ impl Request {
         if self.query != other.query {
             differences.push((DifferenceType::QueryParameters, format!("Request query {:?} != {:?}", self.query, other.query)));
         }
-        let keys = self.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default().sort();
-        let other_keys = other.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default().sort();
+        let mut keys = self.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default();
+        let mut other_keys = other.headers.clone().map(|m| m.keys().cloned().collect_vec()).unwrap_or_default();
+        keys.sort();
+        other_keys.sort();
         if keys != other_keys {
             differences.push((DifferenceType::Headers, format!("Request headers {:?} != {:?}", self.headers, other.headers)));
         }

--- a/rust/pact_matching/src/models/tests.rs
+++ b/rust/pact_matching/src/models/tests.rs
@@ -1423,6 +1423,35 @@ fn interactions_conflict_if_they_have_different_responses() {
     expect!(interaction1.conflicts_with(&interaction2).iter()).to_not(be_empty());
 }
 
+#[test]
+fn request_headers_do_not_conflict_if_they_have_been_serialised_and_deserialised_to_json() {
+    // headers are serialised in a hashmap; serializing and deserializing can can change the
+    // internal order of the keys in the hashmap, and this can confuse the differences_from code.
+    let original_request = Request {
+        method: "".to_string(),
+        path: "".to_string(),
+        query: None,
+        headers: Some(hashmap! {
+          "accept".to_string() => vec!["application/xml".to_string(), "application/json".to_string()],
+          "user-agent".to_string() => vec!["test".to_string(), "test2".to_string()],
+          "content-type".to_string() => vec!["text/plain".to_string()]
+        }),
+        body: OptionalBody::Missing,
+        matching_rules: Default::default(),
+        generators: Default::default(),
+    };
+
+    let json = serde_json::to_string(&original_request).expect("could not serialize");
+
+    let serialized_and_deserialized_request =
+        serde_json::from_str(&json).expect("could not deserialize");
+
+    expect!(original_request
+        .differences_from(&serialized_and_deserialized_request)
+        .iter())
+        .to(be_empty());
+}
+
 fn hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
     t.hash(&mut s);


### PR DESCRIPTION
Request headers are serialised in a hashmap; serializing and deserializing rust hashmaps can change the internal order of keys in the hashmap. 

This can confuse the Request::differences_from code, which sees out-of-order keys as different. 

Sorting the keys before comparison fixes the problem.