### PR TITLE
proposal: all logging methods to pact_matching_ffi

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1125,6 +1125,7 @@ version = "0.0.5"
 dependencies = [
  "anyhow",
  "bytes",
+ "env_logger",
  "fern",
  "lazy_static",
  "libc",

--- a/rust/pact_matching_ffi/Cargo.toml
+++ b/rust/pact_matching_ffi/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.8"
 serde_json = "1.0.51"
 bytes = "1.0.1"
 lazy_static = "1.4.0"
+env_logger = "0.8.2"
 
 [lib]
 crate-type = ["rlib", "cdylib", "staticlib"]

--- a/rust/pact_matching_ffi/src/log/mod.rs
+++ b/rust/pact_matching_ffi/src/log/mod.rs
@@ -16,6 +16,9 @@ pub use crate::log::ffi::{
     log_to_stdout,
     log_to_stderr,
     log_to_file,
-    log_to_buffer
+    log_to_buffer,
+    init,
+    init_with_log_level,
+    log_message
 };
 pub(crate) use crate::log::target::TARGET;

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -93,7 +93,10 @@ pub use pact_matching_ffi::log::{
   log_to_stdout,
   log_to_stderr,
   log_to_file,
-  log_to_buffer
+  log_to_buffer,
+  init,
+  init_with_log_level,
+  log_message
 };
 
 pub mod handles;
@@ -105,32 +108,6 @@ const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
 #[no_mangle]
 pub extern "C" fn version() -> *const c_char {
   VERSION.as_ptr() as *const c_char
-}
-
-/// Initialise the mock server library, can provide an environment variable name to use to
-/// set the log levels.
-///
-/// # Safety
-///
-/// Exported functions are inherently unsafe.
-#[no_mangle]
-pub unsafe extern fn init(log_env_var: *const c_char) {
-  let log_env_var = if !log_env_var.is_null() {
-    let c_str = CStr::from_ptr(log_env_var);
-    match c_str.to_str() {
-      Ok(str) => str,
-      Err(err) => {
-        warn!("Failed to parse the environment variable name as a UTF-8 string: {}", err);
-        "LOG_LEVEL"
-      }
-    }
-  } else {
-    "LOG_LEVEL"
-  };
-
-  let env = env_logger::Env::new().filter(log_env_var);
-  let mut builder = Builder::from_env(env);
-  builder.try_init().unwrap_or(());
 }
 
 /// External interface to create a mock server. A pointer to the pact JSON as a C string is passed in,


### PR DESCRIPTION
I really just want to add a `log_message` function so that callers can utilise the rust logic, but in the course of doing that, it felt unusual that logging was split across packages.

Equally, it doesn't feel write to have these other initialisers in the matching package which seem to have a different flavour of initialisation altogether and I'm a little out of my depth there.

This is a quick PR to test the waters - is this something we should be thinking about?

I'm also wondering if it just makes sense to have a single FFI that contains all of the functions needed for a standard "pact" client?