### PR TITLE
Support verifying message metadata via verifier (CLI/FFI)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
  "async-trait",
+ "base64",
  "bytes",
  "difference",
  "env_logger",

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -354,6 +354,7 @@ use pact_models::content_types::ContentType;
 use pact_models::generators::{apply_generators, GenerateValue, GeneratorCategory, GeneratorTestMode, VariantMatcher};
 use pact_models::matchingrules::{calc_path_weight, Category, MatchingRule, MatchingRuleCategory, path_length, RuleList};
 use pact_models::PactSpecification;
+use pact_models::json_utils::json_to_string;
 
 use crate::headers::{match_header_value, match_headers};
 use crate::matchers::*;
@@ -1422,7 +1423,7 @@ pub fn match_message_metadata(
         },
         None => {
           result.insert(key.clone(), vec![Mismatch::MetadataMismatch { key: key.clone(),
-            expected: value.as_str().unwrap_or_default().to_string(),
+            expected: json_to_string(&value),
             actual: "".to_string(),
             mismatch: format!("Expected message metadata '{}' but was missing", key) }]);
         }

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -1403,13 +1403,13 @@ pub fn match_message_metadata(
     expected.contents.metadata
   } else {
     expected.as_message().unwrap().metadata.iter()
-      .map(|(k, v)| (k.clone(), Value::String(v.clone()))).collect()
+      .map(|(k, v)| (k.clone(), v.clone())).collect()
   };
   let actual_metadata = if let Some(actual) = actual.as_v4_async_message() {
     actual.contents.metadata.clone()
   } else {
     actual.as_message().unwrap().metadata.iter()
-      .map(|(k, v)| (k.clone(), Value::String(v.clone()))).collect()
+      .map(|(k, v)| (k.clone(), v.clone())).collect()
   };
   debug!("Matching message metadata. Expected '{:?}', Actual '{:?}'", expected_metadata, actual_metadata);
 

--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -1411,6 +1411,8 @@ pub fn match_message_metadata(
     actual.as_message().unwrap().metadata.iter()
       .map(|(k, v)| (k.clone(), Value::String(v.clone()))).collect()
   };
+  debug!("Matching message metadata. Expected '{:?}', Actual '{:?}'", expected_metadata, actual_metadata);
+
   if !expected_metadata.is_empty() || context.config == DiffConfig::NoUnexpectedKeys {
     for (key, value) in &expected_metadata {
       match actual_metadata.get(key) {

--- a/rust/pact_matching/src/models/message.rs
+++ b/rust/pact_matching/src/models/message.rs
@@ -183,14 +183,14 @@ impl Message {
                     None => format!("Message {}", index)
                 };
                 let provider_states = ProviderState::from_json(json);
-                let metadata = match json.get("metaData") {
-                    Some(&Value::Object(ref v)) => v.iter().map(|(k, v)| {
-                        (k.clone(), match v {
-                            &Value::String(ref s) => s.clone(),
-                            _ => v.to_string()
-                        })
-                    }).collect(),
-                    _ => hashmap!{}
+                let metadata = match json.get("metaData").or(json.get("metadata")) {
+                  Some(&Value::Object(ref v)) => v.iter().map(|(k, v)| {
+                      (k.clone(), match v {
+                          &Value::String(ref s) => s.clone(),
+                          _ => v.to_string()
+                      })
+                  }).collect(),
+                  _ => hashmap!{},
                 };
                 Ok(Message {
                   id: None,

--- a/rust/pact_matching/src/models/message.rs
+++ b/rust/pact_matching/src/models/message.rs
@@ -11,6 +11,7 @@ use maplit::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use pact_models::json_utils::json_to_string;
 use pact_models::{generators, PactSpecification};
 use pact_models::bodies::OptionalBody;
 use pact_models::content_types::ContentType;
@@ -266,7 +267,7 @@ impl Message {
         let key = k.to_ascii_lowercase();
         key == "contenttype" || key == "content-type"
       }) {
-        Some((_, v)) => ContentType::parse(v.as_str().unwrap_or_default()).ok(),
+        Some((_, v)) => ContentType::parse(json_to_string(&v).as_str()).ok(),
         None => self.detect_content_type()
       }
     }
@@ -298,7 +299,7 @@ impl HttpPart for Message {
     self.metadata.iter().find(|(k, _)| {
       let key = k.to_ascii_lowercase();
       key == "contenttype" || key == "content-type"
-    }).map(|(_, v)| v[0].as_str().unwrap_or_default().to_string())
+    }).map(|(_, v)| json_to_string(&v[0]))
   }
 }
 

--- a/rust/pact_matching/src/models/message_pact.rs
+++ b/rust/pact_matching/src/models/message_pact.rs
@@ -517,6 +517,6 @@ mod tests {
         expect!(pact.as_ref()).to(be_ok());
         let pact = pact.unwrap();
         let contents = pact.to_json(PactSpecification::V3);
-        expect!(contents.unwrap().to_string()).to(be_equal_to("{\"consumer\":{\"name\":\"Consumer\"},\"messages\":[{\"contents\":{\"hello\":\"world\"},\"description\":\"Message Description\",\"metadata\":{}}],\"metadata\":{\"pactRust\":{\"version\":\"".to_owned() + env!("CARGO_PKG_VERSION") + "\"},\"pactSpecification\":{\"version\":\"3.0.0\"}},\"provider\":{\"name\":\"Alice Service\"}}"));
+        expect!(contents.unwrap().to_string()).to(be_equal_to("{\"consumer\":{\"name\":\"Consumer\"},\"messages\":[{\"contents\":{\"hello\":\"world\"},\"description\":\"Message Description\",\"metadata\":{\"contentType\":\"application/json\"}}],\"metadata\":{\"pactRust\":{\"version\":\"".to_owned() + env!("CARGO_PKG_VERSION") + "\"},\"pactSpecification\":{\"version\":\"3.0.0\"}},\"provider\":{\"name\":\"Alice Service\"}}"));
     }
 }

--- a/rust/pact_matching/src/models/v4/mod.rs
+++ b/rust/pact_matching/src/models/v4/mod.rs
@@ -699,7 +699,7 @@ impl HttpPart for AsynchronousMessage {
     self.contents.metadata.iter().find(|(k, _)| {
       let key = k.to_ascii_lowercase();
       key == "contenttype" || key == "content-type"
-    }).map(|(_, v)| v.as_str().unwrap_or_default().to_string())
+    }).map(|(_, v)| json_to_string(v))
   }
 }
 

--- a/rust/pact_matching/src/models/v4/mod.rs
+++ b/rust/pact_matching/src/models/v4/mod.rs
@@ -554,7 +554,7 @@ impl Interaction for AsynchronousMessage {
       description: self.description.clone(),
       provider_states: self.provider_states.clone(),
       contents: self.contents.contents.clone(),
-      metadata: self.contents.metadata.iter().map(|(k, v)| (k.clone(), json_to_string(v))).collect(),
+      metadata: self.contents.metadata.clone(),
       matching_rules: self.contents.matching_rules.rename("content", "body"),
       generators: self.contents.generators.clone()
     })

--- a/rust/pact_matching_ffi/src/models/message.rs
+++ b/rust/pact_matching_ffi/src/models/message.rs
@@ -103,7 +103,7 @@ ffi_fn! {
 
         // Populate the Message metadata.
         let mut metadata = HashMap::new();
-        metadata.insert(String::from("contentType"), content_type.to_string());
+        metadata.insert(String::from("contentType"), JsonValue::String(content_type.to_string()));
 
         // Populate the OptionalBody with our content and content type.
         let contents = OptionalBody::Present(body.into(), Some(content_type));
@@ -358,7 +358,7 @@ ffi_fn! {
         let message = as_ref!(message);
         let key = safe_str!(key);
         let value = message.metadata.get(key).ok_or(anyhow::anyhow!("invalid metadata key"))?;
-        let value_ptr = string::to_c(value)?;
+        let value_ptr = string::to_c(value.as_str().unwrap_or_default())?;
         value_ptr as *const c_char
     } {
         ptr::null_to::<c_char>()
@@ -387,7 +387,7 @@ ffi_fn! {
         let key = safe_str!(key);
         let value = safe_str!(value);
 
-        match message.metadata.insert(key.to_string(), value.to_string()) {
+        match message.metadata.insert(key.to_string(), JsonValue::String(value.to_string())) {
             None => HashMapInsertStatus::SuccessNew as c_int,
             Some(_) => HashMapInsertStatus::SuccessOverwrite as c_int,
         }
@@ -446,7 +446,7 @@ ffi_fn! {
             .metadata
             .get_key_value(key)
             .ok_or(anyhow::anyhow!("iter provided invalid metadata key"))?;
-        let pair = MessageMetadataPair::new(key, value)?;
+        let pair = MessageMetadataPair::new(key, value.as_str().unwrap_or_default())?;
         ptr::raw_to(pair)
     } {
         ptr::null_mut_to::<MessageMetadataPair>()

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![warn(missing_docs)]
 
+use serde_json::Value;
 use std::{ptr, str};
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -1294,7 +1295,7 @@ pub extern fn message_with_contents(message: handles::MessageHandle, content_typ
 pub extern fn message_with_metadata(message: handles::MessageHandle, key: *const c_char, value: *const c_char) {
   if let Some(key) = convert_cstr("key", key) {
     let value = convert_cstr("value", value).unwrap_or_default();
-    message.with_message(&|_, inner| inner.metadata.insert(key.to_string(), value.to_string()));
+    message.with_message(&|_, inner| inner.metadata.insert(key.to_string(), Value::String(value.to_string())));
   }
 }
 

--- a/rust/pact_mock_server_ffi/src/lib.rs
+++ b/rust/pact_mock_server_ffi/src/lib.rs
@@ -90,6 +90,7 @@ use pact_models::matchingrules::{MatchingRule, MatchingRules, RuleLogic};
 use pact_models::PactSpecification;
 use pact_models::provider_states::ProviderState;
 use pact_models::time_utils::{parse_pattern, to_chrono_pattern};
+use pact_models::json_utils::json_to_string;
 
 use crate::bodies::{empty_multipart_body, file_as_multipart_body, MultipartBody, process_json, request_multipart, response_multipart};
 use crate::bodies::process_object;
@@ -662,7 +663,7 @@ fn from_integration_json(rules: &mut MatchingRules, generators: &mut Generators,
       serde_json::Value::Object(ref map) => {
         let json: serde_json::Value = process_object(map, category, generators, path, false, false);
         // These are simple JSON primitives (strings), so we must unescape them
-        json.as_str().unwrap_or_default().to_string()
+        json_to_string(&json)
       },
       _ => value.to_string()
     },

--- a/rust/pact_verifier/Cargo.toml
+++ b/rust/pact_verifier/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1", features = ["full"] }
 http = "0.2"
 async-trait = "0.1.24"
 thiserror = "1.0"
+base64 = "0.13.0"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/rust/pact_verifier/src/provider_client.rs
+++ b/rust/pact_verifier/src/provider_client.rs
@@ -176,6 +176,8 @@ pub async fn make_provider_request<F: RequestFilterExecutor>(
     .await
     .map_err(|err| ProviderClientError::ResponseError(err.to_string()))?;
 
+  debug!("response from call to provider = {:?}", response);
+
   Ok(response)
 }
 

--- a/rust/pact_verifier_cli/README.md
+++ b/rust/pact_verifier_cli/README.md
@@ -243,7 +243,7 @@ There were 8 pact failures
 
 ## Verifying message pacts
 
-Message pacts can be verified, the messages just need to be fetched from an HTTP endpoint. The veryfier will send a
+Message pacts can be verified, the messages just need to be fetched from an HTTP endpoint. The verifier will send a
 POST request to the configured provider and expect the message payload in the response. The POST request will include
 the description and any provider states configured in the Pact file for the message, formatted as JSON.
 
@@ -255,3 +255,24 @@ Example POST request:
     "providerStates":[ {"name": "message exists"} ]
 }
 ```
+
+### Verifying metadata
+
+Message metadata can be included as key/value pairs in the response, packed into the `PACT_MESSAGE_METADATA` HTTP header, and will be compared against any expected metadata in the pact file.
+
+The values may contain any valid JSON.
+
+For example, given this metadata:
+
+```json
+{
+  "Content-Type": "application/json",
+  "topic": "baz",
+  "number": 27,
+  "complex": {
+    "foo": "bar"
+  }
+}
+```
+
+we would encode it into a base64 string, giving us `ewogICJDb250ZW50LVR5cGUiOiAiYXBwbGljYXRpb24vanNvbiIsCiAgInRvcGljIjogImJheiIsCiAgIm51bWJlciI6IDI3LAogICJjb21wbGV4IjogewogICAgImZvbyI6ICJiYXIiCiAgfQp9Cg==`.

--- a/rust/pact_verifier_cli/README.md
+++ b/rust/pact_verifier_cli/README.md
@@ -258,7 +258,7 @@ Example POST request:
 
 ### Verifying metadata
 
-Message metadata can be included as key/value pairs in the response, packed into the `PACT_MESSAGE_METADATA` HTTP header, and will be compared against any expected metadata in the pact file.
+Message metadata can be included as base64 encoded key/value pairs in the response, packed into the `PACT_MESSAGE_METADATA` HTTP header, and will be compared against any expected metadata in the pact file.
 
 The values may contain any valid JSON.
 


### PR DESCRIPTION
There is currently no way to pass metadata back to the (HTTP based) verifier, for use by the command line or FFI interface.

This PR adds that.

1. I noticed the verifier doesn't read the `metadata` section (still uses `metaData` when reading a Pact) but generates a pact with `metadata`. It now reads both for compatibility
2. The incoming payload now supports a header (`PACT_MESSAGE_METADATA`) that accepts a base64 encoded JSON of key/value pairs. The values may be complex JSON objects, or simple primitives
3. The `metadata` property of the `Message` struct, now supports complex values to support this.