### PR TITLE
Feat/capture verifier output

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "pact_verifier"
-version = "0.12.5"
+version = "0.13.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
 dependencies = [
  "flate2",
  "futures-core",
@@ -557,9 +557,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -829,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1272,6 +1272,7 @@ dependencies = [
 name = "pact_ffi"
 version = "0.1.7"
 dependencies = [
+ "ansi_term 0.12.1",
  "anyhow",
  "bytes",
  "chrono",
@@ -1535,6 +1536,7 @@ dependencies = [
 name = "pact_verifier_cli"
 version = "0.9.7"
 dependencies = [
+ "ansi_term 0.12.1",
  "anyhow",
  "clap",
  "expectest",
@@ -2104,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2117,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2151,18 +2153,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -2261,9 +2263,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -2448,9 +2450,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -3004,6 +3006,6 @@ checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "4062c749be08d90be727e9c5895371c3a0e49b90ba2b9592dc7afda95cc2b719"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
 name = "pact_verifier_cli"
 version = "0.9.7"
 dependencies = [
+ "anyhow",
  "clap",
  "expectest",
  "log",
@@ -1542,6 +1543,7 @@ dependencies = [
  "pact_verifier",
  "regex",
  "reqwest",
+ "serde_json",
  "simplelog 0.10.2",
  "tokio",
 ]

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = ["full"] }
 sxd-document = "0.3.2"
 either = "1.6.1"
 pact-plugin-driver = "0.0.17"
+ansi_term = "0.12.1"
 
 [dev-dependencies]
 expectest = "0.12.0"

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 pact_matching = { version = "0.12.2", path = "../pact_matching" }
 pact_models = "0.2.7"
 pact_mock_server = { version = "0.8.6", path = "../pact_mock_server" }
-pact_verifier = { version = "0.12.4", path = "../pact_verifier" }
+pact_verifier = { version = "0.13.0", path = "../pact_verifier" }
 anyhow = "1.0.28"
 libc = "0.2.69"
 zeroize = "1.1.0"

--- a/rust/pact_ffi/src/lib.rs
+++ b/rust/pact_ffi/src/lib.rs
@@ -8,15 +8,16 @@
 use std::ffi::CStr;
 use std::str::FromStr;
 
+use ::log::warn;
 use env_logger::Builder;
 use libc::c_char;
+use pact_models::interaction::Interaction;
+use pact_models::pact::Pact;
+use pact_models::v4::pact::V4Pact;
 
 use models::message::Message;
-use pact_matching::{self as pm};
+use pact_matching as pm;
 pub use pact_matching::Mismatch;
-use pact_models::interaction::Interaction;
-use pact_models::v4::pact::V4Pact;
-use pact_models::pact::Pact;
 
 use crate::util::*;
 
@@ -52,7 +53,7 @@ pub unsafe extern fn pactffi_init(log_env_var: *const c_char) {
         match c_str.to_str() {
             Ok(str) => str,
             Err(err) => {
-                ::log::warn!("Failed to parse the environment variable name as a UTF-8 string: {}", err);
+                warn!("Failed to parse the environment variable name as a UTF-8 string: {}", err);
                 "LOG_LEVEL"
             }
         }

--- a/rust/pact_ffi/src/lib.rs
+++ b/rust/pact_ffi/src/lib.rs
@@ -42,9 +42,11 @@ pub extern "C" fn pactffi_version() -> *const c_char {
 ///
 /// # Safety
 ///
-/// Exported functions are inherently unsafe.
+/// log_env_var must be a valid NULL terminated UTF-8 string.
 #[no_mangle]
 pub unsafe extern fn pactffi_init(log_env_var: *const c_char) {
+    init_windows();
+
     let log_env_var = if !log_env_var.is_null() {
         let c_str = CStr::from_ptr(log_env_var);
         match c_str.to_str() {
@@ -62,6 +64,16 @@ pub unsafe extern fn pactffi_init(log_env_var: *const c_char) {
     let mut builder = Builder::from_env(env);
     builder.try_init().unwrap_or(());
 }
+
+#[cfg(windows)]
+fn init_windows() {
+    if let Err(err) = ansi_term::enable_ansi_support() {
+        warn!("Could not enable ANSI console support - {err}");
+    }
+}
+
+#[cfg(not(windows))]
+fn init_windows() { }
 
 /// Initialises logging, and sets the log level explicitly.
 ///

--- a/rust/pact_ffi/src/verifier/handle.rs
+++ b/rust/pact_ffi/src/verifier/handle.rs
@@ -1,9 +1,11 @@
 //! Handle interface to creating a verifier
 
 use std::sync::Arc;
+use itertools::Itertools;
 
 use log::debug;
 use pact_models::prelude::HttpAuth;
+use serde_json::Value;
 
 use pact_verifier::{
   ConsumerVersionSelector,
@@ -276,6 +278,17 @@ impl VerifierHandle {
       }
       Err(_) => 2
     }
+  }
+
+  /// Return the captured standard output from the verification execution
+  pub fn output(&self) -> String {
+    self.verifier_output.output.iter().join("\n")
+  }
+
+  /// Return the verification results as a JSON document
+  pub fn json(&self) -> String {
+    let json: Value = (&self.verifier_output).into();
+    json.to_string()
   }
 }
 

--- a/rust/pact_ffi/src/verifier/mod.rs
+++ b/rust/pact_ffi/src/verifier/mod.rs
@@ -753,3 +753,31 @@ ffi_fn! {
       std::ptr::null()
     }
 }
+
+ffi_fn! {
+    /// Extracts the standard output for the verification run. The returned string will need to be
+    /// freed with the `free_string` function call to avoid leaking memory.
+    ///
+    /// Will return a NULL pointer if the handle is invalid.
+    fn pactffi_verifier_output(handle: *const handle::VerifierHandle) -> *const c_char {
+      let handle = as_ref!(handle);
+      let output = CString::new(handle.output()).unwrap();
+      output.into_raw() as *const c_char
+    } {
+      std::ptr::null()
+    }
+}
+
+ffi_fn! {
+    /// Extracts the verification result as a JSON document. The returned string will need to be
+    /// freed with the `free_string` function call to avoid leaking memory.
+    ///
+    /// Will return a NULL pointer if the handle is invalid.
+    fn pactffi_verifier_json(handle: *const handle::VerifierHandle) -> *const c_char {
+      let handle = as_ref!(handle);
+      let output = CString::new(handle.json()).unwrap();
+      output.into_raw() as *const c_char
+    } {
+      std::ptr::null()
+    }
+}

--- a/rust/pact_ffi/src/verifier/verifier.rs
+++ b/rust/pact_ffi/src/verifier/verifier.rs
@@ -259,7 +259,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
         error!("Verification failed with error: {}", err);
         2
       })
-      .and_then(|(result, _)| if result { Ok(()) } else { Err(1) })
+      .and_then(|result| if result.result { Ok(()) } else { Err(1) })
 }
 
 fn print_version(version: &str) {

--- a/rust/pact_ffi/src/verifier/verifier.rs
+++ b/rust/pact_ffi/src/verifier/verifier.rs
@@ -259,7 +259,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
         error!("Verification failed with error: {}", err);
         2
       })
-      .and_then(|result| if result { Ok(()) } else { Err(1) })
+      .and_then(|(result, _)| if result { Ok(()) } else { Err(1) })
 }
 
 fn print_version(version: &str) {

--- a/rust/pact_matching/src/metrics.rs
+++ b/rust/pact_matching/src/metrics.rs
@@ -155,7 +155,7 @@ pub fn send_metrics(event: MetricEvent) {
         if *warning_logged == false {
           warn!(
             "\n\nPlease note:\n\
-            Please note: we are tracking events anonymously to gather important usage statistics like Pact version \
+            We are tracking events anonymously to gather important usage statistics like Pact version \
             and operating system. To disable tracking, set the 'PACT_DO_NOT_TRACK' environment \
             variable to 'true'.\n\n"
           );

--- a/rust/pact_verifier/Cargo.toml
+++ b/rust/pact_verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pact_verifier"
-version = "0.12.5"
+version = "0.13.0"
 authors = ["Ronald Holshausen <uglyog@gmail.com>"]
 edition = "2021"
 description = "Pact-Rust support library that implements provider verification functions"

--- a/rust/pact_verifier/src/messages.rs
+++ b/rust/pact_verifier/src/messages.rs
@@ -82,16 +82,16 @@ pub(crate) async fn verify_message_from_provider<'a, F: RequestFilterExecutor>(
   }
 }
 
-pub fn display_message_result(
+pub fn process_message_result(
   interaction: &Message,
   match_result: &Result<Option<String>, MismatchResult>,
   output: &mut Vec<String>) {
   match match_result {
     Ok(_) => {
-      display_result(Green.paint("OK"),
-        interaction.metadata.iter()
+      generate_display_for_result(Green.paint("OK"),
+                                  interaction.metadata.iter()
           .map(|(k, v)| (k.clone(), serde_json::to_string(&v.clone()).unwrap_or_default(), Green.paint("OK"))).collect(),
-        output
+                                  output
       );
     },
     Err(ref err) => match *err {
@@ -118,13 +118,13 @@ pub fn display_message_result(
           Green.paint("OK")
         };
 
-        display_result(body_result, metadata_results, output);
+        generate_display_for_result(body_result, metadata_results, output);
       }
     }
   }
 }
 
-fn display_result(
+fn generate_display_for_result(
   body_result: ANSIGenericString<str>,
   metadata_result: Vec<(String, String, ANSIGenericString<str>)>,
   output: &mut Vec<String>

--- a/rust/pact_verifier/src/messages.rs
+++ b/rust/pact_verifier/src/messages.rs
@@ -84,16 +84,19 @@ pub(crate) async fn verify_message_from_provider<'a, F: RequestFilterExecutor>(
 
 pub fn display_message_result(
   interaction: &Message,
-  match_result: &Result<Option<String>, MismatchResult>) {
+  match_result: &Result<Option<String>, MismatchResult>,
+  output: &mut Vec<String>) {
   match match_result {
     Ok(_) => {
       display_result(Green.paint("OK"),
         interaction.metadata.iter()
-          .map(|(k, v)| (k.clone(), serde_json::to_string(&v.clone()).unwrap_or_default(), Green.paint("OK"))).collect());
+          .map(|(k, v)| (k.clone(), serde_json::to_string(&v.clone()).unwrap_or_default(), Green.paint("OK"))).collect(),
+        output
+      );
     },
     Err(ref err) => match *err {
       MismatchResult::Error(ref err_des, _) => {
-        println!("      {}", Red.paint(format!("Request Failed - {}", err_des)));
+        output.push(format!("      {}", Red.paint(format!("Request Failed - {}", err_des))));
       },
       MismatchResult::Mismatches { ref mismatches, .. } => {
         let metadata_results = interaction.metadata.iter().map(|(k, v)| {
@@ -115,22 +118,26 @@ pub fn display_message_result(
           Green.paint("OK")
         };
 
-        display_result(body_result, metadata_results);
+        display_result(body_result, metadata_results, output);
       }
     }
   }
 }
 
-fn display_result(body_result: ANSIGenericString<str>, metadata_result: Vec<(String, String, ANSIGenericString<str>)>) {
-  println!("    generates a message which");
+fn display_result(
+  body_result: ANSIGenericString<str>,
+  metadata_result: Vec<(String, String, ANSIGenericString<str>)>,
+  output: &mut Vec<String>
+) {
+  output.push("    generates a message which".to_string());
   if !metadata_result.is_empty() {
-    println!("      includes metadata");
+    output.push("      includes metadata".to_string());
     for (key, value, result) in metadata_result {
-      println!("        \"{}\" with value {} ({})", Style::new().bold().paint(key),
-        Style::new().bold().paint(value), result);
+      output.push(format!("        \"{}\" with value {} ({})", Style::new().bold().paint(key),
+        Style::new().bold().paint(value), result));
     }
   }
-  println!("      has a matching body ({})", body_result);
+  output.push(format!("      has a matching body ({})", body_result));
 }
 
 fn extract_metadata(actual_response: &HttpResponse) -> HashMap<String, Value> {

--- a/rust/pact_verifier/src/request_response.rs
+++ b/rust/pact_verifier/src/request_response.rs
@@ -7,7 +7,8 @@ use crate::{display_result, MismatchResult};
 
 pub fn display_request_response_result(
   interaction: &RequestResponseInteraction,
-  match_result: &Result<Option<String>, MismatchResult>) {
+  match_result: &Result<Option<String>, MismatchResult>,
+  output: &mut Vec<String>) {
   match match_result {
     Ok(_) => {
       display_result(
@@ -15,12 +16,13 @@ pub fn display_request_response_result(
         Green.paint("OK"),
         interaction.response.headers.clone().map(|h| h.iter().map(|(k, v)| {
           (k.clone(), v.join(", "), Green.paint("OK"))
-        }).collect()), Green.paint("OK")
+        }).collect()), Green.paint("OK"),
+        output
       );
     },
     Err(ref err) => match *err {
       MismatchResult::Error(ref err_des, _) => {
-        println!("      {}", Red.paint(format!("Request Failed - {}", err_des)));
+        output.push(format!("      {}", Red.paint(format!("Request Failed - {}", err_des))));
       },
       MismatchResult::Mismatches { ref mismatches, .. } => {
         let status_result = if mismatches.iter().any(|m| m.mismatch_type() == "StatusMismatch") {
@@ -50,7 +52,7 @@ pub fn display_request_response_result(
           Green.paint("OK")
         };
 
-        display_result(interaction.response.status, status_result, header_results, body_result);
+        display_result(interaction.response.status, status_result, header_results, body_result, output);
       }
     }
   }

--- a/rust/pact_verifier/src/request_response.rs
+++ b/rust/pact_verifier/src/request_response.rs
@@ -3,15 +3,15 @@ use ansi_term::Colour::*;
 use pact_matching::Mismatch;
 use pact_models::sync_interaction::RequestResponseInteraction;
 
-use crate::{display_result, MismatchResult};
+use crate::{generate_display_for_result, MismatchResult};
 
-pub fn display_request_response_result(
+pub fn process_request_response_result(
   interaction: &RequestResponseInteraction,
   match_result: &Result<Option<String>, MismatchResult>,
   output: &mut Vec<String>) {
   match match_result {
     Ok(_) => {
-      display_result(
+      generate_display_for_result(
         interaction.response.status,
         Green.paint("OK"),
         interaction.response.headers.clone().map(|h| h.iter().map(|(k, v)| {
@@ -52,7 +52,7 @@ pub fn display_request_response_result(
           Green.paint("OK")
         };
 
-        display_result(interaction.response.status, status_result, header_results, body_result, output);
+        generate_display_for_result(interaction.response.status, status_result, header_results, body_result, output);
       }
     }
   }

--- a/rust/pact_verifier/src/verification_result.rs
+++ b/rust/pact_verifier/src/verification_result.rs
@@ -1,0 +1,71 @@
+//! Structs for storing and returning the result of the verification execution
+
+use std::collections::HashMap;
+use pact_matching::Mismatch;
+
+/// Main struct for returning the verification execution result
+#[derive(Debug, Clone)]
+pub struct VerificationExecutionResult {
+  /// Overall pass/fail result
+  pub result: bool,
+  /// Notices provided by the Pact Broker
+  pub notices: Vec<HashMap<String, String>>,
+  /// Collected standard output
+  pub output: Vec<String>,
+  /// Errors that occurred, but are marked as pending
+  pub pending_errors: Vec<(String, MismatchResult)>,
+  /// Errors that occurred that are not considered pending
+  pub errors: Vec<(String, MismatchResult)>,
+}
+
+impl VerificationExecutionResult {
+  /// Create a new VerificationExecutionResult with default values
+  pub fn new() -> Self {
+    VerificationExecutionResult {
+      result: true,
+      notices: vec![],
+      output: vec![],
+      pending_errors: vec![],
+      errors: vec![]
+    }
+  }
+}
+
+/// Result of performing a match. This is a reduced version of super::MismatchResult to make
+/// it thread and panic boundary safe
+#[derive(Debug, Clone)]
+pub enum MismatchResult {
+  /// Response mismatches
+  Mismatches {
+    /// Mismatches that occurred
+    mismatches: Vec<Mismatch>,
+    /// Interaction ID if fetched from a pact broker
+    interaction_id: Option<String>
+  },
+  /// Error occurred
+  Error {
+    /// Error that occurred
+    error: String,
+    /// Interaction ID if fetched from a pact broker
+    interaction_id: Option<String>
+  }
+}
+
+impl From<&crate::MismatchResult> for MismatchResult {
+  fn from(result: &crate::MismatchResult) -> Self {
+    match result {
+      crate::MismatchResult::Mismatches { mismatches, interaction_id, .. } => {
+        MismatchResult::Mismatches {
+          mismatches: mismatches.clone(),
+          interaction_id: interaction_id.clone()
+        }
+      }
+      crate::MismatchResult::Error(error, interaction_id) => {
+        MismatchResult::Error {
+          error: error.clone(),
+          interaction_id: interaction_id.clone()
+        }
+      }
+    }
+  }
+}

--- a/rust/pact_verifier/tests/tests.rs
+++ b/rust/pact_verifier/tests/tests.rs
@@ -89,9 +89,17 @@ async fn verify_pact_with_match_values_matcher() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
+  let mut output = vec![];
 
-  let result = verify_pact_internal(&provider, &FilterInfo::None,
-                                    pact, &options, &provider_states, false).await;
+  let result = verify_pact_internal(
+    &provider,
+    &FilterInfo::None,
+    pact,
+    &options,
+    &provider_states,
+    false,
+    &mut output
+  ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
 }
@@ -133,9 +141,17 @@ async fn verify_pact_with_attributes_with_special_values() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
+  let mut output = vec![];
 
-  let result = verify_pact_internal(&provider, &FilterInfo::None,
-                                    pact, &options, &provider_states, false).await;
+  let result = verify_pact_internal(
+    &provider,
+    &FilterInfo::None,
+    pact,
+    &options,
+    &provider_states,
+    false,
+    &mut output
+  ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
 }
@@ -153,9 +169,17 @@ async fn verifying_a_pact_with_pending_interactions() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
+  let mut output = vec![];
 
-  let result = verify_pact_internal(&provider, &FilterInfo::None,
-                                    pact, &options, &provider_states, false).await;
+  let result = verify_pact_internal(
+    &provider,
+    &FilterInfo::None,
+    pact,
+    &options,
+    &provider_states,
+    false,
+    &mut output
+  ).await;
 
   expect!(result.as_ref().unwrap().results.get(0).unwrap().result.as_ref()).to(be_err());
   expect!(result.as_ref().unwrap().results.get(0).unwrap().pending).to(be_true());
@@ -200,9 +224,17 @@ async fn verifying_a_pact_with_min_type_matcher_and_child_arrays() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
+  let mut output = vec![];
 
-  let result = verify_pact_internal(&provider, &FilterInfo::None,
-                                    pact, &options, &provider_states, false).await;
+  let result = verify_pact_internal(
+    &provider,
+    &FilterInfo::None,
+    pact,
+    &options,
+    &provider_states,
+    false,
+    &mut output
+  ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
 }

--- a/rust/pact_verifier/tests/tests.rs
+++ b/rust/pact_verifier/tests/tests.rs
@@ -89,7 +89,6 @@ async fn verify_pact_with_match_values_matcher() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
-  let mut output = vec![];
 
   let result = verify_pact_internal(
     &provider,
@@ -97,8 +96,7 @@ async fn verify_pact_with_match_values_matcher() {
     pact,
     &options,
     &provider_states,
-    false,
-    &mut output
+    false
   ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
@@ -141,7 +139,6 @@ async fn verify_pact_with_attributes_with_special_values() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
-  let mut output = vec![];
 
   let result = verify_pact_internal(
     &provider,
@@ -149,8 +146,7 @@ async fn verify_pact_with_attributes_with_special_values() {
     pact,
     &options,
     &provider_states,
-    false,
-    &mut output
+    false
   ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
@@ -169,7 +165,6 @@ async fn verifying_a_pact_with_pending_interactions() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
-  let mut output = vec![];
 
   let result = verify_pact_internal(
     &provider,
@@ -177,8 +172,7 @@ async fn verifying_a_pact_with_pending_interactions() {
     pact,
     &options,
     &provider_states,
-    false,
-    &mut output
+    false
   ).await;
 
   expect!(result.as_ref().unwrap().results.get(0).unwrap().result.as_ref()).to(be_err());
@@ -224,7 +218,6 @@ async fn verifying_a_pact_with_min_type_matcher_and_child_arrays() {
   let pact = read_pact(pact_file.as_path()).unwrap();
   let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
   let provider_states = Arc::new(DummyProviderStateExecutor{});
-  let mut output = vec![];
 
   let result = verify_pact_internal(
     &provider,
@@ -232,8 +225,7 @@ async fn verifying_a_pact_with_min_type_matcher_and_child_arrays() {
     pact,
     &options,
     &provider_states,
-    false,
-    &mut output
+    false
   ).await;
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -24,6 +24,7 @@ log = "=0.4.14" # This needs to be the same version across all the libs (i.e. pl
 simplelog = "0.10.2"
 serde_json = "1.0.78"
 anyhow = "1.0.53"
+ansi_term = "0.12.1"
 
 [dev-dependencies]
 expectest = "0.12.0"

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 pact_models = "0.2.7"
-pact_verifier = { version = "0.12.4", path = "../pact_verifier" }
+pact_verifier = { version = "0.13.0", path = "../pact_verifier" }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-native-roots", "blocking", "json"] }
 clap = "2.33"

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -22,6 +22,8 @@ clap = "2.33"
 regex = "1.5.4"
 log = "=0.4.14" # This needs to be the same version across all the libs (i.e. plugin driver)
 simplelog = "0.10.2"
+serde_json = "1.0.78"
+anyhow = "1.0.53"
 
 [dev-dependencies]
 expectest = "0.12.0"

--- a/rust/pact_verifier_cli/README.md
+++ b/rust/pact_verifier_cli/README.md
@@ -11,7 +11,7 @@ The Pact Verifier works by taking all the interactions (requests and responses) 
 The pact verifier is bundled as a single binary executable `pact_verifier_cli`. Running this with out any options displays the standard help.
 
 ```console
-pact_verifier_cli v0.9.9
+pact_verifier_cli 0.9.7
 Standalone Pact verifier
 
 USAGE:
@@ -29,21 +29,23 @@ FLAGS:
     -v, --version                     Prints version information
 
 OPTIONS:
-        --base-path <base-path>                                      Base path to add to all requests
+        --base-path <base-path>                                         Base path to add to all requests
     -b, --broker-url <broker-url>
             URL of the pact broker to fetch pacts from to verify (requires the provider name parameter) [env:
             PACT_BROKER_BASE_URL=]
         --build-url <build-url>
             URL of the build to associate with the published verification results.
 
-        --consumer-version-selectors <consumer-version-selectors>
+        --consumer-version-selectors <consumer-version-selectors>...
             Consumer version selectors to use when fetching pacts from the Broker. Accepts a JSON string as per
             https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/
         --consumer-version-tags <consumer-version-tags>
             Consumer tags to use when fetching pacts from the Broker. Accepts comma-separated values.
 
-    -d, --dir <dir>...                                               Directory of pact files to verify (can be repeated)
-    -f, --file <file>...                                             Pact file to verify (can be repeated)
+    -d, --dir <dir>...
+            Directory of pact files to verify (can be repeated)
+
+    -f, --file <file>...                                                Pact file to verify (can be repeated)
     -c, --filter-consumer <filter-consumer>...
             Consumer name to filter the pacts to be verified (can be repeated)
 
@@ -56,18 +58,22 @@ OPTIONS:
         --filter-state <filter-state>
             Only validate interactions whose provider states match this filter [env: PACT_PROVIDER_STATE=]
 
-    -h, --hostname <hostname>                                        Provider hostname (defaults to localhost)
+    -h, --hostname <hostname>                                           Provider hostname (defaults to localhost)
         --include-wip-pacts-since <include-wip-pacts-since>
             Allow pacts that don't match given consumer selectors (or tags) to  be verified, without causing the overall
             task to fail. For more information, see https://pact.io/wip
+    -j, --json <json-file>                                              Generate a JSON report of the verification
     -l, --loglevel <loglevel>
             Log level (defaults to warn) [possible values: error, warn, info, debug,
             trace, none]
         --password <password>
             Password to use when fetching pacts from URLS [env: PACT_BROKER_PASSWORD=]
 
-    -p, --port <port>                                                Provider port (defaults to protocol default 80/443)
-    -n, --provider-name <provider-name>                              Provider name (defaults to provider)
+    -p, --port <port>
+            Provider port (defaults to protocol default 80/443)
+
+        --provider-branch <provider-branch>                             Provider branch to use when publishing results
+    -n, --provider-name <provider-name>                                 Provider name (defaults to provider)
         --provider-tags <provider-tags>
             Provider tags to use when publishing results. Accepts comma-separated values.
 
@@ -80,11 +86,11 @@ OPTIONS:
         --scheme <scheme>
             Provider URI scheme (defaults to http) [default: http]  [possible values: http, https]
 
-    -s, --state-change-url <state-change-url>                        URL to post state change requests to
+    -s, --state-change-url <state-change-url>                           URL to post state change requests to
     -t, --token <token>
             Bearer token to use when fetching pacts from URLS [env: PACT_BROKER_TOKEN=]
 
-    -u, --url <url>...                                               URL of pact file to verify (can be repeated)
+    -u, --url <url>...                                                  URL of pact file to verify (can be repeated)
         --user <user>
             Username to use when fetching pacts from URLS [env: PACT_BROKER_USERNAME=]
 ```

--- a/rust/pact_verifier_cli/src/args.rs
+++ b/rust/pact_verifier_cli/src/args.rs
@@ -233,7 +233,16 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .empty_values(false)
       .validator(integer_value)
       .help("Sets the HTTP request timeout in milliseconds for requests to the target API and for state change requests."))
-    }
+    .arg(Arg::with_name("json-file")
+      .short("j")
+      .long("json")
+      .takes_value(true)
+      .use_delimiter(false)
+      .multiple(false)
+      .number_of_values(1)
+      .empty_values(false)
+      .help("Generate a JSON report of the verification"))
+}
 
 #[cfg(test)]
 mod test {

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -243,7 +243,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::{AppSettings, ArgMatches, ErrorKind};
-use log::{debug, error, LevelFilter};
+use log::{debug, error, LevelFilter, warn};
 use pact_models::{PACT_RUST_VERSION, PactSpecification};
 use pact_models::prelude::HttpAuth;
 use serde_json::Value;
@@ -467,6 +467,8 @@ fn interaction_filter(matches: &ArgMatches) -> FilterInfo {
 }
 
 fn main() {
+  init_windows();
+
   let runtime = tokio::runtime::Builder::new_multi_thread()
     .enable_all()
     .build()
@@ -487,3 +489,13 @@ fn main() {
     std::process::exit(err);
   }
 }
+
+#[cfg(windows)]
+fn init_windows() {
+  if let Err(err) = ansi_term::enable_ansi_support() {
+    warn!("Could not enable ANSI console support - {err}");
+  }
+}
+
+#[cfg(not(windows))]
+fn init_windows() { }

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -11,68 +11,86 @@
 //! The pact verifier is bundled as a single binary executable `pact_verifier_cli`. Running this with out any options displays the standard help.
 //!
 //! ```console,ignore
-//! pact_verifier_cli v0.6.2
+//! pact_verifier_cli 0.9.7
 //! Standalone Pact verifier
 //!
 //! USAGE:
-//!     pact_verifier_cli [FLAGS] [OPTIONS] --broker-url <broker-url>... --dir <dir>... --file <file>... --provider-name <provider-name> --url <url>...
+//!     pact_verifier_cli [FLAGS] [OPTIONS] --broker-url <broker-url> --dir <dir>... --file <file>... --provider-name <provider-name> --url <url>...
 //!
 //! FLAGS:
-//!         --enable-pending           Enables Pending Pacts
-//!         --filter-no-state          Only validate interactions that have no defined provider state
-//!         --help                     Prints help information
-//!         --publish                  Enables publishing of verification results back to the Pact Broker. Requires the
-//!                                    broker-url and provider-version parameters.
-//!         --state-change-as-query    State change request data will be sent as query parameters instead of in the request
-//!                                    body
-//!         --state-change-teardown    State change teardown requests are to be made after each interaction
-//!     -v, --version                  Prints version information
+//!         --disable-ssl-verification    Disables validation of SSL certificates
+//!         --enable-pending              Enables Pending Pacts
+//!         --help                        Prints help information
+//!         --publish                     Enables publishing of verification results back to the Pact Broker. Requires the
+//!                                       broker-url and provider-version parameters.
+//!         --state-change-as-query       State change request data will be sent as query parameters instead of in the
+//!                                       request body
+//!         --state-change-teardown       State change teardown requests are to be made after each interaction
+//!     -v, --version                     Prints version information
 //!
 //! OPTIONS:
-//!         --base-path <base-path>                                Base path to add to all requests
-//!     -b, --broker-url <broker-url>...
+//!         --base-path <base-path>                                         Base path to add to all requests
+//!     -b, --broker-url <broker-url>
 //!             URL of the pact broker to fetch pacts from to verify (requires the provider name parameter) [env:
-//!             PACT_BROKER_BASE_URL=https://testdemo.pactflow.io]
+//!             PACT_BROKER_BASE_URL=]
 //!         --build-url <build-url>
 //!             URL of the build to associate with the published verification results.
 //!
+//!         --consumer-version-selectors <consumer-version-selectors>...
+//!             Consumer version selectors to use when fetching pacts from the Broker. Accepts a JSON string as per
+//!             https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/
 //!         --consumer-version-tags <consumer-version-tags>
 //!             Consumer tags to use when fetching pacts from the Broker. Accepts comma-separated values.
 //!
-//!     -d, --dir <dir>...                                         Directory of pact files to verify (can be repeated)
-//!     -f, --file <file>...                                       Pact file to verify (can be repeated)
+//!     -d, --dir <dir>...
+//!             Directory of pact files to verify (can be repeated)
+//!
+//!     -f, --file <file>...                                                Pact file to verify (can be repeated)
 //!     -c, --filter-consumer <filter-consumer>...
 //!             Consumer name to filter the pacts to be verified (can be repeated)
 //!
 //!         --filter-description <filter-description>
-//!             Only validate interactions whose descriptions match this filter
+//!             Only validate interactions whose descriptions match this filter [env: PACT_DESCRIPTION=]
+//!
+//!         --filter-no-state <filter-no-state>
+//!             Only validate interactions that have no defined provider state [env: PACT_PROVIDER_NO_STATE=]
 //!
 //!         --filter-state <filter-state>
-//!             Only validate interactions whose provider states match this filter
+//!             Only validate interactions whose provider states match this filter [env: PACT_PROVIDER_STATE=]
 //!
-//!     -h, --hostname <hostname>                                  Provider hostname (defaults to localhost)
+//!     -h, --hostname <hostname>                                           Provider hostname (defaults to localhost)
 //!         --include-wip-pacts-since <include-wip-pacts-since>
 //!             Allow pacts that don't match given consumer selectors (or tags) to  be verified, without causing the overall
 //!             task to fail. For more information, see https://pact.io/wip
+//!     -j, --json <json-file>                                              Generate a JSON report of the verification
 //!     -l, --loglevel <loglevel>
 //!             Log level (defaults to warn) [possible values: error, warn, info, debug,
 //!             trace, none]
 //!         --password <password>
 //!             Password to use when fetching pacts from URLS [env: PACT_BROKER_PASSWORD=]
 //!
-//!     -p, --port <port>                                          Provider port (defaults to protocol default 80/443)
-//!     -n, --provider-name <provider-name>                        Provider name (defaults to provider)
+//!     -p, --port <port>
+//!             Provider port (defaults to protocol default 80/443)
+//!
+//!         --provider-branch <provider-branch>                             Provider branch to use when publishing results
+//!     -n, --provider-name <provider-name>                                 Provider name (defaults to provider)
 //!         --provider-tags <provider-tags>
 //!             Provider tags to use when publishing results. Accepts comma-separated values.
 //!
 //!         --provider-version <provider-version>
 //!             Provider version that is being verified. This is required when publishing results.
 //!
-//!     -s, --state-change-url <state-change-url>                  URL to post state change requests to
-//!     -t, --token <token>
-//!             Bearer token to use when fetching pacts from URLS [env: PACT_BROKER_TOKEN=Dk8qO3_ZOqau8EeMaagK5w]
+//!         --request-timeout <request-timeout>
+//!             Sets the HTTP request timeout in milliseconds for requests to the target API and for state change requests.
 //!
-//!     -u, --url <url>...                                         URL of pact file to verify (can be repeated)
+//!         --scheme <scheme>
+//!             Provider URI scheme (defaults to http) [default: http]  [possible values: http, https]
+//!
+//!     -s, --state-change-url <state-change-url>                           URL to post state change requests to
+//!     -t, --token <token>
+//!             Bearer token to use when fetching pacts from URLS [env: PACT_BROKER_TOKEN=]
+//!
+//!     -u, --url <url>...                                                  URL of pact file to verify (can be repeated)
 //!         --user <user>
 //!             Username to use when fetching pacts from URLS [env: PACT_BROKER_USERNAME=]
 //! ```

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -348,7 +348,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
       error!("Verification failed with error: {}", err);
       2
     })
-    .and_then(|(result, _)| if result { Ok(()) } else { Err(1) })
+    .and_then(|result| if result.result { Ok(()) } else { Err(1) })
 }
 
 fn print_version(version: &str) {

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -348,7 +348,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
       error!("Verification failed with error: {}", err);
       2
     })
-    .and_then(|result| if result { Ok(()) } else { Err(1) })
+    .and_then(|(result, _)| if result { Ok(()) } else { Err(1) })
 }
 
 fn print_version(version: &str) {


### PR DESCRIPTION
I updated the verifier code to capture all the output and also the results. There are two new FFI functions:

`pactffi_verifier_output` - This will return the output that is written to standard out
`pactffi_verifier_json` - This will return the verification result as JSON

I have also added an argument to the verifier CLI to write the results to a JSON file.

![image](https://user-images.githubusercontent.com/863666/151488877-222a6555-6d58-437e-9e2d-813621575889.png)

That generates the following file:

```json
{
  "errors": [
    {
      "interaction": "Verifying a pact between test_consumer and test_provider Given test state - test interaction",
      "mismatch": {
        "interactionId": "",
        "message": "error sending request for url (http://localhost/): error trying to connect: tcp connect error: Connection refused (os error 111)",
        "type": "error"
      }
    }
  ],
  "notices": [],
  "output": [
    "\nVerifying a pact between \u001b[1mtest_consumer\u001b[0m and \u001b[1mtest_provider\u001b[0m",
    "",
    "  test interaction",
    "      \u001b[31mRequest Failed - error sending request for url (http://localhost/): error trying to connect: tcp connect error: Connection refused (os error 111)\u001b[0m",
    "",
    "\nFailures:\n",
    "1) Verifying a pact between test_consumer and test_provider Given test state - test interaction - error sending request for url (http://localhost/): error trying to connect: tcp connect error: Connection refused (os error 111)\n",
    "\nThere were 1 pact failures\n"
  ],
  "pendingErrors": [],
  "result": false
}
```