### PR TITLE
Feat/more consumer ffi matchers

### DIFF
--- a/rust/pact_matching/src/models/matchingrules.rs
+++ b/rust/pact_matching/src/models/matchingrules.rs
@@ -214,8 +214,6 @@ impl <T: Display> DisplayForMismatch for &[T] {
 /// Set of all matching rules
 #[derive(Serialize, Deserialize, Debug, Clone, Eq)]
 pub enum MatchingRule {
-  /// Dummy rule to allow all values passed in via the FFI to be JSON integration values, even primitives
-  Dummy,
   /// Matcher using equals
   Equality,
   /// Match using a regular expression
@@ -267,7 +265,6 @@ impl MatchingRule {
               Some(s) => Some(MatchingRule::Regex(json_to_string(s))),
               None => None
             },
-            "dummy" => Some(MatchingRule::Dummy),
             "equality" => Some(MatchingRule::Equality),
             "include" => match m.get("value") {
               Some(s) => Some(MatchingRule::Include(json_to_string(s))),
@@ -369,7 +366,6 @@ impl MatchingRule {
   /// Converts this `MatchingRule` to a `Value` struct
   pub fn to_json(&self) -> Value {
     match self {
-      MatchingRule::Dummy => json!({}),
       MatchingRule::Equality => json!({ "match": "equality" }),
       MatchingRule::Regex(ref r) => json!({ "match": "regex",
         "regex": r.clone() }),

--- a/rust/pact_matching/src/models/matchingrules.rs
+++ b/rust/pact_matching/src/models/matchingrules.rs
@@ -1668,7 +1668,7 @@ mod tests {
         expect!(matchers.to_v2_json().to_string()).to(be_equal_to(
           "{\"$.body.a.b\":{\"match\":\"type\"},\
           \"$.header.item1\":{\"match\":\"regex\",\"regex\":\"5\"},\
-          \"$.path.\":{\"match\":\"regex\",\"regex\":\"/path/\\\\d+\"},\
+          \"$.path\":{\"match\":\"regex\",\"regex\":\"/path/\\\\d+\"},\
           \"$.query.a\":{\"match\":\"regex\",\"regex\":\"\\\\w+\"}}"
         ));
       }

--- a/rust/pact_matching/src/models/matchingrules.rs
+++ b/rust/pact_matching/src/models/matchingrules.rs
@@ -1023,6 +1023,10 @@ impl MatchingRuleCategory {
       for (k, v) in self.rules.clone() {
         map.insert(k.replace("$", "$.body"), v.to_v2_json());
       }
+    } else if self.name == "path" {
+      for (_, v) in self.rules.clone() {
+        map.insert("$.path".to_string(), v.to_v2_json());
+      }
     } else {
       for (k, v) in self.rules.clone() {
         map.insert(format!("$.{}.{}", self.name, k), v.to_v2_json());

--- a/rust/pact_matching/src/models/matchingrules.rs
+++ b/rust/pact_matching/src/models/matchingrules.rs
@@ -214,6 +214,8 @@ impl <T: Display> DisplayForMismatch for &[T] {
 /// Set of all matching rules
 #[derive(Serialize, Deserialize, Debug, Clone, Eq)]
 pub enum MatchingRule {
+  /// Dummy rule to allow all values passed in via the FFI to be JSON integration values, even primitives
+  Dummy,
   /// Matcher using equals
   Equality,
   /// Match using a regular expression
@@ -265,6 +267,7 @@ impl MatchingRule {
               Some(s) => Some(MatchingRule::Regex(json_to_string(s))),
               None => None
             },
+            "dummy" => Some(MatchingRule::Dummy),
             "equality" => Some(MatchingRule::Equality),
             "include" => match m.get("value") {
               Some(s) => Some(MatchingRule::Include(json_to_string(s))),
@@ -366,6 +369,7 @@ impl MatchingRule {
   /// Converts this `MatchingRule` to a `Value` struct
   pub fn to_json(&self) -> Value {
     match self {
+      MatchingRule::Dummy => json!({}),
       MatchingRule::Equality => json!({ "match": "equality" }),
       MatchingRule::Regex(ref r) => json!({ "match": "regex",
         "regex": r.clone() }),

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -547,7 +547,6 @@ pub extern fn with_query_parameter(interaction: handles::InteractionHandle,
     interaction.with_interaction(&|_, inner| {
       inner.request.query = inner.request.query.clone().map(|mut q| {
         let value = from_integration_json(&mut inner.request.matching_rules, &mut inner.request.generators, &value.to_string(), &format!("{}[{}]", &name, index).to_string(), "query");
-
         if q.contains_key(name) {
           let values = q.get_mut(name).unwrap();
           if index >= values.len() {

--- a/rust/pact_mock_server_ffi/tests/tests.rs
+++ b/rust/pact_mock_server_ffi/tests/tests.rs
@@ -14,9 +14,14 @@ use pact_mock_server_ffi::{
   mock_server_mismatches,
   new_interaction,
   new_pact,
+  upon_receiving,
+  with_request,
+  with_body,
   with_header,
   with_multipart_file,
-  with_query_parameter
+  with_query_parameter,
+  response_status,
+  create_mock_server_for_pact
 };
 use pact_models::bodies::OptionalBody;
 
@@ -127,4 +132,67 @@ fn create_multipart_file() {
 
     expect!(actual_req_body_str).to(be_equal_to(expected_req_body));
   });
+}
+
+#[test]
+fn request_with_matchers() {
+  let consumer_name = CString::new("consumer").unwrap();
+  let provider_name = CString::new("provider").unwrap();
+  let pact_handle = new_pact(consumer_name.as_ptr(), provider_name.as_ptr());
+  let description = CString::new("request_with_matchers").unwrap();
+  let interaction = new_interaction(pact_handle.clone(), description.as_ptr());
+  let special_header = CString::new("My-Special-Content-Type").unwrap();
+  let content_type = CString::new("Content-Type").unwrap();
+  let authorization = CString::new("Authorization").unwrap();
+  let path_matcher = CString::new("{\"value\":\"/request/1234\",\"pact:matcher:type\":\"regex\", \"regex\":\"\\/request\\/[0-9]+\"}").unwrap();
+  let value_header_with_matcher = CString::new("{\"value\":\"application/json\",\"pact:matcher:type\":\"dummy\"}").unwrap();
+  let auth_header_with_matcher = CString::new("{\"value\":\"Bearer 1234\",\"pact:matcher:type\":\"regex\", \"regex\":\"Bearer [0-9]+\"}").unwrap();
+  let query_param_matcher = CString::new("{\"value\":\"bar\",\"pact:matcher:type\":\"regex\", \"regex\":\"(bar|baz|bat)\"}").unwrap();
+  let request_body_with_matchers = CString::new("{\"id\": {\"value\":1,\"pact:matcher:type\":\"type\"}}").unwrap();
+  let response_body_with_matchers = CString::new("{\"created\": {\"value\":\"maybe\",\"pact:matcher:type\":\"regex\", \"regex\":\"(yes|no|maybe)\"}}").unwrap();
+  let address = CString::new("127.0.0.1:0").unwrap();
+
+  upon_receiving(interaction.clone(), CString::new("a request to test the FFI interface").unwrap().as_ptr());
+  with_request(interaction.clone(), CString::new("POST").unwrap().as_ptr(), path_matcher.as_ptr());
+  with_header(interaction.clone(), InteractionPart::Request, content_type.as_ptr(), 0, value_header_with_matcher.as_ptr());
+  with_header(interaction.clone(), InteractionPart::Request, authorization.as_ptr(), 0, auth_header_with_matcher.as_ptr());
+  with_query_parameter(interaction.clone(), CString::new("foo").unwrap().as_ptr(), 0, query_param_matcher.as_ptr());
+  with_body(interaction.clone(), InteractionPart::Request, CString::new("application/json").unwrap().as_ptr(), request_body_with_matchers.as_ptr());
+  // will respond with...
+  with_header(interaction.clone(), InteractionPart::Response, content_type.as_ptr(), 0, value_header_with_matcher.as_ptr());
+  with_header(interaction.clone(), InteractionPart::Response, special_header.as_ptr(), 0, value_header_with_matcher.as_ptr());
+  with_body(interaction.clone(), InteractionPart::Response, CString::new("application/json").unwrap().as_ptr(), response_body_with_matchers.as_ptr());
+  response_status(interaction.clone(), 200);
+  let port = create_mock_server_for_pact(pact_handle.clone(), address.as_ptr(), false);
+
+  expect!(port).to(be_greater_than(0));
+
+  let _ = catch_unwind(|| {
+    let client = Client::default();
+    let result = client.post(format!("http://127.0.0.1:{}/request/9999?foo=baz", port).as_str())
+      .header("Content-Type", "application/json")
+      .header("Authorization", "Bearer 9999")
+      .body(r#"{"id": 7}"#)
+      .send();
+
+    match result {
+      Ok(res) => {
+        expect!(res.status()).to(be_eq(200));
+        expect!(res.headers().get("My-Special-Content-Type").unwrap()).to(be_eq("application/json"));
+        let json: serde_json::Value = res.json().unwrap_or_default();
+        expect!(json.get("created").unwrap().to_string()).to(be_eq("maybe"));
+      },
+      Err(_) => {
+        panic!("expected 200 response but request failed");
+      }
+    };
+  });
+
+  let mismatches = unsafe {
+    CStr::from_ptr(mock_server_mismatches(port)).to_string_lossy().into_owned()
+  };
+
+  cleanup_mock_server(port);
+
+  expect!(mismatches).to(be_equal_to("[]"));
 }


### PR DESCRIPTION
Supports matchers to be passed in as JSON to the FFI for:

* Request Path, Query and Headers
* Response Headers
* Adds a basic feature test to show how the FFI matchers may be used

(bodies were already supported)