### PR TITLE
Feat/custom headers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
  "clap",
  "expectest",
  "log",
+ "maplit",
  "pact_models 0.2.7",
  "pact_verifier",
  "regex",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "pact_models"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/rust/pact_ffi/src/mock_server/bodies.rs
+++ b/rust/pact_ffi/src/mock_server/bodies.rs
@@ -109,7 +109,7 @@ pub fn process_object(
     Value::Object(obj.iter()
       .filter(|(key, _)| !key.starts_with("pact:"))
       .map(|(key, val)| {
-      let mut item_path = path.join(key);
+      let item_path = path.join(key);
       (key.clone(), match val {
         Value::Object(ref map) => process_object(map, matching_rules, generators, item_path, false, skip_matchers),
         Value::Array(ref array) => process_array(array, matching_rules, generators, item_path, false, skip_matchers),

--- a/rust/pact_ffi/src/verifier/handle.rs
+++ b/rust/pact_ffi/src/verifier/handle.rs
@@ -1,7 +1,9 @@
 //! Handle interface to creating a verifier
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use itertools::Itertools;
+use libc::clone;
 
 use log::debug;
 use pact_models::prelude::HttpAuth;
@@ -204,11 +206,8 @@ impl VerifierHandle {
     disable_ssl_verification: bool,
     request_timeout: u64
   ) {
-    self.verification_options = VerificationOptions {
-      request_filter: None::<Arc<NullRequestFilterExecutor>>,
-      disable_ssl_verification,
-      request_timeout
-    }
+    self.verification_options.disable_ssl_verification = disable_ssl_verification;
+    self.verification_options.request_timeout = request_timeout;
   }
 
   /// Update the details used when publishing results
@@ -294,6 +293,11 @@ impl VerifierHandle {
   #[cfg(test)]
   pub fn set_output(&mut self, out: &str) {
     self.verifier_output.output = out.split('\n').map(|s| s.to_string()).collect();
+  }
+
+  /// Add a custom header to be included in the call to the provider
+  pub fn add_custom_header(&mut self, header_name: &str, header_value: &str) {
+    self.verification_options.custom_headers.insert(header_name.to_string(), header_value.to_string());
   }
 }
 

--- a/rust/pact_ffi/src/verifier/handle.rs
+++ b/rust/pact_ffi/src/verifier/handle.rs
@@ -1,9 +1,7 @@
 //! Handle interface to creating a verifier
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use itertools::Itertools;
-use libc::clone;
 
 use log::debug;
 use pact_models::prelude::HttpAuth;

--- a/rust/pact_ffi/src/verifier/mod.rs
+++ b/rust/pact_ffi/src/verifier/mod.rs
@@ -311,6 +311,26 @@ ffi_fn! {
 }
 
 ffi_fn! {
+    /// Adds a custom header to be added to the requests made to the provider.
+    ///
+    /// # Safety
+    ///
+    /// The header name and value must point to a valid NULL terminated string and must contain
+    /// valid UTF-8.
+    fn pactffi_verifier_add_custom_header(
+      handle: *mut handle::VerifierHandle,
+      header_name: *const c_char,
+      header_value: *const c_char
+    ) {
+      let handle = as_mut!(handle);
+      let header_name = safe_str!(header_name);
+      let header_value = safe_str!(header_value);
+
+      handle.add_custom_header(header_name, header_value);
+    }
+}
+
+ffi_fn! {
     /// Adds a Pact file as a source to verify.
     ///
     /// # Safety

--- a/rust/pact_ffi/src/verifier/verifier.rs
+++ b/rust/pact_ffi/src/verifier/verifier.rs
@@ -222,7 +222,8 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
       request_filter: None::<Arc<NullRequestFilterExecutor>>,
       disable_ssl_verification: matches.is_present("disable-ssl-verification"),
       request_timeout: matches.value_of("request-timeout")
-        .map(|t| t.parse::<u64>().unwrap_or(5000)).unwrap_or(5000)
+        .map(|t| t.parse::<u64>().unwrap_or(5000)).unwrap_or(5000),
+      custom_headers: Default::default()
     };
 
     let publish_options = if matches.is_present("publish") {

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -562,6 +562,8 @@ pub struct VerificationOptions<F> where F: RequestFilterExecutor {
   pub disable_ssl_verification: bool,
   /// Timeout in ms for verification requests and state callbacks
   pub request_timeout: u64,
+  /// Custom headers to be added to the requests to the provider
+  pub custom_headers: HashMap<String, String>
 }
 
 impl <F: RequestFilterExecutor> Default for VerificationOptions<F> {
@@ -569,7 +571,8 @@ impl <F: RequestFilterExecutor> Default for VerificationOptions<F> {
     VerificationOptions {
       request_filter: None,
       disable_ssl_verification: false,
-      request_timeout: 5000
+      request_timeout: 5000,
+      custom_headers: Default::default()
     }
   }
 }

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -13,19 +13,14 @@ use std::time::Duration;
 
 use ansi_term::*;
 use ansi_term::Colour::*;
+use anyhow::anyhow;
 use futures::prelude::*;
 use futures::stream::StreamExt;
+use http::{header, HeaderMap};
+use http::header::HeaderName;
 use itertools::Itertools;
 use log::*;
 use maplit::*;
-use pact_plugin_driver::plugin_manager::{load_plugin, shutdown_plugins};
-use regex::Regex;
-use serde_json::Value;
-
-pub use callback_executors::NullRequestFilterExecutor;
-use callback_executors::RequestFilterExecutor;
-use pact_matching::{match_response, Mismatch};
-use pact_matching::logging::LOG_ID;
 use pact_models::generators::GeneratorTestMode;
 use pact_models::http_utils::HttpAuth;
 use pact_models::interaction::Interaction;
@@ -34,16 +29,24 @@ use pact_models::pact::{load_pact_from_url, Pact, read_pact};
 use pact_models::prelude::v4::SynchronousHttp;
 use pact_models::provider_states::*;
 use pact_models::v4::interaction::V4Interaction;
+use pact_plugin_driver::plugin_manager::{load_plugin, shutdown_plugins};
+use pact_plugin_driver::plugin_models::{PluginDependency, PluginDependencyType};
+use regex::Regex;
+use serde_json::Value;
+
+pub use callback_executors::NullRequestFilterExecutor;
+use callback_executors::RequestFilterExecutor;
+use pact_matching::{match_response, Mismatch};
+use pact_matching::logging::LOG_ID;
+use pact_matching::metrics::{MetricEvent, send_metrics};
 
 use crate::callback_executors::{ProviderStateError, ProviderStateExecutor};
 use crate::messages::{process_message_result, verify_message_from_provider, verify_sync_message_from_provider};
+use crate::metrics::VerificationMetrics;
 use crate::pact_broker::{Link, PactVerificationContext, publish_verification_results, TestResult};
 pub use crate::pact_broker::{ConsumerVersionSelector, PactsForVerificationRequest};
 use crate::provider_client::make_provider_request;
 use crate::request_response::process_request_response_result;
-use pact_plugin_driver::plugin_models::{PluginDependency, PluginDependencyType};
-use pact_matching::metrics::{MetricEvent, send_metrics};
-use crate::metrics::VerificationMetrics;
 use crate::verification_result::VerificationExecutionResult;
 
 mod provider_client;
@@ -302,11 +305,21 @@ async fn verify_interaction<'a, F: RequestFilterExecutor, S: ProviderStateExecut
   options: &VerificationOptions<F>,
   provider_state_executor: &Arc<S>
 ) -> Result<Option<String>, MismatchResult> {
-  let client = Arc::new(reqwest::Client::builder()
-  .danger_accept_invalid_certs(options.disable_ssl_verification)
-  .timeout(Duration::from_millis(options.request_timeout))
-  .build()
-  .unwrap_or(reqwest::Client::new()));
+  let mut client_builder = reqwest::Client::builder()
+    .danger_accept_invalid_certs(options.disable_ssl_verification)
+    .timeout(Duration::from_millis(options.request_timeout));
+
+  if !options.custom_headers.is_empty() {
+    let headers = match setup_custom_headers(&options.custom_headers) {
+      Ok(headers) => headers,
+      Err(err) => {
+        return Err(MismatchResult::Error(err.to_string(), interaction.id()));
+      }
+    };
+    client_builder = client_builder.default_headers(headers);
+  }
+
+  let client = Arc::new(client_builder.build().unwrap_or(reqwest::Client::new()));
 
   let mut provider_states_results = hashmap!{};
   let sc_results = futures::stream::iter(
@@ -383,6 +396,26 @@ async fn verify_interaction<'a, F: RequestFilterExecutor, S: ProviderStateExecut
   }
 
   result
+}
+
+fn setup_custom_headers(custom_headers: &HashMap<String, String>) -> anyhow::Result<HeaderMap> {
+  let mut headers = header::HeaderMap::new();
+  for (key, value) in custom_headers {
+    let header_name = match HeaderName::try_from(key) {
+      Ok(name) => name,
+      Err(err) => {
+        return Err(anyhow!("Custom header '{key}' is invalid. Only ASCII characters (32-127) are permitted - {err}"));
+      }
+    };
+    let header_value = match header::HeaderValue::from_str(value.as_str()) {
+      Ok(value) => value,
+      Err(err) => {
+        return Err(anyhow!("Custom header '{key}' has an invalid value '{value}'. Only ASCII characters (32-127) are permitted - {err}"));
+      }
+    };
+    headers.append(header_name, header_value);
+  }
+  Ok(headers)
 }
 
 fn generate_display_for_result(

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -25,6 +25,7 @@ simplelog = "0.10.2"
 serde_json = "1.0.78"
 anyhow = "1.0.53"
 ansi_term = "0.12.1"
+maplit = "1.0.2"
 
 [dev-dependencies]
 expectest = "0.12.0"

--- a/rust/pact_verifier_cli/src/args.rs
+++ b/rust/pact_verifier_cli/src/args.rs
@@ -242,6 +242,13 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .number_of_values(1)
       .empty_values(false)
       .help("Generate a JSON report of the verification"))
+    .arg(Arg::with_name("custom-header")
+      .long("header")
+      .takes_value(true)
+      .use_delimiter(false)
+      .multiple(true)
+      .empty_values(false)
+      .help("Add a custom header to be included in the calls to the provider. Values must be in the form KEY=VALUE, where KEY and VALUE contain ASCII characters (32-127) only. Can be repeated."))
 }
 
 #[cfg(test)]

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -334,6 +334,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
     disable_ssl_verification: matches.is_present("disable-ssl-verification"),
     request_timeout: matches.value_of("request-timeout")
       .map(|t| t.parse::<u64>().unwrap_or(5000)).unwrap_or(5000),
+    custom_headers: Default::default()
   };
 
   let publish_options = if matches.is_present("publish") {
@@ -364,7 +365,7 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
       test_framework: "pact_verifier_cli".to_string(),
       app_name: "pact_verifier_cli".to_string(),
       app_version: env!("CARGO_PKG_VERSION").to_string()
-    })
+    }),
   ).await
     .map_err(|err| {
       error!("Verification failed with error: {}", err);

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -11,7 +11,7 @@
 //! The pact verifier is bundled as a single binary executable `pact_verifier_cli`. Running this with out any options displays the standard help.
 //!
 //! ```console,ignore
-//! pact_verifier_cli 0.9.7
+//! pact_verifier_cli 0.9.8
 //! Standalone Pact verifier
 //!
 //! USAGE:
@@ -42,6 +42,9 @@
 //!         --consumer-version-tags <consumer-version-tags>
 //!             Consumer tags to use when fetching pacts from the Broker. Accepts comma-separated values.
 //!
+//!         --header <custom-header>...
+//!             Add a custom header to be included in the calls to the provider. Values must be in the form KEY=VALUE, where
+//!             KEY and VALUE contain ASCII characters (32-127) only. Can be repeated.
 //!     -d, --dir <dir>...
 //!             Directory of pact files to verify (can be repeated)
 //!
@@ -262,13 +265,22 @@ use std::time::Duration;
 
 use clap::{AppSettings, ArgMatches, ErrorKind};
 use log::{debug, error, LevelFilter, warn};
+use maplit::hashmap;
 use pact_models::{PACT_RUST_VERSION, PactSpecification};
 use pact_models::prelude::HttpAuth;
 use serde_json::Value;
 use simplelog::{ColorChoice, Config, TerminalMode, TermLogger};
 use tokio::time::sleep;
 
-use pact_verifier::{FilterInfo, NullRequestFilterExecutor, PactSource, ProviderInfo, VerificationOptions, verify_provider_async, PublishOptions};
+use pact_verifier::{
+  FilterInfo,
+  NullRequestFilterExecutor,
+  PactSource,
+  ProviderInfo,
+  PublishOptions,
+  VerificationOptions,
+  verify_provider_async
+};
 use pact_verifier::callback_executors::HttpRequestProviderStateExecutor;
 use pact_verifier::metrics::VerificationMetrics;
 use pact_verifier::selectors::{consumer_tags_to_selectors, json_to_selectors};
@@ -329,12 +341,23 @@ async fn handle_matches(matches: &clap::ArgMatches<'_>) -> Result<(), i32> {
     state_change_teardown: matches.is_present("state-change-teardown")
   });
 
+  let mut custom_headers = hashmap!{};
+  if let Some(headers) = matches.values_of("custom-header") {
+    for header in headers {
+      let (key, value) = header.split_once('=').ok_or_else(|| {
+        error!("Custom header values must be in the form KEY=VALUE, where KEY and VALUE contain ASCII characters (32-127) only.");
+        3
+      })?;
+      custom_headers.insert(key.to_string(), value.to_string());
+    }
+  }
+
   let verification_options = VerificationOptions {
     request_filter: None::<Arc<NullRequestFilterExecutor>>,
     disable_ssl_verification: matches.is_present("disable-ssl-verification"),
     request_timeout: matches.value_of("request-timeout")
       .map(|t| t.parse::<u64>().unwrap_or(5000)).unwrap_or(5000),
-    custom_headers: Default::default()
+    custom_headers
   };
 
   let publish_options = if matches.is_present("publish") {


### PR DESCRIPTION
This adds a new function to set custom headers: 
```
pactffi_verifier_add_custom_header(
      handle: *mut handle::VerifierHandle,
      header_name: *const c_char,
      header_value: *const c_char
    )
```

Resolves #182 
