### PR TITLE
Removed dependency on time v0.1

### DIFF
--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -33,7 +33,7 @@ difference = "2.0.0"
 base64 = "0.13.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 nom = "7.1.1"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", features = ["std", "clock"], default_features = false }
 tree_magic_mini = "3.0.3"
 multipart = { version = "0.18.0", default-features = false, features = ["server"] }
 http = "0.2.7"

--- a/rust/pact_models/Cargo.toml
+++ b/rust/pact_models/Cargo.toml
@@ -26,7 +26,7 @@ mime = "0.3.16"
 base64 = "0.13.0"
 regex = "1.5.5"
 nom = "7.1.1"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", features = ["std", "clock"], default-features = false }
 chrono-tz = "0.6.1"
 lenient_semver = "0.4.2"
 sxd-document = "0.3.2"


### PR DESCRIPTION
This solves https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md