### PR TITLE
feat: pact_mock_server_cli osx aarch64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,31 @@
+BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
+  test_pact_mock_server_cli_script: |
+    cd rust/pact_mock_server_cli
+    cargo build --target ${BUILD_TARGET} --release
+    ../target/${BUILD_TARGET}/release/pact_mock_server_cli --help
+    rm -rf ../target/
+  test_pact_verifier_cli_script: |
+    cd rust/pact_verifier_cli
+    cargo build --target ${BUILD_TARGET} --release
+    ../target/${BUILD_TARGET}/release/pact_verifier_cli --help
+
+
+linux_arm64_task: 
+  arm_container:
+    image: rustlang/rust:nightly
+    cpu: 4
+    memory: 12G
+  env:
+    BUILD_TARGET: aarch64-unknown-linux-gnu
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+macosx_arm64_task: 
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  setup_script: brew install rust
+  env:
+    BUILD_TARGET: aarch64-apple-darwin 
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+
+

--- a/rust/pact_mock_server_cli/release-osx.sh
+++ b/rust/pact_mock_server_cli/release-osx.sh
@@ -8,3 +8,12 @@ gzip -c ../target/release/pact_mock_server_cli > ../target/artifacts/pact_mock_s
 #cargo build --release --target x86_64-apple-ios
 #gzip -c ../target/x86_64-apple-ios/release/pact_mock_server_cli > ../target/artifacts/pact_mock_server_cli-ios-x86_64.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-osx-x86_64.gz > ../target/artifacts/pact_mock_server_cli-osx-x86_64.gz.sha256
+
+
+# M1
+export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+cargo build --target aarch64-apple-darwin --release
+
+gzip -c ../target/aarch64-apple-darwin/release/pact_mock_server_cli > ../target/artifacts/pact_mock_server_cli-osx-aarch64.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-osx-aarch64.gz > ../target/artifacts/pact_mock_server_cli-osx-aarch64.gz.sha256


### PR DESCRIPTION
# pact_mock_server_cli

- Add aarch64-apple-darwin target for pact_mock_server_cli
- Adds smoke test for  aarch64-apple-darwin target for pact_mock_server_cli

Bonus

- Adds smoke test for  aarch64-apple-darwin target for pact_mock_server_cli
- Adds smoke test for  aarch64-unknown-linux-gnu target for pact_verifier_cli
- Adds smoke test for  aarch64-unknown-linux-gnu target for pact_verifier_cli


##  Supported Platforms

| OS           | Architecture | Supported |
| ------- | ------------ | --------- |
| OSX        | x86_64       | ✅         |
| OSX        | aarch64 (arm)| ✅         |
| Linux    | x86_64       | ✅         |
| Linux    | aarch64 (arm)| ✅         |
| Windows    | x86_64  | ✅         | 


## Testing

CI can be run locally with [tart.run](https://tart.run/) and [cirrus-cli](https://github.com/cirruslabs/cirrus-cli) on a mac machine with `tart run` in the root folder.

Cirrus-CI account needed for cloud testing of ARM64 machines, all testable within the free tier and no credit card needed

