### PR TITLE
WIP: feat: allow ffi consumers to log using core

### DIFF
--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -130,15 +130,19 @@ pub unsafe extern fn log_level(level: *const c_char) {
 
 /// Log using the shared core logging facility, instead
 ///
+/// * `source` - String. The source of the log, such as the class or caller framework to
+///                      disambiguate log lines from the rust logging (e.g. pact_go)
 /// * `log_level` - String. One of TRACE, DEBUG, INFO, WARN, ERROR
 /// * `message` - Message to log
 ///
 /// Exported functions are inherently unsafe.
 #[no_mangle]
-pub unsafe extern fn log(log_level: *const c_char, message: *const c_char) {
+pub unsafe extern fn log(source: *const c_char, log_level: *const c_char, message: *const c_char) {
+  let target = convert_cstr("target", source).unwrap_or("client");
+
   if !message.is_null() {
     match convert_cstr("message", message) {
-      Some(message) => log!(log_level_from_c_char(log_level), "{}", message),
+      Some(message) => log!(target: target, log_level_from_c_char(log_level), "{}", message),
       None => ()
     }
   }


### PR DESCRIPTION
Interested in feedback here on this idea.

cc: @TimothyJones - let's see how our experiment goes with Pact JS to see how we should/could evolve it. Probably worth marking these methods as highly experimental _just in case_.

I've just added a namespace (target in the `log` package) to the log, to be able to differentiate the client logs from the core from the library. We might need to come up with patterns here, but let's see how this goes.

from https://docs.rs/log/0.4.14/log/:
> A log request consists of a target, a level, and a body. A target is a string which defaults to the module path of the location of the log request, though that default may be overridden. Logger implementations typically use the target to filter requests based on some user configuration.