### PR TITLE
refactor: Use Anyhow instead of `io::Result`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,6 +28,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1113,7 @@ name = "pact_matching"
 version = "0.8.14"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "base64",
  "bytes",
  "chrono",
@@ -1150,6 +1157,7 @@ dependencies = [
 name = "pact_mock_server"
 version = "0.7.17"
 dependencies = [
+ "anyhow",
  "bytes",
  "env_logger",
  "expectest",
@@ -1233,6 +1241,7 @@ name = "pact_verifier"
 version = "0.10.5"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "async-trait",
  "bytes",
  "difference",

--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 build = "build.rs"
 
 [dependencies]
+anyhow = "1.0.40"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 hex = "0.4.2"

--- a/rust/pact_matching/src/models/message_pact.rs
+++ b/rust/pact_matching/src/models/message_pact.rs
@@ -1,14 +1,14 @@
 //! The `message_pact` module defines a Pact
 //! that contains Messages instead of Interactions.
 
-use std::{fs, io};
+use std::fs;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{Error, ErrorKind};
 use std::io::prelude::*;
 use std::path::Path;
 
+use anyhow::anyhow;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 use log::*;
@@ -230,11 +230,11 @@ impl MessagePact {
 }
 
 impl ReadWritePact for MessagePact {
-  fn read_pact(path: &Path) -> io::Result<MessagePact> {
+  fn read_pact(path: &Path) -> anyhow::Result<MessagePact> {
     with_read_lock(path, 3, &mut |f| {
       let pact_json: Value = serde_json::from_reader(f)?;
       MessagePact::from_json(&format!("{:?}", path), &pact_json)
-        .map_err(|err| Error::new(ErrorKind::Other, err.clone()))
+        .map_err(|e| anyhow!(e))
     })
   }
 

--- a/rust/pact_matching/src/models/v4/mod.rs
+++ b/rust/pact_matching/src/models/v4/mod.rs
@@ -1,16 +1,16 @@
 //! V4 specification models
 
-use std::{fmt, io};
+use std::fmt;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Display, Debug};
 use std::hash::{Hash, Hasher};
-use std::io::{Error, ErrorKind};
 use std::path::Path;
 use std::string::ToString;
 use std::sync::{Arc, Mutex};
 
+use anyhow::Context as _;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 use log::*;
@@ -660,11 +660,10 @@ impl Default for V4Pact {
 }
 
 impl ReadWritePact for V4Pact {
-  fn read_pact(path: &Path) -> io::Result<V4Pact> {
+  fn read_pact(path: &Path) -> anyhow::Result<V4Pact> {
     let json = with_read_lock(path, 3, &mut |f| {
       serde_json::from_reader::<_, Value>(f)
-        .map_err(|err|
-          Error::new(ErrorKind::Other, format!("Failed to parse Pact JSON - {}", err)))
+        .context("Failed to parse Pact JSON")
     })?;
     let metadata = meta_data_from_json(&json);
     let consumer = match json.get("consumer") {

--- a/rust/pact_mock_server/Cargo.toml
+++ b/rust/pact_mock_server/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
 ]
 
 [dependencies]
+anyhow = "1.0.40"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 pact_matching = { version =  "0.8.0", path = "../pact_matching" }

--- a/rust/pact_mock_server/src/mock_server.rs
+++ b/rust/pact_mock_server/src/mock_server.rs
@@ -4,7 +4,6 @@
 //!
 
 use std::ffi::CString;
-use std::io;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -232,7 +231,7 @@ impl MockServer {
     }
 
   /// Mock server writes its pact out to the provided directory
-  pub fn write_pact(&self, output_path: &Option<String>, overwrite: bool) -> io::Result<()> {
+  pub fn write_pact(&self, output_path: &Option<String>, overwrite: bool) -> anyhow::Result<()> {
     let pact_file_name = self.pact.default_file_name();
     let filename = match *output_path {
       Some(ref path) => {

--- a/rust/pact_verifier/Cargo.toml
+++ b/rust/pact_verifier/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
 ]
 
 [dependencies]
+anyhow = "1.0.40"
 libc = "0.2.76"
 serde = "1.0"
 serde_json = "1.0"

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::fmt;
 use std::fs;
-use std::io;
 use std::path::Path;
 
 use ansi_term::*;
@@ -358,7 +357,7 @@ fn display_result(
   println!("      has a matching body ({})", body_result);
 }
 
-fn walkdir(dir: &Path) -> io::Result<Vec<io::Result<Box<dyn Pact>>>> {
+fn walkdir(dir: &Path) -> anyhow::Result<Vec<anyhow::Result<Box<dyn Pact>>>> {
     let mut pacts = vec![];
     log::debug!("Scanning {:?}", dir);
     for entry in fs::read_dir(dir)? {


### PR DESCRIPTION
- Add a dependency on the `anyhow` library.
- Replace `io::Result` with `anyhow::Result` in functions that can return multiple types of error.
- Refactor `load_pact_from_url` and `load_pact_from_json` to use `?` operator instead of pattern matching.

## Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2021 The MITRE Corporation. All Rights Reserved.