### PR TITLE
fix: FFI always detects + stores JSON bodies as plain text

### DIFF
--- a/rust/pact_ffi/src/mock_server/handles.rs
+++ b/rust/pact_ffi/src/mock_server/handles.rs
@@ -713,11 +713,12 @@ pub extern fn pactffi_with_body(
           }
           let body = if reqres.request.content_type().unwrap_or_default().is_json() {
             let category = reqres.request.matching_rules.add_category("body");
-            OptionalBody::from(process_json(body.to_string(), category, &mut reqres.request.generators))
+            OptionalBody::Present(Bytes::from(process_json(body.to_string(), category, &mut reqres.request.generators)),
+            Some("application/json".into()), None)
           } else if reqres.request.content_type().unwrap_or_default().is_xml() {
             let category = reqres.request.matching_rules.add_category("body");
             OptionalBody::Present(Bytes::from(process_xml(body.to_string(), category, &mut reqres.request.generators).unwrap_or(vec![])),
-                                  Some("application/xml".into()), None)
+            Some("application/xml".into()), None)
           } else {
             OptionalBody::from(body)
           };
@@ -736,11 +737,12 @@ pub extern fn pactffi_with_body(
           }
           let body = if reqres.response.content_type().unwrap_or_default().is_json() {
             let category = reqres.response.matching_rules.add_category("body");
-            OptionalBody::from(process_json(body.to_string(), category, &mut reqres.response.generators))
+            OptionalBody::Present(Bytes::from(process_json(body.to_string(), category, &mut reqres.response.generators)),
+            Some("application/json".into()), None)
           } else if reqres.response.content_type().unwrap_or_default().is_xml() {
             let category = reqres.request.matching_rules.add_category("body");
-            OptionalBody::Present(Bytes::from(process_xml(body.to_string(), category, &mut reqres.request.generators).unwrap_or(vec![])),
-                                  Some("application/xml".into()), None)
+            OptionalBody::Present(Bytes::from(process_xml(body.to_string(), category, &mut reqres.response.generators).unwrap_or(vec![])),
+            Some("application/xml".into()), None)
           } else {
             OptionalBody::from(body)
           };

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -1,5 +1,4 @@
 use std::ffi::{CStr, CString};
-use std::panic::catch_unwind;
 
 use bytes::Bytes;
 use expectest::prelude::*;
@@ -189,26 +188,26 @@ fn http_consumer_feature_test() {
   // Mock server has started, we can't now modify the pact
   expect!(pactffi_upon_receiving(interaction.clone(), description.as_ptr())).to(be_false());
 
-  let _ = catch_unwind(|| {
-    let client = Client::default();
-    let result = client.post(format!("http://127.0.0.1:{}/request/9999?foo=baz", port).as_str())
-      .header("Content-Type", "application/json")
-      .header("Authorization", "Bearer 9999")
-      .body(r#"{"id": 7}"#)
-      .send();
+  let client = Client::default();
+  let result = client.post(format!("http://127.0.0.1:{}/request/9999?foo=baz", port).as_str())
+    .header("Content-Type", "application/json")
+    .header("Authorization", "Bearer 9999")
+    .body(r#"{"id": 7}"#)
+    .send();
 
-    match result {
-      Ok(res) => {
-        expect!(res.status()).to(be_eq(200));
-        expect!(res.headers().get("My-Special-Content-Type").unwrap()).to(be_eq("application/json"));
-        let json: serde_json::Value = res.json().unwrap_or_default();
-        expect!(json.get("created").unwrap().as_str().unwrap()).to(be_eq("maybe"));
-      },
-      Err(_) => {
-        panic!("expected 200 response but request failed");
-      }
-    };
-  });
+  match result {
+    Ok(res) => {
+      dbg!("here");
+      expect!(res.status()).to(be_eq(200));
+      expect!(res.headers().get("My-Special-Content-Type").unwrap()).to(be_eq("application/json"));
+      let json: serde_json::Value = res.json().unwrap_or_default();
+      dbg!("about to check");
+      expect!(json.get("created").unwrap().as_str().unwrap()).to(be_eq("maybe"));
+    },
+    Err(_) => {
+      panic!("expected 200 response but request failed");
+    }
+  };
 
   let mismatches = unsafe {
     CStr::from_ptr(pactffi_mock_server_mismatches(port)).to_string_lossy().into_owned()
@@ -251,23 +250,21 @@ fn http_xml_consumer_feature_test() {
   // Mock server has started, we can't now modify the pact
   expect!(pactffi_upon_receiving(interaction.clone(), description.as_ptr())).to(be_false());
 
-  let _ = catch_unwind(|| {
-    let client = Client::default();
-    let result = client.get(format!("http://127.0.0.1:{}/xml", port).as_str())
-      .header("Accept", "application/xml")
-      .send();
+  let client = Client::default();
+  let result = client.get(format!("http://127.0.0.1:{}/xml", port).as_str())
+    .header("Accept", "application/xml")
+    .send();
 
-    match result {
-      Ok(res) => {
-        expect!(res.status()).to(be_eq(200));
-        expect!(res.headers().get("Content-Type").unwrap()).to(be_eq("application/xml"));
-        expect!(res.text().unwrap_or_default()).to(be_equal_to("<?xml version='1.0'?><ns1:projects id='1234' xmlns:ns1='http://some.namespace/and/more/stuff'><ns1:project id='1' name='Project 1' type='activity'><ns1:tasks><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/></ns1:tasks></ns1:project><ns1:project id='1' name='Project 1' type='activity'><ns1:tasks><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/></ns1:tasks></ns1:project></ns1:projects>"));
-      },
-      Err(_) => {
-        panic!("expected 200 response but request failed");
-      }
-    };
-  });
+  match result {
+    Ok(res) => {
+      expect!(res.status()).to(be_eq(200));
+      expect!(res.headers().get("Content-Type").unwrap()).to(be_eq("application/xml"));
+      expect!(res.text().unwrap_or_default()).to(be_equal_to("<?xml version='1.0'?><ns1:projects id='1234' xmlns:ns1='http://some.namespace/and/more/stuff'><ns1:project id='1' name='Project 1' type='activity'><ns1:tasks><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/></ns1:tasks></ns1:project><ns1:project id='1' name='Project 1' type='activity'><ns1:tasks><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/><ns1:task done='true' id='1' name='Task 1'/></ns1:tasks></ns1:project></ns1:projects>"));
+    },
+    Err(_) => {
+      panic!("expected 200 response but request failed");
+    }
+  };
 
   let mismatches = unsafe {
     CStr::from_ptr(pactffi_mock_server_mismatches(port)).to_string_lossy().into_owned()


### PR DESCRIPTION
I have small pact acceptance suite in Pact Go that tests that go can call the main FFI methods.
The one that runs through a basic lifecycle is producing this pact file:

```json
{
  "consumer": {
    "name": "test-http-consumer"
  },
  "interactions": [
    {
      "description": "some interaction",
      "key": "8369cdf3b43ff542",
      "pending": false,
      "providerStates": [
        {
          "name": "some state"
        }
      ],
      "request": {
        "method": "GET",
        "path": "/products"
      },
      "response": {
        "body": {
          "content": "{\"age\":23,\"alive\":true,\"name\":\"some name\"}",
          "contentType": "*/*",
          "encoded": false
        },
        "headers": {
          "Content-Type": [
            "application/json"
          ]
        },
        "matchingRules": {
          "body": {
            "$.name": {
              "combine": "AND",
              "matchers": [
                {
                  "match": "type"
                }
              ]
            }
          }
        },
        "status": 200
      },
      "type": "Synchronous/HTTP"
    }
  ],
  "metadata": {
    "pactRust": {
      "ffi": "0.1.2",
      "mockserver": "0.8.2",
      "models": "0.2.1"
    },
    "pactSpecification": {
      "version": "4.0"
    }
  },
  "provider": {
    "name": "test-http-provider"
  }
}
```

there are at least 2 issues:
1. It doesn’t seem to respect the pactffi_with_specification method at all, and always serialises a v4 pact
1. the JSON body seems to be stringified and when it is verified the verification fails because it’s comparing text and the formatting/values are different

It checks the content type, but for some reason is still doing a text comparison on the response:

```sh
  A request to do a foo
    returns a response which
      has status code 200 (OK)
      includes headers
        "Content-Type" with value "application/json" (OK)
      has a matching body (FAILED)

[2021-11-16T11:03:06Z ERROR pact_verifier] Failed to load pact - Failed to load pact '/Users/matthewfellows/go/src/github.com/pact-foundation/pact-go/examples/pacts/PactGoV2ConsumerMatch-V2ProviderMatch.json' - No such file or directory (os error 2)

Failures:

1) Verifying a pact between PactGoV3Consumer and V3Provider Given User foo exists - A request to do a foo
    1.1) has a matching body
           $ -> Expected text 'Some(b"{\"accountBalance\":123.76,\"arrayContaining\":[\"string\",1,{\"foo\":\"bar\"}],\"datetime\":\"2020-01-01\",\"equality\":\"a thing\",\"id\":12,\"itemsMin\":[\"thereshouldbe3ofthese\",\"thereshouldbe3ofthese\",\"thereshouldbe3ofthese\"],\"itemsMinMax\":[27,27,27,27,27],\"lastName\":\"Sampson\",\"name\":\"Billy\",\"superstring\":\"foo\"}")' but received 'Some(b"\n\t\t\t{\n\t\t\t\t\"accountBalance\": 123.76,\n\t\t\t\t\"datetime\": \"2020-01-01\",\n\t\t\t\t\"equality\": \"a thing\",\n\t\t\t\t\"id\": 12,\n\t\t\t\t\"itemsMin\": [\n\t\t\t\t\t\"thereshouldbe3ofthese\",\n\t\t\t\t\t\"thereshouldbe3ofthese\",\n\t\t\t\t\t\"thereshouldbe3ofthese\"\n\t\t\t\t],\n\t\t\t\t\"itemsMinMax\": [\n\t\t\t\t\t27,\n\t\t\t\t\t27,\n\t\t\t\t\t27,\n\t\t\t\t\t27,\n\t\t\t\t\t27\n\t\t\t\t],\n\t\t\t\t\"lastName\": \"Sampson\",\n\t\t\t\t\"name\": \"Billy\",\n\t\t\t\t\"superstring\": \"foo\",\n\t\t\t\t\"arrayContaining\": [\n\t\t\t\t\t\"string\",\n\t\t\t\t\t1,\n\t\t\t\t\t{\n\t\t\t\t\t\t\"foo\": \"bar\"\n\t\t\t\t\t}\n\t\t\t\t]\n\t\t\t}")'
```

_(note this is a different pact file than what is being verified, but the other is a long longer because of matching rules. The same set of symptoms though)_

So, I think I’ve fixed the serialisation issue, which is this PR.

As for spec version, it seems we’ve now migrated to the V4Pact struct, which doesn’t have anywhere to set the spec version (because, presumably, it is always V4)

we track the FFI spec version here:
```rust
pub struct PactHandleInner {
  pub(crate) pact: V4Pact,
  pub(crate) mock_server_started: bool,
  pub(crate) specification_version: PactSpecification
}
```

but because the specification_version property is not ever passed on to the pact itself, it obviously won’t ever serialise another version