### PR TITLE
fix: move state params to "params" key in provider state change executor

### DIFF
--- a/rust/pact_verifier/src/callback_executors.rs
+++ b/rust/pact_verifier/src/callback_executors.rs
@@ -85,20 +85,15 @@ impl ProviderStateExecutor for HttpRequestProviderStateExecutor {
       Some(state_change_url) => {
         let mut state_change_request = Request { method: "POST".to_string(), .. Request::default() };
         if self.state_change_body {
-          let mut json_body = json!({
-                    "state".to_string() : json!(provider_state.name.clone()),
-                    "action".to_string() : json!(if setup {
+          let json_body = json!({
+                    "state".to_string() : provider_state.name.clone(),
+                    "params".to_string() : provider_state.params.clone(),
+                    "action".to_string() : if setup {
                         "setup".to_string()
                     } else {
                         "teardown".to_string()
-                    })
+                    }
                 });
-          {
-            let json_body_mut = json_body.as_object_mut().unwrap();
-            for (k, v) in provider_state.params.clone() {
-              json_body_mut.insert(k, v);
-            }
-          }
           state_change_request.body = OptionalBody::Present(json_body.to_string().into(), Some(JSON.clone()));
           state_change_request.headers = Some(hashmap!{ "Content-Type".to_string() => vec!["application/json".to_string()] });
         } else {

--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -130,7 +130,7 @@ async fn test_state_change_with_parameters() {
       i.request.method("POST");
       i.request.path("/");
       i.request.header("Content-Type", "application/json");
-      i.request.body("{\"A\":\"1\",\"B\":\"2\",\"action\":\"setup\",\"state\":\"TestState\"}");
+      i.request.body("{\"params\":{\"A\":\"1\",\"B\":\"2\"},\"action\":\"setup\",\"state\":\"TestState\"}");
       i.response.status(200);
     })
     .start_mock_server();
@@ -198,7 +198,7 @@ async fn test_state_change_returning_json_values() {
       i.request.method("POST");
       i.request.path("/");
       i.request.header("Content-Type", "application/json");
-      i.request.body("{\"action\":\"setup\",\"state\":\"TestState\"}");
+      i.request.body("{\"action\":\"setup\",\"state\":\"TestState\",\"params\":{}}");
       i.response.status(200);
       i.response.header("Content-Type", "application/json");
       i.response.body("{\"a\": \"A\", \"b\": 100}");


### PR DESCRIPTION
Given this state from the `providerStates` key in the pact:

i.e. I was expecting something to mirror this:
```
{
  "name": "User foo exists",
  "params": {
    "some": "param"
  }
}

```

The current state change process for FFI / CLI sends the following message to the pact client to instruct it to prepare a state:

```
{ "action": "teardown", "some": "param", "state": "User foo exists" }
```

I encountered two issues with this:

1. Note the parameters aren't self-contained for simple extraction to pass to a user provided function. Not having a clear top-level structure made the JSON marshaller a bit confused, so extra work was required to separate the "framework" part from the "user supplied data"
2. If a user wants to use the keys `state` or `action` we'll have a conflict

I'm proposing that we move the body into a top level `params` key, that frameworks can then parse.

I'm thinking it probably makes sense to have both whilst, but not sure of the adoption here and if it will break other users.

P.S. unrelated, but the related "value from provider states" stuff (just return JSON from the state handler) was a piece of magic and so easy to support👌 