### PR TITLE
feat: get a generator/matching rule from JSON

### DIFF
--- a/rust/pact_ffi/src/matching.rs
+++ b/rust/pact_ffi/src/matching.rs
@@ -262,7 +262,8 @@ ffi_fn! {
 
 #[cfg(test)]
 mod tests {
-  use std::ffi::{c_char, CString};
+  use std::ffi::{CString};
+  use libc::{c_char};
 
   use expectest::prelude::*;
   use pact_models::matchingrules::MatchingRule;

--- a/rust/pact_ffi/src/models/matching_rules.rs
+++ b/rust/pact_ffi/src/models/matching_rules.rs
@@ -1,9 +1,10 @@
 //! FFI functions to deal with matching rules
 
+use anyhow::Context;
 use pact_models::matchingrules::MatchingRule;
 use libc::c_char;
 
-use crate::{ffi_fn, as_ref};
+use crate::{ffi_fn, as_ref, safe_str};
 use crate::util::{ptr, string};
 
 ffi_fn! {
@@ -24,6 +25,29 @@ ffi_fn! {
   }
 }
 
+ffi_fn! {
+  /// Get a Matching Rule from its JSON representation. 
+  ///
+  /// Will return a NULL pointer if the matching rule was invalid.
+  /// 
+  /// # Safety
+  ///
+  /// This function will fail if it is passed a NULL pointer, or the iterator that owns the
+  /// value of the matching rule has been deleted.
+  fn pactffi_matching_rule_from_json(rule: *const c_char) -> *const MatchingRule {
+    let rule = safe_str!(rule);
+    let value: serde_json::Value = serde_json::from_str(rule).context("error parsing matching rule as JSON")?;
+    let result = MatchingRule::from_json(&value);
+
+    match result {
+      Ok(rule) => ptr::raw_to(rule) as *const MatchingRule,
+      _ => ptr::null_to::<MatchingRule>()
+    }
+  } {
+      ptr::null_to::<MatchingRule>()
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use std::ffi::CString;
@@ -32,14 +56,25 @@ mod tests {
   use libc::c_char;
   use pact_models::matchingrules::MatchingRule;
 
-  use crate::models::matching_rules::pactffi_matching_rule_to_json;
+  use crate::models::matching_rules::{pactffi_matching_rule_to_json, pactffi_matching_rule_from_json};
 
   #[test]
-  fn matching_rule_json() {
+  fn matching_rule_to_json() {
     let rule = MatchingRule::Regex("\\d+".to_string());
     let rule_ptr = &rule as *const MatchingRule;
     let json_ptr = pactffi_matching_rule_to_json(rule_ptr);
     let json = unsafe { CString::from_raw(json_ptr as *mut c_char) };
     expect!(json.to_string_lossy()).to(be_equal_to("{\"match\":\"regex\",\"regex\":\"\\\\d+\"}"));
+  }
+
+  #[test]
+  fn matching_rule_from_json() {
+    let json_string = CString::new("{\"match\":\"regex\",\"regex\":\"\\\\d+\"}").unwrap();
+    let rule_ptr = pactffi_matching_rule_from_json(json_string.as_ptr());
+
+    unsafe {
+      expect!(rule_ptr.as_ref().unwrap().name()).to(be_eq("regex"));
+      expect!(rule_ptr.as_ref().unwrap().has_generators()).to(be_eq(false));
+    }
   }
 }

--- a/rust/pact_models/src/generators/mod.rs
+++ b/rust/pact_models/src/generators/mod.rs
@@ -232,6 +232,24 @@ impl Generator {
     }
   }
 
+  /// Builds a `Generator` from a `Value` struct
+  pub fn from_json(value: &Value) -> anyhow::Result<Generator> {
+    match value {
+      Value::Object(m) => match m.get("type") {
+        Some(match_val) => {
+          let val = json_to_string(match_val);
+          if let Some(generator) = Generator::from_map(val.as_str(), m) {
+            Ok(generator)
+          } else {
+            Err(anyhow!("Generator missing 'type' field and unable to guess its type"))
+          }
+        }
+        _ => Err(anyhow!("Generator missing 'type' field and unable to guess its type"))
+      },
+      _ => Err(anyhow!("Generator JSON is not an Object")),
+    }
+  }
+
   /// If this generator is compatible with the given generator mode
   pub fn corresponds_to_mode(&self, mode: &GeneratorTestMode) -> bool {
     match self {


### PR DESCRIPTION
I haven't tested the generator function yet, but the matching rule function works nicely.

This enables me to pull them out from the following plugin RPCs:

* `CompareContents`
* `GenerateContent`

And therefore would solve the problem for a content matcher plugin, but not a transport one.

i.e. it won't work for the methods that accept the `Pact` object (e.g. `VerifyInteraction` or `StartMockServer`). I had a look at the existing FFI methods, and I don't think there is a way to navigate to a place where you can extract a `MatchingRule` (that might be possible, and perhaps is a better pathway).

`PrepareInteractionForVerification` and `VerifyInteraction` both already have access to the `Config` struct, and so could use the other FFI methods (e.g. `pactffi_parse_matcher_definition(const char *expression)`) for this purpose..

So that would leave just `StartMockServer` lacking a way to get to the expressions. 

This can all be worked around by maintaining state of course, but you mentioned this is against the aim of the framework.

What do you think is the best way to make the expressions (in the form of `MatchingRule`s and `Generator`s) available to a Plugin at all stages?

_(I also expect the build to fail because the FFI package will need the new functions in the models package)_