### PR TITLE
refactor: Introduce DocPath struct for path expressions

### DIFF
--- a/rust/pact_consumer/src/builders/request_builder.rs
+++ b/rust/pact_consumer/src/builders/request_builder.rs
@@ -13,6 +13,7 @@ use pact_models::bodies::OptionalBody;
 use pact_models::expression_parser::DataType;
 use pact_models::generators::{Generator, GeneratorCategory, Generators};
 use pact_models::matchingrules::{Category, MatchingRules};
+use pact_models::path_exp::DocPath;
 use pact_models::request::Request;
 
 use crate::prelude::*;
@@ -64,7 +65,7 @@ impl RequestBuilder {
         let path = path.into();
         self.request.path = path.to_example();
         path.extract_matching_rules(
-            "",
+            DocPath::empty(),
             self.request.matching_rules.add_category(Category::PATH),
         );
         self
@@ -117,9 +118,12 @@ impl RequestBuilder {
             .or_insert_with(Default::default)
             .push(value.to_example());
 
+        let mut path = DocPath::root();
+        path.push_field(key);
+
         // Extract our matching rules.
         value.extract_matching_rules(
-            &key,
+            path,
             self.request.matching_rules.add_category("query"),
         );
 

--- a/rust/pact_consumer/src/patterns/date_time.rs
+++ b/rust/pact_consumer/src/patterns/date_time.rs
@@ -3,6 +3,7 @@
 use std::marker::PhantomData;
 
 use pact_models::matchingrules::{MatchingRule, MatchingRuleCategory, RuleLogic};
+use pact_models::path_exp::DocPath;
 use pact_models::time_utils::parse_pattern;
 
 use crate::patterns::{JsonPattern, Pattern, StringPattern};
@@ -42,7 +43,7 @@ where
     From::from(self.example.clone())
   }
 
-  fn extract_matching_rules(&self, path: &str, rules_out: &mut MatchingRuleCategory) {
+  fn extract_matching_rules(&self, path: DocPath, rules_out: &mut MatchingRuleCategory) {
     rules_out.add_rule(path, MatchingRule::Timestamp(self.format.clone()), &RuleLogic::And);
   }
 }
@@ -56,7 +57,7 @@ fn datetime_is_pattern() {
   expect!(matchable.to_example()).to(be_equal_to("Wed, 4 Jul 2001 12:08:56 -0700"));
 
   let mut rules = MatchingRuleCategory::empty("body");
-  matchable.extract_matching_rules("$", &mut rules);
+  matchable.extract_matching_rules(DocPath::root(), &mut rules);
   let expected_rules = json!({
     "$": {
       "combine": "AND", "matchers": [

--- a/rust/pact_consumer/src/patterns/mod.rs
+++ b/rust/pact_consumer/src/patterns/mod.rs
@@ -2,6 +2,7 @@
 //! match them.
 
 use pact_models::matchingrules::MatchingRuleCategory;
+use pact_models::path_exp::DocPath;
 use std::fmt::Debug;
 
 #[macro_use]
@@ -53,5 +54,5 @@ pub trait Pattern: Debug {
     ///
     /// [ruby]:
     /// https://github.com/pact-foundation/pact-support/blob/master/lib/pact/matching_rules/extract.rb
-    fn extract_matching_rules(&self, path: &str, rules_out: &mut MatchingRuleCategory);
+    fn extract_matching_rules(&self, path: DocPath, rules_out: &mut MatchingRuleCategory);
 }

--- a/rust/pact_consumer/src/patterns/string_pattern.rs
+++ b/rust/pact_consumer/src/patterns/string_pattern.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use pact_models::matchingrules::MatchingRuleCategory;
+use pact_models::path_exp::DocPath;
 
 use super::Pattern;
 
@@ -35,7 +36,7 @@ impl Pattern for StringPattern {
         }
     }
 
-    fn extract_matching_rules(&self, path: &str, rules_out: &mut MatchingRuleCategory) {
+    fn extract_matching_rules(&self, path: DocPath, rules_out: &mut MatchingRuleCategory) {
         match *self {
             StringPattern::String(_) => {},
             StringPattern::Pattern(ref p) => {
@@ -67,7 +68,7 @@ fn string_pattern_is_pattern() {
         "$.query.val".to_string() => json!({ "match": "regex", "regex": "^[0-9]+$" })
     );
     let mut rules = MatchingRuleCategory::empty("query");
-    pattern.extract_matching_rules("val", &mut rules);
+    pattern.extract_matching_rules(DocPath::new_unwrap("val"), &mut rules);
     assert_eq!(rules.to_v2_json(), expected_rules);
 }
 

--- a/rust/pact_consumer/src/util.rs
+++ b/rust/pact_consumer/src/util.rs
@@ -2,9 +2,6 @@
 //! Most of these are `pub(crate)`, which makes them available to the rest of
 //! the crate, but prevents them from winding up in our public API.
 
-use regex::{Captures, Regex};
-use lazy_static::*;
-
 /// Internal helper method for `strip_null_fields`.
 fn strip_null_fields_mut(json: &mut serde_json::Value) {
     use serde_json::Value;
@@ -85,42 +82,4 @@ impl<T: Default> GetDefaulting<T> for Option<T> {
     fn get_defaulting(&mut self) -> &mut T {
         self.get_or_insert_with(Default::default)
     }
-}
-
-/// Format a JSON object key for use in a JSON path expression. If we were
-/// more concerned about performance, we might try to come up with a scheme
-/// to minimize string allocation here.
-pub(crate) fn obj_key_for_path(key: &str) -> String {
-    lazy_static! {
-        // Only use "." syntax for things which are obvious identifiers.
-        static ref IDENT: Regex = Regex::new(r#"^[_A-Za-z][_A-Za-z0-9]*$"#)
-            .expect("could not parse IDENT regex");
-        // Escape these characters when using string syntax.
-        static ref ESCAPE: Regex = Regex::new(r#"\\|'"#)
-            .expect("could not parse ESCAPE regex");
-    }
-
-    if IDENT.is_match(key) {
-        format!(".{}", key)
-    } else {
-        format!(
-            "['{}']",
-            ESCAPE.replace_all(key, |caps: &Captures| format!(r#"\{}"#, &caps[0]))
-        )
-    }
-}
-
-#[test]
-fn obj_key_for_path_quotes_keys_when_necessary() {
-    assert_eq!(obj_key_for_path("foo"), ".foo");
-    assert_eq!(obj_key_for_path("_foo"), "._foo");
-    assert_eq!(obj_key_for_path("["), "['[']");
-
-    // I don't actually know how the JSON Path specification wants us to handle
-    // these cases, but we need to _something_ to avoid panics or passing
-    // `Result` around everywhere, so let's go with JavaScript string escape
-    // syntax.
-    assert_eq!(obj_key_for_path(r#"''"#), r#"['\'\'']"#);
-    assert_eq!(obj_key_for_path(r#"a'"#), r#"['a\'']"#);
-    assert_eq!(obj_key_for_path(r#"\"#), r#"['\\']"#);
 }

--- a/rust/pact_models/src/http_parts.rs
+++ b/rust/pact_models/src/http_parts.rs
@@ -9,6 +9,7 @@ use crate::bodies::OptionalBody;
 use crate::content_types::{ContentType, detect_content_type_from_string};
 use crate::generators::{Generator, GeneratorCategory, Generators};
 use crate::matchingrules::{Category, MatchingRules};
+use crate::path_exp::DocPath;
 
 /// Trait to specify an HTTP part of an interaction. It encapsulates the shared parts of a request
 /// and response.
@@ -92,7 +93,7 @@ pub trait HttpPart {
   }
 
   /// Builds a map of generators from the generators and matching rules
-  fn build_generators(&self, category: &GeneratorCategory) -> HashMap<String, Generator> {
+  fn build_generators(&self, category: &GeneratorCategory) -> HashMap<DocPath, Generator> {
     let mut generators = hashmap!{};
     if let Some(generators_for_category) = self.generators().categories.get(category) {
       for (path, generator) in generators_for_category {


### PR DESCRIPTION
- DocPaths are eagerly parsed into tokens, instead of lazily at usage time.
- Headers and Query parameters are parsed into DocPaths, and the first Field token is extracted to recover the plain string.

- Many functions now take `DocPath` instead of `&str`.  This might be considered a breaking change.
- Errors when parsing DocPaths will now be fatal errors during the parsing of Pact JSON structures.  This might be considered a breaking change.

- Moved `fn obj_key_for_path` from the `pact_consumer` crate into `path_exp`.
- Deleted now-obsolete tests for generators handling invalid expressions.
- (Code Style) Split function signatures and invocations into multiple lines and added trailing commas, where changes were already being made.

### Notice

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2021 The MITRE Corporation. All Rights Reserved.