### PR TITLE
refactor: bump indextree, use append_value()

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "indextree"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497f036ac2fae75c34224648a77802e5dd4e9cfb56f4713ab6b12b7160a0523b"
+checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
 
 [[package]]
 name = "instant"

--- a/rust/pact_models/Cargo.toml
+++ b/rust/pact_models/Cargo.toml
@@ -30,7 +30,7 @@ chrono = { version = "0.4.22", features = ["std", "clock"], default-features = f
 chrono-tz = "0.8.0"
 lenient_semver = "0.4.2"
 sxd-document = "0.3.2"
-indextree = "4.5.0"
+indextree = "4.6.0"
 rand = "0.8.5"
 hex = "0.4.3"
 rand_regex = "0.15.1"

--- a/rust/pact_models/src/generators/mod.rs
+++ b/rust/pact_models/src/generators/mod.rs
@@ -1380,10 +1380,8 @@ impl JsonHandler {
               match body_cursor.clone().as_object() {
                 Some(map) => match map.get(name) {
                   Some(val) => {
-                    let node = tree.new_node(name.clone());
-                    node_cursor.append(node, tree);
+                    node_cursor = node_cursor.append_value(name.clone(), tree);
                     body_cursor = val.clone();
-                    node_cursor = node;
                   },
                   None => return
                 },
@@ -1393,10 +1391,8 @@ impl JsonHandler {
             &PathToken::Index(index) => {
               match body_cursor.clone().as_array() {
                 Some(list) => if list.len() > index {
-                  let node = tree.new_node(format!("{}", index));
-                  node_cursor.append(node, tree);
+                  node_cursor = node_cursor.append_value(format!("{}", index), tree);
                   body_cursor = list[index].clone();
-                  node_cursor = node;
                 },
                 None => return
               }
@@ -1406,8 +1402,7 @@ impl JsonHandler {
                 Some(map) => {
                   let remaining = it.by_ref().cloned().collect();
                   for (key, val) in map {
-                    let node = tree.new_node(key.clone());
-                    node_cursor.append(node, tree);
+                    let node = node_cursor.append_value(key.clone(), tree);
                     body_cursor = val.clone();
                     self.query_object_graph(&remaining, tree, node, val.clone());
                   }
@@ -1420,8 +1415,7 @@ impl JsonHandler {
                 Some(list) => {
                   let remaining = it.by_ref().cloned().collect();
                   for (index, val) in list.iter().enumerate() {
-                    let node = tree.new_node(format!("{}", index));
-                    node_cursor.append(node, tree);
+                    let node = node_cursor.append_value(format!("{}", index), tree);
                     body_cursor = val.clone();
                     self.query_object_graph(&remaining, tree, node,val.clone());
                   }


### PR DESCRIPTION
I added a fast path for adding new nodes with `indextree` - https://github.com/saschagrunert/indextree/pull/92.
From a glimpse at this project I'm guessing perf isn't important, but maybe you'll still be interested in this tiny refactor.