### PR TITLE
chore: upgrade maplit, itertools

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -657,15 +657,6 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
@@ -749,12 +740,6 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
-
-[[package]]
-name = "maplit"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
 
 [[package]]
 name = "maplit"
@@ -1086,11 +1071,11 @@ dependencies = [
  "env_logger",
  "expectest",
  "futures",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libc",
  "log",
- "maplit 0.1.6",
+ "maplit",
  "pact_matching",
  "pact_mock_server",
  "quickcheck",
@@ -1118,11 +1103,11 @@ dependencies = [
  "hex",
  "http",
  "indextree",
- "itertools 0.10.0",
+ "itertools",
  "lazy_static",
  "lenient_semver",
  "log",
- "maplit 1.0.2",
+ "maplit",
  "mime",
  "multipart",
  "nom 5.1.2",
@@ -1155,10 +1140,10 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-rustls",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "log",
- "maplit 0.1.6",
+ "maplit",
  "pact_matching",
  "quickcheck",
  "reqwest",
@@ -1179,11 +1164,11 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libc",
  "log",
- "maplit 0.1.6",
+ "maplit",
  "pact_matching",
  "pact_mock_server",
  "quickcheck",
@@ -1207,11 +1192,11 @@ dependencies = [
  "chrono-tz",
  "env_logger",
  "expectest",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libc",
  "log",
- "maplit 1.0.2",
+ "maplit",
  "multipart",
  "onig",
  "pact_matching",
@@ -1236,11 +1221,11 @@ dependencies = [
  "expectest",
  "futures",
  "http",
- "itertools 0.10.0",
+ "itertools",
  "lazy_static",
  "libc",
  "log",
- "maplit 1.0.2",
+ "maplit",
  "mime",
  "pact_consumer",
  "pact_matching",
@@ -1273,7 +1258,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "maplit 1.0.2",
+ "maplit",
  "pact_matching",
  "pact_verifier",
  "quickcheck",
@@ -2416,10 +2401,10 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "itertools 0.10.0",
+ "itertools",
  "lazy_static",
  "log",
- "maplit 1.0.2",
+ "maplit",
  "serde",
  "serde_json",
 ]

--- a/rust/pact_consumer/Cargo.toml
+++ b/rust/pact_consumer/Cargo.toml
@@ -19,11 +19,11 @@ libc = "0.2.9"
 pact_matching = { version = "0.8.6", path = "../pact_matching" }
 pact_mock_server = { version = "0.7.12", path = "../pact_mock_server" }
 log = "0.4.0"
-maplit = "0.1.3"
+maplit = "1.0.2"
 lazy_static = "1.4.0"
 regex = "1"
 serde_json = "1.0"
-itertools = "0.9.0"
+itertools = "0.10.0"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
 futures = "0.3"

--- a/rust/pact_mock_server/Cargo.toml
+++ b/rust/pact_mock_server/Cargo.toml
@@ -18,10 +18,10 @@ exclude = [
 serde_json = "1.0"
 pact_matching = { version =  "0.8.0", path = "../pact_matching" }
 log = "0.4.8"
-maplit = "0.1.4"
+maplit = "1.0.2"
 lazy_static = "1.4.0"
 uuid = { version = "0.8", features = ["v4"] }
-itertools = "0.9.0"
+itertools = "0.10.0"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/rust/pact_mock_server_cli/Cargo.toml
+++ b/rust/pact_mock_server_cli/Cargo.toml
@@ -22,7 +22,7 @@ pact_mock_server = { version = "0.7.12", path = "../pact_mock_server" }
 simplelog = "0.9"
 log = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-maplit = "0.1.3"
+maplit = "1.0.2"
 rand = "0.8"
 webmachine-rust = "0.2.2"
 regex = "1"
@@ -33,7 +33,7 @@ http = "0.2"
 futures = "0.3.0"
 tokio = { version = "1", features = ["full"] }
 hyper = "0.14.0"
-itertools = "0.9.0"
+itertools = "0.10.0"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/rust/pact_mock_server_ffi/Cargo.toml
+++ b/rust/pact_mock_server_ffi/Cargo.toml
@@ -29,7 +29,7 @@ rand_regex = "0.15.0"
 regex-syntax = "0.6.4"
 onig = { version = "6.1.0", default-features = false }
 rand = "0.8"
-itertools = "0.9.0"
+itertools = "0.10.0"
 multipart = { version = "0.17", default-features = false, features = ["client", "mock"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Found some more outdated crate versions. No hurry to make a new release.