### PR TITLE
feat(ffi)!: Separate verification and publishing options

### DIFF
--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -259,14 +259,11 @@ fn publish_result_does_nothing_if_not_from_broker() {
         .await
         .start_mock_server();
 
-      let options = super::VerificationOptions {
-        publish: true,
+      let options = super::PublishOptions {
         provider_version: None,
         build_url: None,
-        request_filter: None::<Arc<super::NullRequestFilterExecutor>>,
         provider_tags: vec![],
-        disable_ssl_verification: false,
-        .. super::VerificationOptions::default()
+        .. super::PublishOptions::default()
       };
       super::publish_result(&vec![], &PactSource::File("/tmp/test".into()), &options).await;
     })
@@ -299,15 +296,11 @@ async fn publish_successful_result_to_broker() {
     .await
     .start_mock_server();
 
-  let options = super::VerificationOptions {
-    publish: true,
+  let options = super::PublishOptions {
     provider_version: Some("1".into()),
-    build_url: None,
-    request_filter: None::<Arc<super::NullRequestFilterExecutor>>,
-    provider_tags: vec![],
-    disable_ssl_verification: false,
-    .. super::VerificationOptions::default()
+    .. super::PublishOptions::default()
   };
+
   let links = vec![
     Link {
       name: "pb:publish-verification-results".to_string(),
@@ -316,6 +309,7 @@ async fn publish_successful_result_to_broker() {
       title: None
     }
   ];
+  
   let source = PactSource::BrokerUrl("Test".to_string(), server.url().to_string(), None, links);
   super::publish_result(&vec![(Some("1".to_string()), Ok(()))], &source, &options).await;
 }

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -247,7 +247,7 @@ use pact_models::prelude::HttpAuth;
 use simplelog::{ColorChoice, Config, TerminalMode, TermLogger};
 use tokio::time::sleep;
 
-use pact_verifier::{FilterInfo, NullRequestFilterExecutor, PactSource, ProviderInfo, VerificationOptions, verify_provider_async};
+use pact_verifier::{FilterInfo, NullRequestFilterExecutor, PactSource, ProviderInfo, VerificationOptions, verify_provider_async, PublishOptions};
 use pact_verifier::callback_executors::HttpRequestProviderStateExecutor;
 use pact_verifier::metrics::VerificationMetrics;
 use pact_verifier::selectors::{consumer_tags_to_selectors, json_to_selectors};
@@ -307,17 +307,23 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
     state_change_teardown: matches.is_present("state-change-teardown")
   });
 
-  let options = VerificationOptions {
-    publish: matches.is_present("publish"),
-    provider_version: matches.value_of("provider-version").map(|v| v.to_string()),
-    build_url: matches.value_of("build-url").map(|v| v.to_string()),
+  let verification_options = VerificationOptions {
     request_filter: None::<Arc<NullRequestFilterExecutor>>,
-    provider_tags: matches.values_of("provider-tags")
-      .map_or_else(Vec::new, |tags| tags.map(|tag| tag.to_string()).collect()),
     disable_ssl_verification: matches.is_present("disable-ssl-verification"),
     request_timeout: matches.value_of("request-timeout")
       .map(|t| t.parse::<u64>().unwrap_or(5000)).unwrap_or(5000),
-    provider_branch: matches.value_of("provider-branch").map(|v| v.to_string())
+  };
+
+  let publish_options = if matches.is_present("publish") {
+    Some(PublishOptions {
+      provider_version: matches.value_of("provider-version").map(|v| v.to_string()),
+      build_url: matches.value_of("build-url").map(|v| v.to_string()),
+      provider_tags: matches.values_of("provider-tags")
+        .map_or_else(Vec::new, |tags| tags.map(|tag| tag.to_string()).collect()),
+      provider_branch: matches.value_of("provider-branch").map(|v| v.to_string())
+    })
+  } else {
+    None
   };
 
   for s in &source {
@@ -329,7 +335,8 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
     source,
     filter,
     matches.values_of_lossy("filter-consumer").unwrap_or_default(),
-    options,
+    &verification_options,
+    publish_options.as_ref(),
     &provider_state_executor,
     Some(VerificationMetrics {
       test_framework: "pact_verifier_cli".to_string(),


### PR DESCRIPTION
This change makes the verifier FFI easier to work with because the publishing options are split from the verification options.

The verification options should apply to all pact sources (such as file and URL) because they contain global settings such as request timeouts and callbacks.

However, the publish options only make sense when a Pact Broker is configured. This made the FFI tricky to use from library code (in particular from PactNet) because that meant you could only set the global verification options when using a Pact Broker source, instead of when using any source. This change will allow that happen properly in future.

As an aside, I didn't find any unit tests to update at all for this, which is a bit concerning.