### PR TITLE
Feat/verifier multiple transports

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -209,9 +209,34 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1175,6 +1200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1252,7 @@ version = "0.0.0"
 dependencies = [
  "ansi_term",
  "anyhow",
- "clap",
+ "clap 2.34.0",
  "expectest",
  "glob",
  "log",
@@ -1273,7 +1304,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "clap",
+ "clap 2.34.0",
  "either",
  "env_logger 0.9.0",
  "expectest",
@@ -1431,7 +1462,7 @@ name = "pact_mock_server_cli"
 version = "0.7.8"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 2.34.0",
  "expectest",
  "futures",
  "http",
@@ -1614,7 +1645,7 @@ version = "0.9.13"
 dependencies = [
  "ansi_term",
  "anyhow",
- "clap",
+ "clap 3.2.16",
  "env_logger 0.9.0",
  "expectest",
  "log",
@@ -2450,6 +2481,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
  "glob",
  "log",
  "maplit",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_models 0.4.1",
  "serde",
  "serde_json",
@@ -1278,7 +1278,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_mock_server",
  "pact_models 0.4.1",
  "quickcheck",
@@ -1317,10 +1317,10 @@ dependencies = [
  "onig",
  "os_info",
  "pact-plugin-driver",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_mock_server",
  "pact_models 0.4.1",
- "pact_verifier 0.13.10",
+ "pact_verifier",
  "quickcheck",
  "rand",
  "rand_regex",
@@ -1340,44 +1340,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "zeroize",
-]
-
-[[package]]
-name = "pact_matching"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050ab620e524609ed9dd5918a13c51c92f43eac6a77c70cb73f1f082edad6a5"
-dependencies = [
- "ansi_term",
- "anyhow",
- "base64",
- "bytes",
- "chrono",
- "difference",
- "hex",
- "http",
- "itertools",
- "lazy_static",
- "lenient_semver",
- "maplit",
- "md5",
- "mime",
- "multipart",
- "nom",
- "onig",
- "pact-plugin-driver",
- "pact_models 0.4.1",
- "rand",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "sxd-document",
- "tokio",
- "tracing",
- "tracing-core",
- "tree_magic_mini",
- "uuid",
 ]
 
 [[package]]
@@ -1439,7 +1401,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_models 0.4.1",
  "quickcheck",
  "reqwest",
@@ -1472,7 +1434,7 @@ dependencies = [
  "libc",
  "log",
  "maplit",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_mock_server",
  "pact_models 0.4.1",
  "quickcheck",
@@ -1571,40 +1533,6 @@ dependencies = [
 
 [[package]]
 name = "pact_verifier"
-version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03d44d6cc63f8ec6a8b06e9578fc11a8bb5f2cc1f8412b8e3fb84ec0e8ecac2"
-dependencies = [
- "ansi_term",
- "anyhow",
- "async-trait",
- "base64",
- "bytes",
- "difference",
- "futures",
- "http",
- "itertools",
- "lazy_static",
- "libc",
- "maplit",
- "mime",
- "pact-plugin-driver",
- "pact_matching 0.12.9",
- "pact_models 0.4.1",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-core",
- "urlencoding",
-]
-
-[[package]]
-name = "pact_verifier"
 version = "0.13.10"
 dependencies = [
  "ansi_term",
@@ -1624,7 +1552,7 @@ dependencies = [
  "mime",
  "pact-plugin-driver",
  "pact_consumer",
- "pact_matching 0.12.10",
+ "pact_matching",
  "pact_models 0.4.1",
  "quickcheck",
  "regex",
@@ -1632,6 +1560,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -1651,7 +1580,7 @@ dependencies = [
  "log",
  "maplit",
  "pact_models 0.4.1",
- "pact_verifier 0.13.9",
+ "pact_verifier",
  "regex",
  "reqwest",
  "serde_json",

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -19,6 +19,9 @@ pub struct InteractionBuilder {
     comments: Vec<String>,
     test_name: Option<String>,
 
+    /// Protocol transport for this interaction
+    transport: Option<String>,
+
     /// A builder for this interaction's `Request`.
     pub request: RequestBuilder,
 
@@ -37,6 +40,7 @@ impl InteractionBuilder {
       provider_states: vec![],
       comments: vec![],
       test_name: None,
+      transport: None,
       request: RequestBuilder::default(),
       response: ResponseBuilder::default(),
     }
@@ -62,6 +66,13 @@ impl InteractionBuilder {
   /// page, and potentially in the test output.
   pub fn test_name<G: Into<String>>(&mut self, name: G) -> &mut Self {
     self.test_name = Some(name.into());
+    self
+  }
+
+  /// Sets the protocol transport for this interaction. This would be required when there are
+  /// different types of interactions in the Pact file (i.e. HTTP and messages).
+  pub fn transport<G: Into<String>>(&mut self, name: G) -> &mut Self {
+    self.transport = Some(name.into());
     self
   }
 
@@ -94,7 +105,7 @@ impl InteractionBuilder {
       pending: false,
       plugin_config: self.plugin_config(),
       interaction_markup: self.request.interaction_markup().merge(self.response.interaction_markup()),
-      transport: None
+      transport: self.transport.clone()
     }
   }
 

--- a/rust/pact_ffi/src/verifier/handle.rs
+++ b/rust/pact_ffi/src/verifier/handle.rs
@@ -82,9 +82,10 @@ impl VerifierHandle {
       port: port.clone(),
       path: path.clone(),
       transports: vec![ ProviderTransport {
-        transport: scheme,
+        transport: scheme.clone(),
         port,
-        path: if path.is_empty() { None } else { Some(path) }
+        path: if path.is_empty() { None } else { Some(path) },
+        scheme: None
       } ]
     }
   }

--- a/rust/pact_ffi/src/verifier/handle.rs
+++ b/rust/pact_ffi/src/verifier/handle.rs
@@ -7,16 +7,7 @@ use pact_models::prelude::HttpAuth;
 use serde_json::Value;
 use tracing::debug;
 
-use pact_verifier::{
-  ConsumerVersionSelector,
-  FilterInfo,
-  NullRequestFilterExecutor,
-  PactSource,
-  ProviderInfo,
-  PublishOptions,
-  VerificationOptions,
-  verify_provider_async
-};
+use pact_verifier::{ConsumerVersionSelector, FilterInfo, NullRequestFilterExecutor, PactSource, ProviderInfo, ProviderTransport, PublishOptions, VerificationOptions, verify_provider_async};
 use pact_verifier::callback_executors::HttpRequestProviderStateExecutor;
 use pact_verifier::metrics::VerificationMetrics;
 use pact_verifier::verification_result::VerificationExecutionResult;
@@ -83,12 +74,18 @@ impl VerifierHandle {
     port: u16,
     path: String
   ) {
+    let port = if port == 0 { None } else { Some(port) };
     self.provider = ProviderInfo {
       name,
-      protocol: scheme,
+      protocol: scheme.clone(),
       host,
-      port: if port == 0 { None } else { Some(port) },
-      path
+      port: port.clone(),
+      path: path.clone(),
+      transports: vec![ ProviderTransport {
+        transport: scheme,
+        port,
+        path: if path.is_empty() { None } else { Some(path) }
+      } ]
     }
   }
 

--- a/rust/pact_verifier/Cargo.toml
+++ b/rust/pact_verifier/Cargo.toml
@@ -57,3 +57,4 @@ quickcheck = "1"
 expectest = "0.12.0"
 env_logger = "0.8"
 pact_consumer = { version = "0.9.5", path = "../pact_consumer" }
+test-log = "0.2.11"

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -44,7 +44,7 @@ use pact_matching::logging::LOG_ID;
 use pact_matching::metrics::{MetricEvent, send_metrics};
 
 use crate::callback_executors::{ProviderStateError, ProviderStateExecutor};
-use crate::messages::{process_message_result, verify_message_from_provider, verify_sync_message_from_provider};
+use crate::messages::{process_message_result, process_sync_message_result, verify_message_from_provider, verify_sync_message_from_provider};
 use crate::metrics::VerificationMetrics;
 use crate::pact_broker::{Link, PactVerificationContext, publish_verification_results, TestResult};
 pub use crate::pact_broker::{ConsumerVersionSelector, PactsForVerificationRequest};
@@ -1257,11 +1257,15 @@ pub async fn verify_pact_internal<'a, F: RequestFilterExecutor, S: ProviderState
       }
     };
 
+    // TODO: Update this to use V4 models
     if let Some(interaction) = interaction.as_request_response() {
-      process_request_response_result(&interaction, &match_result, &mut output, options.coloured_output)
+      process_request_response_result(&interaction, &match_result, &mut output, options.coloured_output);
     }
     if let Some(interaction) = interaction.as_message() {
-      process_message_result(&interaction, &match_result, &mut output, options.coloured_output)
+      process_message_result(&interaction, &match_result, &mut output, options.coloured_output);
+    }
+    if let Some(interaction) = interaction.as_v4_sync_message() {
+      process_sync_message_result(&interaction, &match_result, &mut output, options.coloured_output);
     }
 
     match match_result {

--- a/rust/pact_verifier/src/messages.rs
+++ b/rust/pact_verifier/src/messages.rs
@@ -50,7 +50,17 @@ pub(crate) async fn verify_message_from_provider<'a, F: RequestFilterExecutor>(
     .. HttpRequest::default()
   };
 
-  match make_provider_request(provider, &message_request, options, client).await {
+  let transport = if interaction.is_v4() {
+    if let Some(v4) = interaction.as_v4() {
+      v4.transport().clone()
+    } else {
+      None
+    }
+  } else {
+    None
+  };
+
+  match make_provider_request(provider, &message_request, options, client, transport).await {
     Ok(ref actual_response) => {
       let metadata = extract_metadata(actual_response);
       let actual = AsynchronousMessage {
@@ -211,7 +221,7 @@ pub(crate) async fn verify_sync_message_from_provider<'a, F: RequestFilterExecut
     .. HttpRequest::default()
   };
 
-  match make_provider_request(provider, &message_request, options, client).await {
+  match make_provider_request(provider, &message_request, options, client, message.transport.clone()).await {
     Ok(ref actual_response) => {
       if actual_response.is_success() {
         let metadata = extract_metadata(actual_response);

--- a/rust/pact_verifier/src/provider_client.rs
+++ b/rust/pact_verifier/src/provider_client.rs
@@ -182,10 +182,14 @@ pub async fn make_provider_request<F: RequestFilterExecutor>(
     request.clone()
   };
 
-  let base_url = match provider.port {
-    Some(port) => format!("{}://{}:{}{}", provider.protocol, provider.host, port, provider.path),
-    None => format!("{}://{}{}", provider.protocol, provider.host, provider.path),
-  };
+  let base_url = provider.transports.first()
+    .map(|trans| trans.base_url(&provider.host))
+    .unwrap_or_else(|| {
+      match provider.port {
+        Some(port) => format!("{}://{}:{}{}", provider.protocol, provider.host, port, provider.path),
+        None => format!("{}://{}{}", provider.protocol, provider.host, provider.path),
+      }
+    });
 
   info!("Sending request to provider at {base_url}");
   debug!("Provider details = {provider:?}");

--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -520,28 +520,32 @@ fn transport_base_url_test() {
   let transport = ProviderTransport {
     transport: "https".to_string(),
     port: None,
-    path: None
+    path: None,
+    scheme: Some("https".to_string())
   };
   expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST"));
 
   let transport = ProviderTransport {
     transport: "https".to_string(),
     port: None,
-    path: Some("/a/b/c".to_string())
+    path: Some("/a/b/c".to_string()),
+    scheme: Some("https".to_string())
   };
   expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST/a/b/c"));
 
   let transport = ProviderTransport {
     transport: "https".to_string(),
     port: Some(5678),
-    path: None
+    path: None,
+    scheme: Some("https".to_string())
   };
   expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST:5678"));
 
   let transport = ProviderTransport {
     transport: "https".to_string(),
     port: Some(7765),
-    path: Some("/a/b/c".to_string())
+    path: Some("/a/b/c".to_string()),
+    scheme: None
   };
-  expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST:7765/a/b/c"));
+  expect!(transport.base_url("HOST")).to(be_equal_to("http://HOST:7765/a/b/c"));
 }

--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -19,7 +19,7 @@ use pact_models::sync_pact::RequestResponsePact;
 
 use crate::callback_executors::HttpRequestProviderStateExecutor;
 use crate::pact_broker::Link;
-use crate::PactSource;
+use crate::{PactSource, ProviderTransport};
 
 use super::{execute_state_change, filter_consumers, filter_interaction, FilterInfo};
 
@@ -203,10 +203,8 @@ async fn test_state_change_with_parameters_in_query() {
   expect!(result.clone()).to(be_ok());
 }
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_state_change_returning_json_values() {
-  try_init().unwrap_or(());
-
   let server = PactBuilder::new("RustPactVerifier", "SomeRunningProvider")
     .interaction("a state change request which returns a map of values", "", |mut i| async move {
       i.request.method("POST");
@@ -512,4 +510,38 @@ async fn test_fetch_pact_from_url_with_links() {
   let first_result = result.get(0).unwrap().as_ref();
   let source = &first_result.clone().unwrap();
   expect(source.2.to_string().starts_with("PactBroker(")).to(be_true());
+}
+
+#[test]
+fn transport_base_url_test() {
+  let transport = ProviderTransport::default();
+  expect!(transport.base_url("HOST")).to(be_equal_to("http://HOST:8080"));
+
+  let transport = ProviderTransport {
+    transport: "https".to_string(),
+    port: None,
+    path: None
+  };
+  expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST"));
+
+  let transport = ProviderTransport {
+    transport: "https".to_string(),
+    port: None,
+    path: Some("/a/b/c".to_string())
+  };
+  expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST/a/b/c"));
+
+  let transport = ProviderTransport {
+    transport: "https".to_string(),
+    port: Some(5678),
+    path: None
+  };
+  expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST:5678"));
+
+  let transport = ProviderTransport {
+    transport: "https".to_string(),
+    port: Some(7765),
+    path: Some("/a/b/c".to_string())
+  };
+  expect!(transport.base_url("HOST")).to(be_equal_to("https://HOST:7765/a/b/c"));
 }

--- a/rust/pact_verifier/tests/tests.rs
+++ b/rust/pact_verifier/tests/tests.rs
@@ -45,10 +45,8 @@ impl ProviderStateExecutor for DummyProviderStateExecutor {
     }
 }
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn verify_pact_with_match_values_matcher() {
-  try_init().unwrap_or(());
-
   let server = PactBuilder::new("consumer", "matchValuesService")
     .interaction("request requiring matching values", "", |mut i| async move {
       i.test_name("verify_pact_with_match_values_matcher");

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -18,7 +18,7 @@ pact_models = "=0.4.1"
 pact_verifier = "=0.13.9"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls-native-roots", "blocking", "json"] }
-clap = "2.33.4"
+clap = { version = "3.2.16", features = ["cargo", "env"] }
 regex = "1.5.4"
 log = "0.4.17"
 serde_json = "1.0.79"

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 pact_models = "=0.4.1"
-pact_verifier = "=0.13.9"
+pact_verifier = { version = "0.13.10", path = "../pact_verifier" }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls-native-roots", "blocking", "json"] }
 clap = { version = "3.2.16", features = ["cargo", "env"] }

--- a/rust/pact_verifier_cli/src/args.rs
+++ b/rust/pact_verifier_cli/src/args.rs
@@ -1,28 +1,28 @@
 use clap::{App, Arg};
 use regex::Regex;
 
-fn port_value(v: String) -> Result<(), String> {
+fn port_value(v: &str) -> Result<(), String> {
   v.parse::<u16>().map(|_| ()).map_err(|e| format!("'{}' is not a valid port value: {}", v, e) )
 }
 
-fn integer_value(v: String) -> Result<(), String> {
+fn integer_value(v: &str) -> Result<(), String> {
   v.parse::<u64>().map(|_| ()).map_err(|e| format!("'{}' is not a valid integer value: {}", v, e) )
 }
 
-pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b> {
+pub(crate) fn setup_app(program: String, version: &str) -> App {
   App::new(program)
     .version(version)
     .about("Standalone Pact verifier")
-    .version_short("v")
+    .version_short('v')
     .arg(Arg::with_name("loglevel")
-      .short("l")
+      .short('l')
       .long("loglevel")
       .takes_value(true)
       .use_delimiter(false)
       .possible_values(&["error", "warn", "info", "debug", "trace", "none"])
       .help("Log level (defaults to warn)"))
     .arg(Arg::with_name("file")
-      .short("f")
+      .short('f')
       .long("file")
       .required_unless_one(&["dir", "url", "broker-url"])
       .takes_value(true)
@@ -32,7 +32,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .empty_values(false)
       .help("Pact file to verify (can be repeated)"))
     .arg(Arg::with_name("dir")
-      .short("d")
+      .short('d')
       .long("dir")
       .required_unless_one(&["file", "url", "broker-url"])
       .takes_value(true)
@@ -42,7 +42,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .empty_values(false)
       .help("Directory of pact files to verify (can be repeated)"))
     .arg(Arg::with_name("url")
-      .short("u")
+      .short('u')
       .long("url")
       .required_unless_one(&["file", "dir", "broker-url"])
       .takes_value(true)
@@ -52,7 +52,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .empty_values(false)
       .help("URL of pact file to verify (can be repeated)"))
     .arg(Arg::with_name("broker-url")
-      .short("b")
+      .short('b')
       .long("broker-url")
       .env("PACT_BROKER_BASE_URL")
       .required_unless_one(&["file", "dir", "url"])
@@ -62,13 +62,13 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .empty_values(false)
       .help("URL of the pact broker to fetch pacts from to verify (requires the provider name parameter)"))
     .arg(Arg::with_name("hostname")
-      .short("h")
+      .short('h')
       .long("hostname")
       .takes_value(true)
       .use_delimiter(false)
       .help("Provider hostname (defaults to localhost)"))
     .arg(Arg::with_name("port")
-      .short("p")
+      .short('p')
       .long("port")
       .takes_value(true)
       .use_delimiter(false)
@@ -81,13 +81,13 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .default_value("http")
       .help("Provider protocol transport to use (http, https, grpc, etc.)"))
     .arg(Arg::with_name("provider-name")
-      .short("n")
+      .short('n')
       .long("provider-name")
       .takes_value(true)
       .use_delimiter(false)
       .help("Provider name (defaults to provider)"))
     .arg(Arg::with_name("state-change-url")
-      .short("s")
+      .short('s')
       .long("state-change-url")
       .takes_value(true)
       .use_delimiter(false)
@@ -123,7 +123,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .conflicts_with("filter-state")
       .help("Only validate interactions that have no defined provider state"))
     .arg(Arg::with_name("filter-consumer")
-      .short("c")
+      .short('c')
       .long("filter-consumer")
       .takes_value(true)
       .multiple(true)
@@ -148,7 +148,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .conflicts_with("token")
       .help("Password to use when fetching pacts from URLS"))
     .arg(Arg::with_name("token")
-      .short("t")
+      .short('t')
       .long("token")
       .env("PACT_BROKER_TOKEN")
       .takes_value(true)
@@ -234,7 +234,7 @@ pub(crate) fn setup_app<'a, 'b>(program: String, version: &'b str) -> App<'a, 'b
       .validator(integer_value)
       .help("Sets the HTTP request timeout in milliseconds for requests to the target API and for state change requests."))
     .arg(Arg::with_name("json-file")
-      .short("j")
+      .short('j')
       .long("json")
       .takes_value(true)
       .use_delimiter(false)
@@ -262,13 +262,13 @@ mod test {
 
   #[test]
   fn validates_port_value() {
-    expect!(port_value("1234".to_string())).to(be_ok());
-    expect!(port_value("1234x".to_string())).to(be_err());
+    expect!(port_value("1234")).to(be_ok());
+    expect!(port_value("1234x")).to(be_err());
   }
 
   #[test]
   fn validates_integer_value() {
-    expect!(integer_value("3000000".to_string())).to(be_ok());
-    expect!(integer_value("1234x".to_string())).to(be_err());
+    expect!(integer_value("3000000")).to(be_ok());
+    expect!(integer_value("1234x")).to(be_err());
   }
 }

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -471,7 +471,8 @@ pub(crate) fn configure_provider(matches: &ArgMatches) -> ProviderInfo {
         ProviderTransport {
           transport: transport.to_string(),
           port: Some(*port),
-          path: None
+          path: None,
+          scheme: None
         }
       }).collect()
     }).unwrap_or_default();

--- a/rust/pact_verifier_cli/src/main.rs
+++ b/rust/pact_verifier_cli/src/main.rs
@@ -11,91 +11,132 @@
 //! The pact verifier is bundled as a single binary executable `pact_verifier_cli`. Running this with out any options displays the standard help.
 //!
 //! ```console,ignore
-//! pact_verifier_cli 0.9.10
+//! pact_verifier_cli 0.9.13
 //! Standalone Pact verifier
 //!
 //! USAGE:
-//!     pact_verifier_cli [FLAGS] [OPTIONS] --broker-url <broker-url> --dir <dir>... --file <file>... --provider-name <provider-name> --url <url>...
-//!
-//! FLAGS:
-//!         --disable-ssl-verification    Disables validation of SSL certificates
-//!         --enable-pending              Enables Pending Pacts
-//!         --help                        Prints help information
-//!         --publish                     Enables publishing of verification results back to the Pact Broker. Requires the
-//!                                       broker-url and provider-version parameters.
-//!         --state-change-as-query       State change request data will be sent as query parameters instead of in the
-//!                                       request body
-//!         --state-change-teardown       State change teardown requests are to be made after each interaction
-//!     -v, --version                     Prints version information
+//!     pact_verifier_cli [OPTIONS]
 //!
 //! OPTIONS:
-//!         --base-path <base-path>                                         Base path to add to all requests
 //!     -b, --broker-url <broker-url>
-//!             URL of the pact broker to fetch pacts from to verify (requires the provider name parameter) [env:
-//!             PACT_BROKER_BASE_URL=]
+//!             URL of the pact broker to fetch pacts from to verify (requires the provider name
+//!             parameter) [env: PACT_BROKER_BASE_URL=]
+//!
+//!         --base-path <base-path>
+//!             Base path to add to all requests
+//!
 //!         --build-url <build-url>
 //!             URL of the build to associate with the published verification results.
 //!
-//!         --consumer-version-selectors <consumer-version-selectors>...
-//!             Consumer version selectors to use when fetching pacts from the Broker. Accepts a JSON string as per
-//!             https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/
-//!         --consumer-version-tags <consumer-version-tags>
-//!             Consumer tags to use when fetching pacts from the Broker. Accepts comma-separated values.
-//!
-//!         --header <custom-header>...
-//!             Add a custom header to be included in the calls to the provider. Values must be in the form KEY=VALUE, where
-//!             KEY and VALUE contain ASCII characters (32-127) only. Can be repeated.
-//!     -d, --dir <dir>...
-//!             Directory of pact files to verify (can be repeated)
-//!
-//!     -f, --file <file>...                                                Pact file to verify (can be repeated)
 //!     -c, --filter-consumer <filter-consumer>...
 //!             Consumer name to filter the pacts to be verified (can be repeated)
+//!
+//!         --consumer-version-selectors <consumer-version-selectors>
+//!             Consumer version selectors to use when fetching pacts from the Broker. Accepts a JSON
+//!             string as per
+//!             https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/
+//!
+//!         --consumer-version-tags <consumer-version-tags>
+//!             Consumer tags to use when fetching pacts from the Broker. Accepts comma-separated
+//!             values.
+//!
+//!     -d, --dir <dir>
+//!             Directory of pact files to verify (can be repeated)
+//!
+//!         --disable-ssl-verification
+//!             Disables validation of SSL certificates
+//!
+//!         --enable-pending
+//!             Enables Pending Pacts
+//!
+//!     -f, --file <file>
+//!             Pact file to verify (can be repeated)
 //!
 //!         --filter-description <filter-description>
 //!             Only validate interactions whose descriptions match this filter [env: PACT_DESCRIPTION=]
 //!
-//!         --filter-no-state <filter-no-state>
-//!             Only validate interactions that have no defined provider state [env: PACT_PROVIDER_NO_STATE=]
+//!         --filter-no-state
+//!             Only validate interactions that have no defined provider state [env:
+//!             PACT_PROVIDER_NO_STATE=]
 //!
 //!         --filter-state <filter-state>
-//!             Only validate interactions whose provider states match this filter [env: PACT_PROVIDER_STATE=]
+//!             Only validate interactions whose provider states match this filter [env:
+//!             PACT_PROVIDER_STATE=]
 //!
-//!     -h, --hostname <hostname>                                           Provider hostname (defaults to localhost)
+//!     -h, --hostname <hostname>
+//!             Provider hostname (defaults to localhost)
+//!
+//!         --header <custom-header>...
+//!             Add a custom header to be included in the calls to the provider. Values must be in the
+//!             form KEY=VALUE, where KEY and VALUE contain ASCII characters (32-127) only. Can be
+//!             repeated.
+//!
+//!         --help
+//!             Print help information
+//!
 //!         --include-wip-pacts-since <include-wip-pacts-since>
-//!             Allow pacts that don't match given consumer selectors (or tags) to  be verified, without causing the overall
-//!             task to fail. For more information, see https://pact.io/wip
-//!     -j, --json <json-file>                                              Generate a JSON report of the verification
+//!             Allow pacts that don't match given consumer selectors (or tags) to  be verified, without
+//!             causing the overall task to fail. For more information, see https://pact.io/wip
+//!
+//!     -j, --json <json-file>
+//!             Generate a JSON report of the verification
+//!
 //!     -l, --loglevel <loglevel>
-//!             Log level (defaults to warn) [possible values: error, warn, info, debug,
-//!             trace, none]
-//!         --password <password>
-//!             Password to use when fetching pacts from URLS [env: PACT_BROKER_PASSWORD=]
+//!             Log level (defaults to warn) [possible values: error, warn, info, debug, trace, none]
+//!
+//!     -n, --provider-name <provider-name>
+//!             Provider name (defaults to provider)
+//!
+//!         --no-colour
+//!             Disables ANSI escape codes in the output [aliases: no-color]
 //!
 //!     -p, --port <port>
 //!             Provider port (defaults to protocol default 80/443)
 //!
-//!         --provider-branch <provider-branch>                             Provider branch to use when publishing results
-//!     -n, --provider-name <provider-name>                                 Provider name (defaults to provider)
+//!         --password <password>
+//!             Password to use when fetching pacts from URLS [env: PACT_BROKER_PASSWORD=]
+//!
+//!         --provider-branch <provider-branch>
+//!             Provider branch to use when publishing results
+//!
 //!         --provider-tags <provider-tags>
 //!             Provider tags to use when publishing results. Accepts comma-separated values.
 //!
 //!         --provider-version <provider-version>
 //!             Provider version that is being verified. This is required when publishing results.
 //!
-//!         --request-timeout <request-timeout>
-//!             Sets the HTTP request timeout in milliseconds for requests to the target API and for state change requests.
+//!         --publish
+//!             Enables publishing of verification results back to the Pact Broker. Requires the
+//!             broker-url and provider-version parameters.
 //!
-//!     -s, --state-change-url <state-change-url>                           URL to post state change requests to
+//!         --request-timeout <request-timeout>
+//!             Sets the HTTP request timeout in milliseconds for requests to the target API and for
+//!             state change requests.
+//!
+//!     -s, --state-change-url <state-change-url>
+//!             URL to post state change requests to
+//!
+//!         --state-change-as-query
+//!             State change request data will be sent as query parameters instead of in the request
+//!             body
+//!
+//!         --state-change-teardown
+//!             State change teardown requests are to be made after each interaction
+//!
 //!     -t, --token <token>
 //!             Bearer token to use when fetching pacts from URLS [env: PACT_BROKER_TOKEN=]
 //!
 //!         --transport <transport>
 //!             Provider protocol transport to use (http, https, grpc, etc.) [default: http]
 //!
-//!     -u, --url <url>...                                                  URL of pact file to verify (can be repeated)
+//!     -u, --url <url>
+//!             URL of pact file to verify (can be repeated)
+//!
 //!         --user <user>
 //!             Username to use when fetching pacts from URLS [env: PACT_BROKER_USERNAME=]
+//!
+//!     -v, --version
+//!             Print version information
 //! ```
 //!
 //! ## Options
@@ -306,11 +347,11 @@ pub async fn handle_cli(version: &str) -> Result<(), i32> {
     Ok(results) => handle_matches(&results).await,
     Err(ref err) => {
       match err.kind {
-        ErrorKind::HelpDisplayed => {
-          println!("{}", err.message);
+        ErrorKind::DisplayHelp => {
+          let _ = err.print();
           Ok(())
         },
-        ErrorKind::VersionDisplayed => {
+        ErrorKind::DisplayVersion => {
           print_version(version);
           println!();
           Ok(())
@@ -323,7 +364,7 @@ pub async fn handle_cli(version: &str) -> Result<(), i32> {
   }
 }
 
-async fn handle_matches(matches: &ArgMatches<'_>) -> Result<(), i32> {
+async fn handle_matches(matches: &ArgMatches) -> Result<(), i32> {
   let coloured_output = !matches.is_present("no-colour");
   let level = matches.value_of("loglevel").unwrap_or("warn");
   let log_level = match level {
@@ -440,7 +481,7 @@ fn write_json_report(result: &VerificationExecutionResult, file_name: &str) -> a
 }
 
 fn print_version(version: &str) {
-  println!("\npact verifier version   : v{}", version);
+  println!("pact verifier version   : v{}", version);
   println!("pact specification      : v{}", PactSpecification::V4.version_str());
   println!("models version          : v{}", PACT_RUST_VERSION.unwrap_or_default());
 }


### PR DESCRIPTION
Updates the CLI verifier to support verifying Pacts were there are different interactions (i.e HTTP app and then a different proxy for the messages).

![image](https://user-images.githubusercontent.com/38309842/182540611-81ce8e18-31f2-4563-b1d4-48aa77a30a58.png)
