### PR TITLE
Feat/ffi plugin support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "cfg-if"
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -437,15 +437,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -827,9 +827,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "output_vt100"
@@ -1479,7 +1479,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "futures",
  "itertools",
@@ -1515,7 +1515,7 @@ dependencies = [
  "chrono-tz",
  "clap 2.34.0",
  "either",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "itertools",
  "lazy_static",
@@ -1562,7 +1562,7 @@ dependencies = [
  "bytes",
  "chrono",
  "difference",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "hamcrest2",
  "hex",
@@ -1602,7 +1602,7 @@ version = "0.9.5"
 dependencies = [
  "anyhow",
  "bytes",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "futures",
  "hyper",
@@ -1707,7 +1707,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "fs2",
  "hamcrest2",
@@ -1751,7 +1751,7 @@ dependencies = [
  "base64",
  "bytes",
  "difference",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "futures",
  "http",
@@ -1784,7 +1784,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "clap 3.2.23",
- "env_logger 0.9.1",
+ "env_logger 0.9.3",
  "expectest",
  "log",
  "maplit",

--- a/rust/pact_ffi/src/models/expressions.rs
+++ b/rust/pact_ffi/src/models/expressions.rs
@@ -481,9 +481,10 @@ mod tests {
     expect!(rule.is_null()).to(be_false());
     let r = unsafe { rule.as_ref() }.unwrap();
     match r {
-      MatchingRuleResult::MatchingRule(id, v, _p) => {
+      MatchingRuleResult::MatchingRule(id, v, p) => {
         expect!(*id).to(be_equal_to(3));
         expect!(v.is_null()).to(be_true());
+        expect!(p.is_null()).to(be_false());
       }
       MatchingRuleResult::MatchingReference(_) => {
         panic!("Expected a matching rule");

--- a/rust/pact_ffi/src/models/expressions.rs
+++ b/rust/pact_ffi/src/models/expressions.rs
@@ -1,0 +1,210 @@
+//! Functions for dealing with matching rule expressions
+
+use anyhow::Context;
+use either::Either;
+use libc::c_char;
+use pact_models::matchingrules::expressions::{
+  is_matcher_def,
+  MatchingRuleDefinition,
+  parse_matcher_def,
+  ValueType
+};
+use tracing::{debug, error};
+
+use crate::{as_ref, ffi_fn, safe_str};
+use crate::util::{ptr, string};
+
+/// Result of parsing a matching rule definition
+#[derive(Debug, Clone)]
+pub struct MatchingRuleDefinitionResult {
+  result: Either<String, MatchingRuleDefinition>
+}
+
+ffi_fn! {
+  /// Parse a matcher definition string into a MatchingRuleDefinition containing the example value,
+  /// and matching rules and any generator.
+  ///
+  /// The following are examples of matching rule definitions:
+  /// * `matching(type,'Name')` - type matcher with string value 'Name'
+  /// * `matching(number,100)` - number matcher
+  /// * `matching(datetime, 'yyyy-MM-dd','2000-01-01')` - datetime matcher with format string
+  ///
+  /// See [Matching Rule definition expressions](https://docs.rs/pact_models/latest/pact_models/matchingrules/expressions/index.html).
+  ///
+  /// The returned value needs to be freed up with the `pactffi_matcher_definition_delete` function.
+  ///
+  /// # Errors
+  /// If the expression is invalid, the MatchingRuleDefinition error will be set. You can check for
+  /// this value with the `pactffi_matcher_definition_error` function.
+  ///
+  /// # Safety
+  ///
+  /// This function is safe if the expression is a valid NULL terminated string pointer.
+  fn pactffi_parse_matcher_definition(expression: *const c_char) -> *const MatchingRuleDefinitionResult {
+    let expression = safe_str!(expression);
+    let result = if is_matcher_def(expression) {
+      match parse_matcher_def(expression) {
+        Ok(definition) => {
+          debug!("Parsed matcher definition '{}' to '{:?}'", expression, definition);
+          MatchingRuleDefinitionResult {
+            result: Either::Right(definition)
+          }
+        }
+        Err(err) => {
+          error!("Failed to parse matcher definition '{}': {}", expression, err);
+          MatchingRuleDefinitionResult {
+            result: Either::Left(err.to_string())
+          }
+        }
+      }
+    } else if expression.is_empty() {
+      MatchingRuleDefinitionResult {
+        result: Either::Left("Expected a matching rule definition, but got an empty string".to_string())
+      }
+    } else {
+      MatchingRuleDefinitionResult {
+        result: Either::Right(MatchingRuleDefinition {
+          value: expression.to_string(),
+          value_type: ValueType::String,
+          rules: vec![],
+          generator: None
+        })
+      }
+    };
+
+    ptr::raw_to(result) as *const MatchingRuleDefinitionResult
+  } {
+    ptr::null_to::<MatchingRuleDefinitionResult>()
+  }
+}
+
+ffi_fn! {
+  /// Returns any error message from parsing a matching definition expression. If there is no error,
+  /// it will return a NULL pointer, otherwise returns the error message as a NULL-terminated string.
+  /// The returned string must be freed using the `pactffi_string_delete` function once done with it.
+  fn pactffi_matcher_definition_error(definition: *const MatchingRuleDefinitionResult) -> *const c_char {
+    let definition = as_ref!(definition);
+    if let Either::Left(error) = &definition.result {
+      string::to_c(&error)? as *const c_char
+    } else {
+      ptr::null_to::<c_char>()
+    }
+  } {
+    ptr::null_to::<c_char>()
+  }
+}
+
+ffi_fn! {
+  /// Returns the value from parsing a matching definition expression. If there was an error,
+  /// it will return a NULL pointer, otherwise returns the value as a NULL-terminated string.
+  /// The returned string must be freed using the `pactffi_string_delete` function once done with it.
+  fn pactffi_matcher_definition_value(definition: *const MatchingRuleDefinitionResult) -> *const c_char {
+    let definition = as_ref!(definition);
+    if let Either::Right(definition) = &definition.result {
+      string::to_c(&definition.value)? as *const c_char
+    } else {
+      ptr::null_to::<c_char>()
+    }
+  } {
+    ptr::null_to::<c_char>()
+  }
+}
+
+ffi_fn! {
+  /// Frees the memory used by the result of parsing the matching definition expression
+  fn pactffi_matcher_definition_delete(definition: *const MatchingRuleDefinitionResult) {
+    ptr::drop_raw(definition as *mut MatchingRuleDefinitionResult);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::CString;
+
+  use expectest::prelude::*;
+  use libc::c_char;
+
+  use crate::models::expressions::{
+    MatchingRuleDefinitionResult,
+    pactffi_matcher_definition_error,
+    pactffi_matcher_definition_value,
+    pactffi_parse_matcher_definition
+  };
+  use crate::util::ptr;
+
+  #[test]
+  fn parse_expression_with_null() {
+    let result = pactffi_parse_matcher_definition(ptr::null_to());
+    expect!(result.is_null()).to(be_true());
+  }
+
+  #[test]
+  fn parse_expression_with_empty_string() {
+    let empty = CString::new("").unwrap();
+    let result = pactffi_parse_matcher_definition(empty.as_ptr());
+    expect!(result.is_null()).to(be_false());
+
+    let error = pactffi_matcher_definition_error(result);
+    let string = unsafe { CString::from_raw(error as *mut c_char) };
+    expect!(string.to_string_lossy()).to(be_equal_to("Expected a matching rule definition, but got an empty string"));
+
+    let definition = unsafe { Box::from_raw(result as *mut MatchingRuleDefinitionResult) };
+    expect!(definition.result.left()).to(be_some().value("Expected a matching rule definition, but got an empty string"));
+  }
+
+  #[test]
+  fn parse_expression_with_invalid_expression() {
+    let value = CString::new("matching(type,").unwrap();
+    let result = pactffi_parse_matcher_definition(value.as_ptr());
+    expect!(result.is_null()).to(be_false());
+
+    let error = pactffi_matcher_definition_error(result);
+    let string = unsafe { CString::from_raw(error as *mut c_char) };
+    expect!(string.to_string_lossy()).to(be_equal_to("expected a primitive value"));
+
+    let value = pactffi_matcher_definition_value(result);
+    expect!(value.is_null()).to(be_true());
+
+    let definition = unsafe { Box::from_raw(result as *mut MatchingRuleDefinitionResult) };
+    expect!(definition.result.left()).to(be_some().value("expected a primitive value"));
+  }
+
+  #[test]
+  fn parse_expression_with_valid_expression() {
+    let value = CString::new("matching(type,'Name')").unwrap();
+    let result = pactffi_parse_matcher_definition(value.as_ptr());
+    expect!(result.is_null()).to(be_false());
+
+    let error = pactffi_matcher_definition_error(result);
+    expect!(error.is_null()).to(be_true());
+
+    let value = pactffi_matcher_definition_value(result);
+    expect!(value.is_null()).to(be_false());
+    let string = unsafe { CString::from_raw(value as *mut c_char) };
+    expect!(string.to_string_lossy()).to(be_equal_to("Name"));
+
+    let definition = unsafe { Box::from_raw(result as *mut MatchingRuleDefinitionResult) };
+    expect!(definition.result.as_ref().left()).to(be_none());
+    expect!(definition.result.as_ref().right()).to(be_some());
+  }
+
+  #[test]
+  fn parse_expression_with_normal_string() {
+    let value = CString::new("I am not an expression").unwrap();
+    let result = pactffi_parse_matcher_definition(value.as_ptr());
+    expect!(result.is_null()).to(be_false());
+
+    let error = pactffi_matcher_definition_error(result);
+    expect!(error.is_null()).to(be_true());
+
+    let value = pactffi_matcher_definition_value(result);
+    expect!(value.is_null()).to(be_false());
+    let string = unsafe { CString::from_raw(value as *mut c_char) };
+    expect!(string.to_string_lossy()).to(be_equal_to("I am not an expression"));
+
+    let definition = unsafe { Box::from_raw(result as *mut MatchingRuleDefinitionResult) };
+    expect!(definition.result.as_ref().left()).to(be_none());
+    expect!(definition.result.as_ref().right()).to(be_some());
+    expect!(definition.result.as_ref().right().unwrap().rules.is_empty()).to(be_true());
+  }
+}

--- a/rust/pact_ffi/src/models/expressions.rs
+++ b/rust/pact_ffi/src/models/expressions.rs
@@ -198,6 +198,33 @@ ffi_fn! {
 }
 
 /// The matching rule or reference from parsing the matching definition expression.
+///
+/// For matching rules, the ID corresponds to the following rules:
+/// | Rule | ID |
+/// | ---- | -- |
+/// | Equality | 1 |
+/// | Regex | 2 |
+/// | Type | 3 |
+/// | MinType | 4 |
+/// | MaxType | 5 |
+/// | MinMaxType | 6 |
+/// | Timestamp | 7 |
+/// | Time | 8 |
+/// | Date | 9 |
+/// | Include | 10 |
+/// | Number | 11 |
+/// | Integer | 12 |
+/// | Decimal | 13 |
+/// | Null | 14 |
+/// | ContentType | 15 |
+/// | ArrayContains | 16 |
+/// | Values | 17 |
+/// | Boolean | 18 |
+/// | StatusCode | 19 |
+/// | NotEmpty | 20 |
+/// | Semver | 21 |
+/// | EachKey | 22 |
+/// | EachValue | 23 |
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MatchingRuleResult {
@@ -359,7 +386,6 @@ ffi_fn! {
         ptr::null_mut_to::<MatchingRuleResult>()
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/pact_ffi/src/models/generators.rs
+++ b/rust/pact_ffi/src/models/generators.rs
@@ -1,1 +1,127 @@
 //! FFI functions to deal with generators and generated values
+
+use anyhow::anyhow;
+use libc::{c_char, c_ushort};
+use pact_models::generators::{GenerateValue, Generator, NoopVariantMatcher, VariantMatcher};
+use serde_json::Value;
+use tracing::{error, warn};
+
+use crate::{as_ref, ffi_fn};
+use crate::util::{ptr, string};
+
+ffi_fn! {
+  /// Generate a string value using the provided generator and an optional JSON payload containing
+  /// any generator context. The context value is used for generators like `MockServerURL` (which
+  /// should contain details about the running mock server) and `ProviderStateGenerator` (which
+  /// should be the values returned from the Provider State callback function).
+  ///
+  /// If anything goes wrong, it will return a NULL pointer.
+  fn pactffi_generator_generate_string(
+    generator: *const Generator,
+    context_json: *const c_char
+  ) -> *const c_char {
+    let generator = as_ref!(generator);
+    let context = string::optional_str(context_json);
+
+    let context_entries = context_map(context)?;
+    let map = context_entries.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+    match generator.generate_value(&"".to_string(), &map, &NoopVariantMatcher.boxed()) {
+      Ok(value) => string::to_c(value.as_str())? as *const c_char,
+      Err(err) => {
+        error!("Failed to generate value - {}", err);
+        ptr::null_to::<c_char>()
+      }
+    }
+  } {
+    ptr::null_to::<c_char>()
+  }
+}
+
+fn context_map<'a>(context: Option<String>) -> anyhow::Result<serde_json::Map<String, Value>> {
+  if let Some(context) = context {
+    match serde_json::from_str::<Value>(context.as_str()) {
+      Ok(json) => match json {
+        Value::Object(entries) => Ok(entries.clone()),
+        _ => {
+          warn!("'{}' is not a JSON object, ignoring it", json);
+          Ok(serde_json::Map::default())
+        }
+      },
+      Err(err) => {
+        error!("Failed to parse the context value as JSON - {}", err);
+        Err(anyhow!("Failed to parse the context value as JSON - {}", err))
+      }
+    }
+  } else {
+    Ok(serde_json::Map::default())
+  }
+}
+
+ffi_fn! {
+  /// Generate an integer value using the provided generator and an optional JSON payload containing
+  /// any generator context. The context value is used for generators like `ProviderStateGenerator`
+  /// (which should be the values returned from the Provider State callback function).
+  ///
+  /// If anything goes wrong or the generator is not a type that can generate an integer value, it
+  /// will return a zero value.
+  fn pactffi_generator_generate_integer(
+    generator: *const Generator,
+    context_json: *const c_char
+  ) -> c_ushort {
+    let generator = as_ref!(generator);
+    let context = string::optional_str(context_json);
+
+    let context_entries = context_map(context)?;
+    let map = context_entries.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+    match generator.generate_value(&0, &map, &NoopVariantMatcher.boxed()) {
+      Ok(value) => value,
+      Err(err) => {
+        error!("Failed to generate value - {}", err);
+        0
+      }
+    }
+  } {
+    0
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::CString;
+  use expectest::prelude::*;
+  use libc::c_char;
+  use pact_models::prelude::Generator::{RandomInt, RandomString};
+
+  use crate::models::generators::{pactffi_generator_generate_integer, pactffi_generator_generate_string};
+  use crate::util::ptr::null_to;
+  use crate::util::string;
+
+  #[test]
+  fn generate_string_test() {
+    let generator = RandomString(4);
+
+    let value = pactffi_generator_generate_string(&generator, null_to());
+    expect!(value.is_null()).to(be_false());
+    let string = unsafe { CString::from_raw(value as *mut c_char) };
+    expect!(string.to_string_lossy().len()).to(be_equal_to(4));
+  }
+
+  #[test]
+  fn generate_string_test_with_invalid_context() {
+    let generator = RandomString(4);
+    let context = "{not valid";
+
+    let context_json = string::to_c(context).unwrap();
+    let value = pactffi_generator_generate_string(&generator, context_json);
+    expect!(value.is_null()).to(be_true());
+  }
+
+  #[test]
+  fn generate_integer_test() {
+    let generator = RandomInt(10, 100);
+
+    let value = pactffi_generator_generate_integer(&generator, null_to());
+    expect!(value).to(be_greater_or_equal_to(10));
+    expect!(value).to(be_less_or_equal_to(100));
+  }
+}

--- a/rust/pact_ffi/src/models/generators.rs
+++ b/rust/pact_ffi/src/models/generators.rs
@@ -1,0 +1,1 @@
+//! FFI functions to deal with generators and generated values

--- a/rust/pact_ffi/src/models/iterators.rs
+++ b/rust/pact_ffi/src/models/iterators.rs
@@ -68,7 +68,6 @@ ffi_fn! {
     }
 }
 
-
 /// An iterator over synchronous request/response messages in a pact.
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]

--- a/rust/pact_ffi/src/models/matching_rules.rs
+++ b/rust/pact_ffi/src/models/matching_rules.rs
@@ -1,1 +1,45 @@
 //! FFI functions to deal with matching rules
+
+use pact_models::matchingrules::MatchingRule;
+use libc::c_char;
+
+use crate::{ffi_fn, as_ref};
+use crate::util::{ptr, string};
+
+ffi_fn! {
+  /// Get the JSON form of the matching rule.
+  ///
+  /// The returned string must be deleted with `pactffi_string_delete`.
+  ///
+  /// # Safety
+  ///
+  /// This function will fail if it is passed a NULL pointer, or the iterator that owns the
+  /// value of the matching rule has been deleted.
+  fn pactffi_matching_rule_json(rule: *const MatchingRule) -> *const c_char {
+    let rule = as_ref!(rule);
+    let json = rule.to_json().to_string();
+    string::to_c(&json)? as *const c_char
+  } {
+    ptr::null_to::<c_char>()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::CString;
+
+  use expectest::prelude::*;
+  use libc::c_char;
+  use pact_models::matchingrules::MatchingRule;
+
+  use crate::models::matching_rules::pactffi_matching_rule_json;
+
+  #[test]
+  fn matching_rule_json() {
+    let rule = MatchingRule::Regex("\\d+".to_string());
+    let rule_ptr = &rule as *const MatchingRule;
+    let json_ptr = pactffi_matching_rule_json(rule_ptr);
+    let json = unsafe { CString::from_raw(json_ptr as *mut c_char) };
+    expect!(json.to_string_lossy()).to(be_equal_to("{\"match\":\"regex\",\"regex\":\"\\\\d+\"}"));
+  }
+}

--- a/rust/pact_ffi/src/models/matching_rules.rs
+++ b/rust/pact_ffi/src/models/matching_rules.rs
@@ -1,0 +1,1 @@
+//! FFI functions to deal with matching rules

--- a/rust/pact_ffi/src/models/matching_rules.rs
+++ b/rust/pact_ffi/src/models/matching_rules.rs
@@ -15,7 +15,7 @@ ffi_fn! {
   ///
   /// This function will fail if it is passed a NULL pointer, or the iterator that owns the
   /// value of the matching rule has been deleted.
-  fn pactffi_matching_rule_json(rule: *const MatchingRule) -> *const c_char {
+  fn pactffi_matching_rule_to_json(rule: *const MatchingRule) -> *const c_char {
     let rule = as_ref!(rule);
     let json = rule.to_json().to_string();
     string::to_c(&json)? as *const c_char
@@ -32,13 +32,13 @@ mod tests {
   use libc::c_char;
   use pact_models::matchingrules::MatchingRule;
 
-  use crate::models::matching_rules::pactffi_matching_rule_json;
+  use crate::models::matching_rules::pactffi_matching_rule_to_json;
 
   #[test]
   fn matching_rule_json() {
     let rule = MatchingRule::Regex("\\d+".to_string());
     let rule_ptr = &rule as *const MatchingRule;
-    let json_ptr = pactffi_matching_rule_json(rule_ptr);
+    let json_ptr = pactffi_matching_rule_to_json(rule_ptr);
     let json = unsafe { CString::from_raw(json_ptr as *mut c_char) };
     expect!(json.to_string_lossy()).to(be_equal_to("{\"match\":\"regex\",\"regex\":\"\\\\d+\"}"));
   }

--- a/rust/pact_ffi/src/models/mod.rs
+++ b/rust/pact_ffi/src/models/mod.rs
@@ -10,3 +10,5 @@ pub mod iterators;
 pub mod sync_message;
 pub mod http_interaction;
 pub mod expressions;
+pub mod matching_rules;
+pub mod generators;

--- a/rust/pact_ffi/src/models/mod.rs
+++ b/rust/pact_ffi/src/models/mod.rs
@@ -1,4 +1,22 @@
-//! Represents messages in `pact_matching`.
+//! FFI functions to support Pact models.
+
+use std::collections::BTreeMap;
+use std::panic::UnwindSafe;
+use std::sync::Mutex;
+
+use anyhow::anyhow;
+use libc::c_char;
+use maplit::btreemap;
+use serde_json::Value;
+use tracing::{error, warn};
+
+use pact_models::{Consumer, Provider};
+use pact_models::plugins::PluginData;
+use pact_models::v4::interaction::interactions_from_json;
+use pact_models::v4::pact::V4Pact;
+
+use crate::{as_ref, ffi_fn, safe_str};
+use crate::util::{ptr, string};
 
 pub mod consumer;
 pub mod message;
@@ -12,3 +30,127 @@ pub mod http_interaction;
 pub mod expressions;
 pub mod matching_rules;
 pub mod generators;
+
+/// Opaque type for use as a pointer to a Pact model
+pub struct Pact {
+  inner: Mutex<V4Pact>
+}
+
+impl Pact {
+  pub fn new(pact: V4Pact) -> Self {
+    Pact {
+      inner: Mutex::new(pact)
+    }
+  }
+}
+
+ffi_fn! {
+  /// Parses the provided JSON into a Pact model. The returned Pact model must be freed with the
+  /// `pactffi_pact_model_delete` function when no longer needed.
+  ///
+  /// # Error Handling
+  ///
+  /// This function will return a NULL pointer if passed a NULL pointer or if an error occurs.
+  fn pactffi_parse_pact_json(json: *const c_char) -> *mut Pact {
+    let json_str = safe_str!(json);
+    match serde_json::from_str::<Value>(json_str) {
+      Ok(pact_json) => {
+        // TODO: when pact_models 1.1.0 is released, update to this
+        // let pact = V4Pact::pact_from_json(&pact_json, "<FFI>")?;
+        let pact = pact_from_json(&pact_json, "<FFI>")?;
+        ptr::raw_to(Pact::new(pact))
+      },
+      Err(err) => {
+        error!("Failed to parse the Pact JSON - {}", err);
+        ptr::null_mut_to::<Pact>()
+      }
+    }
+  } {
+    ptr::null_mut_to::<Pact>()
+  }
+}
+
+ffi_fn! {
+  /// Frees the memory used by the Pact model
+  fn pactffi_pact_model_delete(pact: *mut Pact) {
+    ptr::drop_raw(pact);
+  }
+}
+
+// TODO: remove when pact_models 1.1.0 is released
+fn pact_from_json(json: &Value, source: &str) -> anyhow::Result<V4Pact> {
+  let mut metadata = meta_data_from_json(&json);
+
+  let consumer = match json.get("consumer") {
+    Some(v) => Consumer::from_json(v),
+    None => Consumer { name: "consumer".into() }
+  };
+  let provider = match json.get("provider") {
+    Some(v) => Provider::from_json(v),
+    None => Provider { name: "provider".into() }
+  };
+
+  let plugin_data = extract_plugin_data(&mut metadata);
+
+  Ok(V4Pact {
+    consumer,
+    provider,
+    interactions: interactions_from_json(&json, source),
+    metadata,
+    plugin_data
+  })
+}
+
+// TODO: remove when pact_models 1.1.0 is released
+fn meta_data_from_json(pact_json: &Value) -> BTreeMap<String, Value> {
+  match pact_json.get("metadata") {
+    Some(Value::Object(ref obj)) => {
+      obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    }
+    _ => btreemap!{}
+  }
+}
+
+// TODO: remove when pact_models 1.1.0 is released
+fn extract_plugin_data(metadata: &mut BTreeMap<String, Value>) -> Vec<PluginData> {
+  if let Some(plugin_data) = metadata.remove("plugins") {
+    match plugin_data {
+      Value::Array(items) => {
+        let mut v = vec![];
+
+        for item in &items {
+          match serde_json::from_value::<PluginData>(item.clone()) {
+            Ok(data) => v.push(data),
+            Err(err) => warn!("Could not convert '{}' into PluginData format - {}", item, err)
+          };
+        }
+
+        v
+      }
+      _ => {
+        warn!("'{}' is not valid plugin data", plugin_data);
+        vec![]
+      }
+    }
+  } else {
+    vec![]
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::CString;
+
+  use expectest::prelude::*;
+
+  use crate::models::{pactffi_pact_model_delete, pactffi_parse_pact_json};
+
+  #[test]
+  fn load_pact_from_json() {
+    let json = CString::new("{}").unwrap();
+    let pact = pactffi_parse_pact_json(json.as_ptr());
+    expect!(pact.is_null()).to(be_false());
+
+    pactffi_pact_model_delete(pact);
+  }
+}

--- a/rust/pact_ffi/src/models/mod.rs
+++ b/rust/pact_ffi/src/models/mod.rs
@@ -30,11 +30,13 @@ pub mod matching_rules;
 pub mod generators;
 
 /// Opaque type for use as a pointer to a Pact model
+#[derive(Debug)]
 pub struct Pact {
   inner: Mutex<V4Pact>
 }
 
 impl Pact {
+  /// Create a new FFI Pact wrapper for the given Pact model
   pub fn new(pact: V4Pact) -> Self {
     Pact {
       inner: Mutex::new(pact)

--- a/rust/pact_ffi/src/models/mod.rs
+++ b/rust/pact_ffi/src/models/mod.rs
@@ -9,3 +9,4 @@ pub mod provider_state;
 pub mod iterators;
 pub mod sync_message;
 pub mod http_interaction;
+pub mod expressions;

--- a/rust/pact_ffi/src/models/mod.rs
+++ b/rust/pact_ffi/src/models/mod.rs
@@ -1,10 +1,8 @@
 //! FFI functions to support Pact models.
 
 use std::collections::BTreeMap;
-use std::panic::UnwindSafe;
 use std::sync::Mutex;
 
-use anyhow::anyhow;
 use libc::c_char;
 use maplit::btreemap;
 use serde_json::Value;
@@ -15,8 +13,8 @@ use pact_models::plugins::PluginData;
 use pact_models::v4::interaction::interactions_from_json;
 use pact_models::v4::pact::V4Pact;
 
-use crate::{as_ref, ffi_fn, safe_str};
-use crate::util::{ptr, string};
+use crate::{ffi_fn, safe_str};
+use crate::util::ptr;
 
 pub mod consumer;
 pub mod message;

--- a/rust/pact_ffi/src/util/ffi.rs
+++ b/rust/pact_ffi/src/util/ffi.rs
@@ -10,13 +10,18 @@ macro_rules! ffi_fn {
         $(#[$doc])*
         #[no_mangle]
         #[allow(clippy::or_fun_call)]
-        #[::tracing::instrument(level = "trace")]
         pub extern fn $name($($arg: $arg_ty),*) -> $ret {
             use $crate::error::catch_panic;
 
+            ::tracing::debug!("{}::{} FFI function invoked", module_path!(), stringify!($name));
+
+            $(
+                ::tracing::trace!("@param {} = {:?}", stringify!($arg), $arg);
+            )*
+
             let output = catch_panic(|| Ok($body)).unwrap_or($fail);
 
-            ::tracing::trace!(output = ?output, "FFI function invoked");
+            ::tracing::trace!(output = ?output, "{} FFI function completed", stringify!($name));
 
             output
         }

--- a/rust/pact_ffi/src/util/string.rs
+++ b/rust/pact_ffi/src/util/string.rs
@@ -51,6 +51,7 @@ macro_rules! cstr {
 #[macro_export]
 macro_rules! safe_str {
     ( $name:ident ) => {{
+        use ::anyhow::Context;
         $crate::cstr!($name).to_str().context(concat!(
             "error parsing ",
             stringify!($name),


### PR DESCRIPTION
Adds support for matching rule expressions via FFI functions. This allows matching rule expressions to be parsed, and the resulting values, matching rules and generators to be retrieved.
