### PR TITLE
ci(chore) - various updates to replace deprecated action notices and red builds

### DIFF
--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
         rust: [ stable ]
@@ -21,7 +22,7 @@ jobs:
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -12,12 +12,12 @@ jobs:
     env:
       pact_do_not_track: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustc --version || true
         shell: bash
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,37 +12,31 @@ jobs:
     env:
       pact_do_not_track: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: clippy
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info
       - name: Tests
-        uses: marcopolo/cargo@master # TODO: - use actions-rs/cargo@v1 when PR merged https://github.com/actions-rs/cargo/pull/59
-        with:
-          working-directory: rust
-          command: test
+        run: cargo test
+        working-directory: rust
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
       - name: Build Components
-        uses: marcopolo/cargo@master
-        with:
-          working-directory: rust
-          command: build
+        run: cargo build
+        working-directory: rust
       - name: Clippy
         if: runner.os == 'Linux'
-        uses: marcopolo/cargo@master
-        with:
-          working-directory: rust
-          command: clippy
+        run: cargo clippy
+        working-directory: rust
 
   musl-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
          docker run --rm --user "$(id -u)":"$(id -g)" -v $(pwd):/workspace -w /workspace/rust -t -e TZ=UTC pactfoundation/rust-musl-build ./scripts/ci-musl-build.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
-
       - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'Linux'
         run: ./release-linux.sh
         working-directory: rust/pact_mock_server_cli
@@ -67,12 +66,13 @@ jobs:
         shell: bash
         working-directory: rust/pact_ffi
       - name: Upload the artifacts
+        if: startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
         uses: actions/upload-artifact@v3.1.2
         with:
           name: release-artifacts
           path: rust/target/artifacts
       - name: Upload Release Assets
-        id: upload-release-asset
+        if: startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
         uses: svenstaro/upload-release-action@v2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           path: rust/target/artifacts
       - name: Upload Release Assets
         id: upload-release-asset
-        uses: svenstaro/upload-release-action@v@v2.5.0
+        uses: svenstaro/upload-release-action@v2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/target/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           path: rust/target/artifacts
       - name: Upload Release Assets
         if: startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
-        uses: svenstaro/upload-release-action@v2.5.0
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/target/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,26 @@ jobs:
     env:
       pact_do_not_track: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          target: aarch64-apple-darwin
-      - name: Install LLVM
-        run: choco install -y llvm
+          targets: aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl
+      - name: Install stable Rust toolchain
         if: runner.os == 'Windows'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
+      - name: Install stable Rust toolchain
+        if: runner.os == 'MacOS'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
       - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'Linux'
         run: ./release-linux.sh
         working-directory: rust/pact_mock_server_cli
@@ -46,9 +55,6 @@ jobs:
         run: ./release-osx.sh
         shell: bash
         working-directory: rust/pact_verifier_cli
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
       - if: startsWith(github.ref, 'refs/tags/libpact_ffi') && runner.os == 'Linux'
         run: ./release-linux.sh
         working-directory: rust/pact_ffi
@@ -61,13 +67,13 @@ jobs:
         shell: bash
         working-directory: rust/pact_ffi
       - name: Upload the artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: release-artifacts
           path: rust/target/artifacts
       - name: Upload Release Assets
         id: upload-release-asset
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@v@v2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/target/artifacts/*

--- a/rust/pact_ffi/CMakeLists.txt
+++ b/rust/pact_ffi/CMakeLists.txt
@@ -273,7 +273,7 @@ set_source_files_properties(
 add_custom_command(
     OUTPUT ${CBINDGEN_HEADER_FILE}
     COMMAND
-        rustup run nightly-2022-12-01
+        rustup run nightly
         ${CBINDGEN_EXECUTABLE}
         --config ${CBINDGEN_CONFIG_FILE}
         --crate ${CRATE_NAME}

--- a/rust/pact_ffi/ci-build.sh
+++ b/rust/pact_ffi/ci-build.sh
@@ -8,7 +8,7 @@ rustc --version
 cargo install --force cbindgen
 rm -rf ./include
 
-rustup toolchain install nightly-2022-12-01
+rustup toolchain install nightly
 
 echo -------------------------------------
 echo - Build library with CMake
@@ -22,11 +22,11 @@ cd ..
 echo -------------------------------------
 echo - Generate header with cbindgen
 echo -------------------------------------
-rustup run nightly-2022-12-01 cbindgen \
+rustup run nightly cbindgen \
   --config cbindgen.toml \
   --crate pact_ffi \
   --output include/pact.h
-rustup run nightly-2022-12-01 cbindgen \
+rustup run nightly cbindgen \
   --config cbindgen-c++.toml \
   --crate pact_ffi \
   --output include/pact-c++.h

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -17,13 +17,13 @@ gzip -c ../target/release/libpact_ffi.a > ../target/artifacts/libpact_ffi-linux-
 openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-linux-x86_64.a.gz > ../target/artifacts/libpact_ffi-linux-x86_64.a.gz.sha256
 
 echo -- Generate the header files --
-rustup toolchain install nightly-2022-12-01
-rustup component add rustfmt --toolchain nightly-2022-12-01
-rustup run nightly-2022-12-01 cbindgen \
+rustup toolchain install nightly
+rustup component add rustfmt --toolchain nightly
+rustup run nightly cbindgen \
   --config cbindgen.toml \
   --crate pact_ffi \
   --output include/pact.h
-rustup run nightly-2022-12-01 cbindgen \
+rustup run nightly cbindgen \
   --config cbindgen-c++.toml \
   --crate pact_ffi \
   --output include/pact-cpp.h


### PR DESCRIPTION
Hey @uglyog 

Noted the CI workflows were throwing a few deprecation notices, and the release workflow was failing on any jobs that were for the ffi, verifier cli, or mock server cli, so this PR add's a few changes to clean up the build

1. Update `actions/checkout@v2` to `actions/checkout@v3`
2. Switch deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain` https://github.com/dtolnay/rust-toolchain as original unmaintained - see [issue](https://github.com/actions-rs/toolchain/issues/216) 
3. Replace `marcopolo/cargo@master` also unmaintained, and not sure using an action for this adds value based on what we are using from it, with a cargo rust/test/build and setting the `working-directory` as part of the gh action step value
4. Remove `choco install -y llvm` from windows build-chain, llvm is already installed on windows runners https://github.com/actions/runner-images/blob/d8d4d924ad21a8ba4931b2988f74bbb376cad021/images/win/toolsets/toolset-2022.json#L400
5. replace `nightly-2022-12-01` with `nightly` - fails with updated toolchain actions update, it looks like the underlying reason for it being pinned has been fixed https://github.com/rust-lang/rust/issues/105886
6. Skip upload release assets on the release workflow, where the tags don't correlate with a step to build artefacts.