### PR TITLE
feat: add all current buildable targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release workflow
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  # release:
+  #   types: [published]
 
 jobs:
   build-release:

--- a/.github/workflows/x-plat.yml
+++ b/.github/workflows/x-plat.yml
@@ -1,0 +1,395 @@
+name: FFI - Cross
+
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  cross:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        crate: [pact_ffi]
+        target: # https://github.com/cross-rs/cross/blob/main/targets.toml
+          # ✅ These all build with cross 
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabihf
+          - arm-unknown-linux-musleabi
+          - arm-unknown-linux-musleabihf
+          - armv7-unknown-linux-gnueabi
+          - armv7-unknown-linux-gnueabihf
+          - armv7-unknown-linux-musleabi
+          - armv7-unknown-linux-musleabihf
+          - i586-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+          - x86_64-unknown-netbsd
+          - x86_64-unknown-freebsd
+          - armv5te-unknown-linux-gnueabi
+          - armv5te-unknown-linux-musleabi
+          - arm-linux-androideabi
+          - armv7-linux-androideabi
+          - aarch64-linux-android
+          - i686-linux-android
+          - x86_64-linux-android
+          - thumbv7neon-linux-androideabi
+          - thumbv7neon-unknown-linux-gnueabihf
+          # ✅ The above build with cross 
+
+          # 🚧 This did build with cross?! 
+
+          - i686-pc-windows-gnu
+          # ❌ These dont build with cross, or fall back to host and fail 
+
+
+          # - i586-unknown-linux-musl
+          # - i686-unknown-linux-musl
+          # = note: /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(aes_nohw.o): in function `GFp_aes_nohw_ctr32_encrypt_blocks':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c:961: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(poly1305.o): in function `poly1305_update':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/poly1305/poly1305.c:158: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `ge_double_scalarmult_vartime':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:937: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `GFp_x25519_ge_frombytes_vartime':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:520: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `GFp_x25519_ge_scalarmult_base':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:828: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o):/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:1854: more undefined references to `__stack_chk_fail_local' follow
+          #   collect2: error: ld returned 1 exit status
+          # = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
+          # = note: use the `-l` flag to specify native libraries to link
+          # = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
+          # - i686-unknown-freebsd # fails to build
+          # /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(aes_nohw.o): in function `GFp_aes_nohw_ctr32_encrypt_blocks':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c:961: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(poly1305.o): in function `poly1305_update':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/poly1305/poly1305.c:158: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `ge_double_scalarmult_vartime':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:937: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `GFp_x25519_ge_frombytes_vartime':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:520: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `GFp_x25519_ge_scalarmult_base':
+          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:828: undefined reference to `__stack_chk_fail_local'
+          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o):/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:1854: more undefined references to `__stack_chk_fail_local' follow
+          #   collect2: error: ld returned 1 exit status
+          # = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
+          # = note: use the `-l` flag to specify native libraries to link
+          # = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
+          # - aarch64-unknown-freebsd  # fails to build
+          # error: component 'rust-std' for target 'aarch64-unknown-freebsd' is unavailable for download for channel 'nightly'
+          # - armv6-unknown-freebsd  # fails to build
+          # error: component 'rust-std' for target 'armv6-unknown-freebsd' is unavailable for download for channel 'nightly'
+          # - armv7-unknown-freebsd  # fails to build
+          # error: component 'rust-std' for target 'armv7-unknown-freebsd' is unavailable for download for channel 'nightly'
+          
+          # - asmjs-unknown-emscripten
+          # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
+
+          # # All MIPS builds - error: failed to run custom build command for `ring v0.16.20`
+          # - mips-unknown-linux-gnu
+          # - mips-unknown-linux-musl
+          # - mipsel-unknown-linux-gnu
+          # - mipsel-unknown-linux-musl
+          # - mips64-unknown-linux-gnuabi64
+          # - mips64el-unknown-linux-gnuabi64
+          # - mips64-unknown-linux-muslabi64
+          # - mips64el-unknown-linux-muslabi64
+
+
+          # - powerpc-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+          # - powerpc64-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+          # - powerpc64le-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+          # - powerpc64le-unknown-linux-musl
+          # # error: component 'rust-std' for target 'powerpc64le-unknown-linux-musl' is unavailable for download for channel 'nightly'
+          # - riscv64gc-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+          # - s390x-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+          # - s390x-unknown-linux-musl
+          # # error: component 'rust-std' for target 's390x-unknown-linux-musl' is unavailable for download for channel 'nightly'
+          # - sparc64-unknown-linux-gnu
+          # # error: failed to run custom build command for `ring v0.16.20`
+
+
+          # - wasm32-unknown-emscripten
+          # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
+
+          # - sparcv9-sun-solaris
+          # # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
+          # - x86_64-sun-solaris
+          # # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
+          # - x86_64-unknown-illumos
+          # # error[E0425]: cannot find function `allocate` in module `sys`
+          # #  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fs2-0.4.3/src/lib.rs:104:14
+
+          # - x86_64-unknown-dragonfly
+
+          # # error[E0463]: can't find crate for `std`
+          # # |
+          # # = note: the `thumbv6m-none-eabi` target may not support the standard library
+          # # = note: `std` is required by `serde` because it does not declare `#![no_std]`
+          # # = help: consider building the standard library from source with `cargo build -Zbuild-std`
+          # - thumbv6m-none-eabi
+          # - thumbv7em-none-eabi
+          # - thumbv7em-none-eabihf
+          # - thumbv7m-none-eabi
+          # - thumbv8m.base-none-eabi
+          # - thumbv8m.main-none-eabi
+          
+          # - x86_64-pc-windows-msvc
+          # # --- stderr
+          # # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m64" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/x86_64-pc-windows-msvc/release/build/ring-6ebd52ee81449ee8/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
+          # # cc: error: -E or -x required when input is from standard input
+          # # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
+          # # note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+          # - x86_64-pc-windows-gnu # ✅
+          # - aarch64-pc-windows-msvc
+          # --- stderr
+          # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/aarch64-pc-windows-msvc/release/build/ring-9d224d33b6544594/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
+          # cc: error: -E or -x required when input is from standard input
+          # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
+
+          # - aarch64-pc-windows-gnullvm
+          # # error: component 'rust-std' for target 'aarch64-pc-windows-gnullvm' is unavailable for download for channel 'nightly'
+          # - aarch64-uwp-windows-msvc
+          # # error: component 'rust-std' for target 'aarch64-uwp-windows-msvc' is unavailable for download for channel 'nightly'
+          # - i586-pc-windows-msvc
+          # # --- stderr
+          # # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m32" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/i586-pc-windows-msvc/release/build/ring-c2331d92d4e35b3e/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
+          # # cc: error: -E or -x required when input is from standard input
+          # # In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/stdint.h:9,
+          # #                  from include/GFp/base.h:66,
+          # #                  from include/GFp/aes.h:52,
+          # #                  from crypto/fipsmodule/aes/aes_nohw.c:15:
+          # # /usr/include/stdint.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
+          # #    26 | #include <bits/libc-header-start.h>
+          # #       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
+          # # compilation terminated.
+          # # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
+          # # note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+          # - i686-pc-windows-gnu
+          # - i686-pc-windows-msvc
+          # #   --- stderr
+          # #   running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m32" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/i686-pc-windows-msvc/release/build/ring-1b1a65c4b81efaf2/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
+          # #   cc: error: -E or -x required when input is from standard input
+          # #   In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/stdint.h:9,
+          # #                   from include/GFp/base.h:66,
+          # #                   from include/GFp/aes.h:52,
+          # #                   from crypto/fipsmodule/aes/aes_nohw.c:15:
+          # #   /usr/include/stdint.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
+          # #     26 | #include <bits/libc-header-start.h>
+          # #         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
+          # #   compilation terminated.
+          # #   thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
+          # #   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+          # # warning: build failed, waiting for other jobs to finish...
+          # - i686-uwp-windows-gnu
+          # # error: component 'rust-std' for target 'i686-uwp-windows-gnu' is unavailable for download for channel 'nightly'
+          # - i686-uwp-windows-msvc
+          # # error: component 'rust-std' for target 'i686-uwp-windows-msvc' is unavailable for download for channel 'nightly'
+          # - thumbv7a-pc-windows-msvc
+          # # error: component 'rust-std' for target 'thumbv7a-pc-windows-msvc' is unavailable for download for channel 'nightly'
+          # - thumbv7a-uwp-windows-msvc
+          # # error: component 'rust-std' for target 'thumbv7a-uwp-windows-msvc' is unavailable for download for channel 'nightly'
+
+          # - x86_64-pc-windows-gnullvm
+          # # error: component 'rust-std' for target 'x86_64-pc-windows-gnullvm' is unavailable for download for channel 'nightly'
+
+          # - x86_64-uwp-windows-gnu
+          # # error: component 'rust-std' for target 'x86_64-uwp-windows-gnu' is unavailable for download for channel 'nightly'
+          # - x86_64-uwp-windows-msvc
+          # # error: component 'rust-std' for target 'x86_64-uwp-windows-msvc' is unavailable for download for channel 'nightly'
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustc --version || true
+        shell: bash
+      - uses: dtolnay/rust-toolchain@stable
+        continue-on-error: true
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
+        run: ./build-cross.sh
+        working-directory: rust/${{ matrix.crate }}
+        shell: bash
+        env:
+          target: ${{ matrix.target }}
+      - name: Show ${{ matrix.crate }} release
+        run: ls && ls ../../artifacts
+        working-directory: rust/target/${{ matrix.target }}/release
+        shell: bash
+      - name: Upload the artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: release-artifacts
+          path: rust/target/artifacts
+      - name: Upload Release Assets
+        if: (startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli'))
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/target/artifacts/*
+          file_glob: true
+          tag: ${{ github.ref }}
+
+  windows:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        crate: [pact_ffi]
+        target:
+          - x86_64-pc-windows-msvc # ✅
+          - aarch64-pc-windows-msvc # ✅
+          - i686-pc-windows-msvc # ✅
+          - x86_64-pc-windows-gnu # ✅
+          # - i686-pc-windows-gnu # native with cargo error: linker `i686-w64-mingw32-gcc` not found
+          # - i586-pc-windows-msvc # Fails, could be possible. https://seri.tools/blog/compiling-rust-for-legacy-windows/
+          # - aarch64-pc-windows-gnullvm
+          # - aarch64-uwp-windows-msvc
+          # - i686-uwp-windows-gnu
+          # - i686-uwp-windows-msvc
+          # - thumbv7a-pc-windows-msvc
+          # - thumbv7a-uwp-windows-msvc
+          # - x86_64-pc-windows-gnullvm
+          # - x86_64-uwp-windows-gnu
+          # - x86_64-uwp-windows-msvc
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustc --version || true
+        shell: bash
+      - uses: dtolnay/rust-toolchain@stable
+        continue-on-error: true
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
+        run: ./build-cross.sh
+        working-directory: rust/${{ matrix.crate }}
+        shell: bash
+        env:
+          target: ${{ matrix.target }}
+      - name: Show ${{ matrix.crate }} release
+        run: ls && ls ../../artifacts
+        working-directory: rust/target/${{ matrix.target }}/release
+        shell: bash
+      - name: Upload the artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: release-artifacts
+          path: rust/target/artifacts
+      - name: Upload Release Assets
+        if: (startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli'))
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/target/artifacts/*
+          file_glob: true
+          tag: ${{ github.ref }}
+
+  macos:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [pact_ffi]
+        os: [macos-latest]
+        target:
+          - aarch64-apple-darwin # ✅
+          - x86_64-apple-darwin # ✅
+          - aarch64-apple-ios # ✅
+          - aarch64-apple-ios-sim # ✅
+          - x86_64-apple-ios # ✅
+          # - x86_64h-apple-darwin # https://doc.rust-lang.org/nightly/rustc/platform-support/x86_64h-apple-darwin.html
+          # - i686-apple-darwin
+          # - armv7k-apple-watchos
+          # - aarch64-apple-tvos
+          # - aarch64-apple-watchos-sim
+          # - arm64_32-apple-watchos
+          # - x86_64-apple-watchos-sim
+          # - x86_64-apple-tvos
+          # - armv7s-apple-ios
+          # - armv7-apple-ios
+          # - aarch64-apple-ios-macabi
+          # - x86_64-apple-ios-macabi
+          # - i386-apple-ios
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustc --version || true
+        shell: bash
+      - uses: dtolnay/rust-toolchain@stable
+        continue-on-error: true
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
+        run: ./build-cross.sh
+        working-directory: rust/${{ matrix.crate }}
+        shell: bash
+        env:
+          target: ${{ matrix.target }}
+      - name: Show ${{ matrix.crate }} release
+        run: ls && ls ../../artifacts
+        working-directory: rust/target/${{ matrix.target }}/release
+        shell: bash
+      - name: Upload the artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: release-artifacts
+          path: rust/target/artifacts
+      - name: Upload Release Assets
+        if: (startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli'))
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/target/artifacts/*
+          file_glob: true
+          tag: ${{ github.ref }}
+
+
+  build_headers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustc --version || true
+        shell: bash
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Build headers with cargo pact_ffi
+        run: ./build-headers.sh
+        working-directory: rust/pact_ffi
+        shell: bash
+      - name: Upload the artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: release-artifacts
+          path: rust/target/artifacts
+      - name: Upload Release Assets
+        if: startsWith(github.ref, 'refs/tags/libpact_ffi')
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/target/artifacts/*
+          file_glob: true
+          tag: ${{ github.ref }}

--- a/.github/workflows/x-plat.yml
+++ b/.github/workflows/x-plat.yml
@@ -1,4 +1,4 @@
-name: FFI - Cross
+name: Cross - FFI / Mock Server / Verifier
 
 on:
   push:
@@ -6,16 +6,39 @@ on:
     types: [published]
 
 jobs:
+
+  setup_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      crate: ${{ steps.generate_matrix.outputs.crate }}
+    steps:
+      - name: Generate Matrix for testing
+        id: generate_matrix
+        run: |
+          if [[ ${{ github.ref }} == *"libpact_ffi"* ]]; then
+            crate_to_test=[\"pact_ffi\"]
+          elif [[ ${{ github.ref }} == *"pact_verifier_cli"* ]]; then
+            crate_to_test=[\"pact_verifier_cli\"]
+          elif [[ ${{ github.ref }} == *"pact_mock_server_cli"* ]]; then
+            crate_to_test=[\"pact_mock_server_cli\"]
+          else
+            crate_to_test=[\"pact_verifier_cli\",\"pact_mock_server_cli\",\"pact_ffi\"]
+          fi
+          CRATE=$crate_to_test
+          echo "crate=${CRATE}" >> "$GITHUB_OUTPUT"
+      - run: echo "${{ toJson(steps.generate_matrix.outputs.crate) }}"
+        name: Testing ${{ toJson(steps.generate_matrix.outputs.crate) }}
+  
   cross:
     runs-on: ${{ matrix.os }}
+    needs: setup_matrix
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        crate: [pact_ffi]
+        crate: ${{ fromJson(needs.setup_matrix.outputs.crate) }}
         target: # https://github.com/cross-rs/cross/blob/main/targets.toml
           # ✅ These all build with cross 
           - x86_64-unknown-linux-gnu
@@ -43,175 +66,7 @@ jobs:
           - x86_64-linux-android
           - thumbv7neon-linux-androideabi
           - thumbv7neon-unknown-linux-gnueabihf
-          # ✅ The above build with cross 
-
-          # 🚧 This did build with cross?! 
-
           - i686-pc-windows-gnu
-          # ❌ These dont build with cross, or fall back to host and fail 
-
-
-          # - i586-unknown-linux-musl
-          # - i686-unknown-linux-musl
-          # = note: /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(aes_nohw.o): in function `GFp_aes_nohw_ctr32_encrypt_blocks':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c:961: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(poly1305.o): in function `poly1305_update':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/poly1305/poly1305.c:158: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `ge_double_scalarmult_vartime':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:937: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `GFp_x25519_ge_frombytes_vartime':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:520: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o): in function `GFp_x25519_ge_scalarmult_base':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:828: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/bin/../lib/gcc/i586-linux-musl/9.2.0/../../../../i586-linux-musl/bin/ld: /target/i586-unknown-linux-musl/release/deps/libring-85b4fbaf5798ec9c.rlib(curve25519.o):/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:1854: more undefined references to `__stack_chk_fail_local' follow
-          #   collect2: error: ld returned 1 exit status
-          # = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
-          # = note: use the `-l` flag to specify native libraries to link
-          # = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
-          # - i686-unknown-freebsd # fails to build
-          # /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(aes_nohw.o): in function `GFp_aes_nohw_ctr32_encrypt_blocks':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c:961: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(poly1305.o): in function `poly1305_update':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/poly1305/poly1305.c:158: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `ge_double_scalarmult_vartime':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:937: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `GFp_x25519_ge_frombytes_vartime':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:520: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o): in function `GFp_x25519_ge_scalarmult_base':
-          #   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:828: undefined reference to `__stack_chk_fail_local'
-          #   /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/release/deps/libring-045c2b14a100e932.rlib(curve25519.o):/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/crypto/curve25519/curve25519.c:1854: more undefined references to `__stack_chk_fail_local' follow
-          #   collect2: error: ld returned 1 exit status
-          # = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
-          # = note: use the `-l` flag to specify native libraries to link
-          # = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
-          # - aarch64-unknown-freebsd  # fails to build
-          # error: component 'rust-std' for target 'aarch64-unknown-freebsd' is unavailable for download for channel 'nightly'
-          # - armv6-unknown-freebsd  # fails to build
-          # error: component 'rust-std' for target 'armv6-unknown-freebsd' is unavailable for download for channel 'nightly'
-          # - armv7-unknown-freebsd  # fails to build
-          # error: component 'rust-std' for target 'armv7-unknown-freebsd' is unavailable for download for channel 'nightly'
-          
-          # - asmjs-unknown-emscripten
-          # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
-
-          # # All MIPS builds - error: failed to run custom build command for `ring v0.16.20`
-          # - mips-unknown-linux-gnu
-          # - mips-unknown-linux-musl
-          # - mipsel-unknown-linux-gnu
-          # - mipsel-unknown-linux-musl
-          # - mips64-unknown-linux-gnuabi64
-          # - mips64el-unknown-linux-gnuabi64
-          # - mips64-unknown-linux-muslabi64
-          # - mips64el-unknown-linux-muslabi64
-
-
-          # - powerpc-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-          # - powerpc64-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-          # - powerpc64le-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-          # - powerpc64le-unknown-linux-musl
-          # # error: component 'rust-std' for target 'powerpc64le-unknown-linux-musl' is unavailable for download for channel 'nightly'
-          # - riscv64gc-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-          # - s390x-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-          # - s390x-unknown-linux-musl
-          # # error: component 'rust-std' for target 's390x-unknown-linux-musl' is unavailable for download for channel 'nightly'
-          # - sparc64-unknown-linux-gnu
-          # # error: failed to run custom build command for `ring v0.16.20`
-
-
-          # - wasm32-unknown-emscripten
-          # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
-
-          # - sparcv9-sun-solaris
-          # # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
-          # - x86_64-sun-solaris
-          # # 199 |     compile_error!("unsupported target for `mio::unix::pipe`");
-          # - x86_64-unknown-illumos
-          # # error[E0425]: cannot find function `allocate` in module `sys`
-          # #  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fs2-0.4.3/src/lib.rs:104:14
-
-          # - x86_64-unknown-dragonfly
-
-          # # error[E0463]: can't find crate for `std`
-          # # |
-          # # = note: the `thumbv6m-none-eabi` target may not support the standard library
-          # # = note: `std` is required by `serde` because it does not declare `#![no_std]`
-          # # = help: consider building the standard library from source with `cargo build -Zbuild-std`
-          # - thumbv6m-none-eabi
-          # - thumbv7em-none-eabi
-          # - thumbv7em-none-eabihf
-          # - thumbv7m-none-eabi
-          # - thumbv8m.base-none-eabi
-          # - thumbv8m.main-none-eabi
-          
-          # - x86_64-pc-windows-msvc
-          # # --- stderr
-          # # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m64" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/x86_64-pc-windows-msvc/release/build/ring-6ebd52ee81449ee8/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
-          # # cc: error: -E or -x required when input is from standard input
-          # # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
-          # # note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-          # - x86_64-pc-windows-gnu # ✅
-          # - aarch64-pc-windows-msvc
-          # --- stderr
-          # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/aarch64-pc-windows-msvc/release/build/ring-9d224d33b6544594/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
-          # cc: error: -E or -x required when input is from standard input
-          # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
-
-          # - aarch64-pc-windows-gnullvm
-          # # error: component 'rust-std' for target 'aarch64-pc-windows-gnullvm' is unavailable for download for channel 'nightly'
-          # - aarch64-uwp-windows-msvc
-          # # error: component 'rust-std' for target 'aarch64-uwp-windows-msvc' is unavailable for download for channel 'nightly'
-          # - i586-pc-windows-msvc
-          # # --- stderr
-          # # running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m32" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/i586-pc-windows-msvc/release/build/ring-c2331d92d4e35b3e/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
-          # # cc: error: -E or -x required when input is from standard input
-          # # In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/stdint.h:9,
-          # #                  from include/GFp/base.h:66,
-          # #                  from include/GFp/aes.h:52,
-          # #                  from crypto/fipsmodule/aes/aes_nohw.c:15:
-          # # /usr/include/stdint.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
-          # #    26 | #include <bits/libc-header-start.h>
-          # #       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
-          # # compilation terminated.
-          # # thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
-          # # note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-          # - i686-pc-windows-gnu
-          # - i686-pc-windows-msvc
-          # #   --- stderr
-          # #   running "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m32" "-I" "include" "-Wall" "-Wextra" "/GS" "/Gy" "/EHsc" "/GR-" "/Zc:wchar_t" "/Zc:forScope" "/Zc:inline" "/Zc:rvalueCast" "/sdl" "/Wall" "/wd4127" "/wd4464" "/wd4514" "/wd4710" "/wd4711" "/wd4820" "/wd5045" "/Ox" "-DNDEBUG" "-c" "/Fo/home/runner/work/pact-reference/pact-reference/rust/target/i686-pc-windows-msvc/release/build/ring-1b1a65c4b81efaf2/out/aes_nohw.obj" "crypto/fipsmodule/aes/aes_nohw.c"
-          # #   cc: error: -E or -x required when input is from standard input
-          # #   In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/stdint.h:9,
-          # #                   from include/GFp/base.h:66,
-          # #                   from include/GFp/aes.h:52,
-          # #                   from crypto/fipsmodule/aes/aes_nohw.c:15:
-          # #   /usr/include/stdint.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
-          # #     26 | #include <bits/libc-header-start.h>
-          # #         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
-          # #   compilation terminated.
-          # #   thread 'main' panicked at 'execution failed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/build.rs:656:9
-          # #   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-          # # warning: build failed, waiting for other jobs to finish...
-          # - i686-uwp-windows-gnu
-          # # error: component 'rust-std' for target 'i686-uwp-windows-gnu' is unavailable for download for channel 'nightly'
-          # - i686-uwp-windows-msvc
-          # # error: component 'rust-std' for target 'i686-uwp-windows-msvc' is unavailable for download for channel 'nightly'
-          # - thumbv7a-pc-windows-msvc
-          # # error: component 'rust-std' for target 'thumbv7a-pc-windows-msvc' is unavailable for download for channel 'nightly'
-          # - thumbv7a-uwp-windows-msvc
-          # # error: component 'rust-std' for target 'thumbv7a-uwp-windows-msvc' is unavailable for download for channel 'nightly'
-
-          # - x86_64-pc-windows-gnullvm
-          # # error: component 'rust-std' for target 'x86_64-pc-windows-gnullvm' is unavailable for download for channel 'nightly'
-
-          # - x86_64-uwp-windows-gnu
-          # # error: component 'rust-std' for target 'x86_64-uwp-windows-gnu' is unavailable for download for channel 'nightly'
-          # - x86_64-uwp-windows-msvc
-          # # error: component 'rust-std' for target 'x86_64-uwp-windows-msvc' is unavailable for download for channel 'nightly'
     steps:
       - uses: actions/checkout@v3
       - run: rustc --version || true
@@ -222,7 +77,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
       - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
-        run: ./build-cross.sh
+        run: ../scripts/build-cross.sh
         working-directory: rust/${{ matrix.crate }}
         shell: bash
         env:
@@ -247,6 +102,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.os }}
+    needs: setup_matrix
     defaults:
       run:
         shell: bash
@@ -254,23 +110,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        crate: [pact_ffi]
+        crate: ${{ fromJson(needs.setup_matrix.outputs.crate) }}
         target:
           - x86_64-pc-windows-msvc # ✅
           - aarch64-pc-windows-msvc # ✅
           - i686-pc-windows-msvc # ✅
           - x86_64-pc-windows-gnu # ✅
-          # - i686-pc-windows-gnu # native with cargo error: linker `i686-w64-mingw32-gcc` not found
-          # - i586-pc-windows-msvc # Fails, could be possible. https://seri.tools/blog/compiling-rust-for-legacy-windows/
-          # - aarch64-pc-windows-gnullvm
-          # - aarch64-uwp-windows-msvc
-          # - i686-uwp-windows-gnu
-          # - i686-uwp-windows-msvc
-          # - thumbv7a-pc-windows-msvc
-          # - thumbv7a-uwp-windows-msvc
-          # - x86_64-pc-windows-gnullvm
-          # - x86_64-uwp-windows-gnu
-          # - x86_64-uwp-windows-msvc
     steps:
       - uses: actions/checkout@v3
       - run: rustc --version || true
@@ -281,7 +126,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
       - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
-        run: ./build-cross.sh
+        run: ../scripts/build-cross.sh
         working-directory: rust/${{ matrix.crate }}
         shell: bash
         env:
@@ -306,13 +151,14 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.os }}
+    needs: setup_matrix
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        crate: [pact_ffi]
+        crate: ${{ fromJson(needs.setup_matrix.outputs.crate) }}
         os: [macos-latest]
         target:
           - aarch64-apple-darwin # ✅
@@ -320,19 +166,6 @@ jobs:
           - aarch64-apple-ios # ✅
           - aarch64-apple-ios-sim # ✅
           - x86_64-apple-ios # ✅
-          # - x86_64h-apple-darwin # https://doc.rust-lang.org/nightly/rustc/platform-support/x86_64h-apple-darwin.html
-          # - i686-apple-darwin
-          # - armv7k-apple-watchos
-          # - aarch64-apple-tvos
-          # - aarch64-apple-watchos-sim
-          # - arm64_32-apple-watchos
-          # - x86_64-apple-watchos-sim
-          # - x86_64-apple-tvos
-          # - armv7s-apple-ios
-          # - armv7-apple-ios
-          # - aarch64-apple-ios-macabi
-          # - x86_64-apple-ios-macabi
-          # - i386-apple-ios
     steps:
       - uses: actions/checkout@v3
       - run: rustc --version || true
@@ -343,7 +176,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
       - name: Build ${{ matrix.crate }} with cross for ${{ matrix.target }}
-        run: ./build-cross.sh
+        run: ../scripts/build-cross.sh
         working-directory: rust/${{ matrix.crate }}
         shell: bash
         env:
@@ -368,7 +201,13 @@ jobs:
 
 
   build_headers:
-    runs-on: ubuntu-latest
+    if: ${{ fromJson(needs.setup_matrix.outputs.crate) }} == [\"pact_ffi\"]
+    runs-on: ${{ matrix.operating-system }}
+    needs: setup_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - run: rustc --version || true

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,241 @@
+
+# Pact-Reference Supported Platforms / Architectures
+
+## Legend
+
+- ✅ : Builds with cross and officially supported
+- 🧪 : Builds with cross and unofficially released for testing
+- 🚧 : Cross image available, doesn't build
+- ❌ : doesn't build, (or no cross image available)
+- ❓ : Untested
+- 👷🏽 : Locally built and tested
+
+## Pact-Reference Target Matrix
+
+| target | notes | tier | cross | pact_ffi | pact_verifier_cli | pact_mock_server_cli
+| ---- | ---- | --- | ---- | --- | --- | --- |
+| x86_64-pc-windows-msvc| 64-bit MSVC (Windows 7+) | 1 |  ✅ | ✅ | ✅ | ✅ |
+| x86_64-apple-darwin |64-bit macOS (10.7+, Lion+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| x86_64-unknown-linux-gnu |64-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| aarch64-unknown-linux-gnu |ARM64 Linux (kernel 4.1, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| aarch64-apple-darwin |ARM64 macOS (11.0+, Big Sur+)| 2 | ❌ | ✅ |  ✅ |   ✅|
+| x86_64-unknown-linux-musl |64-bit Linux with MUSL| 2 | ✅ | ✅ | 🚧 | 🚧 |
+
+## Unofficial Pact-Reference Target Matrix
+
+target lists taken from
+
+- Rust Platform support list <https://doc.rust-lang.org/nightly/rustc/platform-support.html>
+- Cross <https://github.com/cross-rs/cross>
+- Cargo-xWin <https://github.com/rust-cross/cargo-xwin>
+
+| target | notes | tier | cross | pact_ffi | pact_verifier_cli | pact_mock_server_cli
+| ---- | ---- | --- | ---- | --- | --- | --- |
+| aarch64-unknown-linux-gnu |ARM64 Linux (kernel 4.1, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| i686-pc-windows-gnu| 32-bit MinGW (Windows 7+) | 1 |🧪 | 🧪 | 🧪 | 🧪 |
+| i686-pc-windows-msvc |32-bit MSVC (Windows 7+) | 1 | 🧪 | 🧪 | 🧪 | 🧪 |
+| i686-unknown-linux-gnu| 32-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | 🧪 | 🧪 | 🧪 | 🧪 |
+| x86_64-apple-darwin |64-bit macOS (10.7+, Lion+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| x86_64-pc-windows-gnu |64-bit MinGW (Windows 7+) | 1 | 🧪 | 🧪 | 🧪 | 🧪 |
+| x86_64-pc-windows-msvc| 64-bit MSVC (Windows 7+) | 1 |  ✅ | ✅ | ✅ | ✅ |
+| x86_64-unknown-linux-gnu |64-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
+| ---- | ---- | --- | ---- | --- | --- | --- |
+| aarch64-apple-darwin |ARM64 macOS (11.0+, Big Sur+)| 2 | ❌ | ✅ |  ✅ |   ✅|
+| aarch64-pc-windows-msvc| ARM64 Windows MSVC| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
+| aarch64-unknown-linux-musl |ARM64 Linux with MUSL| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
+| arm-unknown-linux-gnueabi |ARMv6 Linux (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
+| arm-unknown-linux-gnueabihf |ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
+| armv7-unknown-linux-gnueabihf |ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
+| mips-unknown-linux-gnu| MIPS Linux (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
+| mips64-unknown-linux-gnuabi64| MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
+| mips64el-unknown-linux-gnuabi64| MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
+| mipsel-unknown-linux-gnu |MIPS (LE) Linux (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-linux-gnu| PowerPC Linux (kernel 3.2, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
+| powerpc64-unknown-linux-gnu| PPC64 Linux (kernel 3.2, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
+| powerpc64le-unknown-linux-gnu |PPC64LE Linux (kernel 3.10, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
+| riscv64gc-unknown-linux-gnu| RISC-V Linux (kernel 4.20, glibc 2.29)| 2 | 🚧  | 🚧  | 🚧   | 🚧  |
+| s390x-unknown-linux-gnu| S390x Linux (kernel 3.2, glibc 2.17)| 2 | 🚧  | 🚧  | 🚧   | 🚧  |
+| x86_64-unknown-freebsd| 64-bit FreeBSD| 2 |🧪 | 🧪 | 🧪 | 🧪 |
+| x86_64-unknown-illumos| illumos| 2 |🚧  | 🚧  | 🚧   | 🚧  |
+| x86_64-unknown-linux-musl |64-bit Linux with MUSL| 2 | ✅ | ✅ | 🚧 | 🚧 |
+| x86_64-unknown-netbsd| NetBSD/amd64| 2 |🧪 | 🧪 | 🧪 | 🧪 |
+| ---- | ---- | --- | ---- | --- | --- | --- |
+| aarch64-apple-ios | ARM64 iOS| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
+| aarch64-apple-ios-sim | Apple iOS Simulator on ARM64| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| aarch64-fuchsia | Alias for aarch64-unknown-fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-fuchsia | ARM64 Fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-linux-android | ARM64 Android| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| aarch64-unknown-none-softfloat | Bare ARM64, softfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-none | Bare ARM64, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-uefi | ARM64 UEFI| 2*|❌ |  ❓ | ❓  |  ❓ |
+| arm-linux-androideabi | ARMv7 Android| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
+| arm-unknown-linux-musleabi | ARMv6 Linux with MUSL| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
+| arm-unknown-linux-musleabihf | ARMv6 Linux with MUSL, hardfloat| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armebv7r-none-eabi | Bare ARMv7-R, Big Endian| 2*|❌ |  ❓ | ❓  |  ❓ |
+| armebv7r-none-eabihf | Bare ARMv7-R, Big Endian, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
+| armv5te-unknown-linux-gnueabi | ARMv5TE Linux (kernel 4.4, glibc 2.23)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armv5te-unknown-linux-musleabi | ARMv5TE Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armv7-linux-androideabi | ARMv7a Android| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
+| armv7-unknown-linux-gnueabi | ARMv7 Linux (kernel 4.15, glibc 2.27)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armv7-unknown-linux-musleabi | ARMv7 Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armv7-unknown-linux-musleabihf | ARMv7 Linux with MUSL, hardfloat| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| armv7a-none-eabi | Bare ARMv7-A| 2*|❌ |  ❓ | ❓  |  ❓ |
+| armv7r-none-eabi | Bare ARMv7-R| 2*|❌ |  ❓ | ❓  |  ❓ |
+| armv7r-none-eabihf | Bare ARMv7-R, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
+| asmjs-unknown-emscripten | asm.js via Emscripten| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| i586-pc-windows-msvc | 32-bit Windows w/o SSE| 2*|❌ |  ❓ | ❓  |  ❓ |
+| i586-unknown-linux-gnu | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| i586-unknown-linux-musl | 32-bit Linux w/o SSE, MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| i686-linux-android | 32-bit x86 Android| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| i686-unknown-freebsd | 32-bit FreeBSD| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| i686-unknown-linux-musl | 32-bit Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| i686-unknown-uefi | 32-bit UEFIV| 2*|❌ |  ❓ | ❓  |  ❓ |
+| mips-unknown-linux-musl | MIPS Linux with MUSL| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| mips64-unknown-linux-muslabi64 | MIPS64 Linux, n64 ABI, MUSL| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| mips64el-unknown-linux-muslabi64 | MIPS64 (LE) Linux, n64 ABI, MUSL| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| mipsel-unknown-linux-musl | MIPS (LE) Linux with MUSL| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| nvptx64-nvidia-cuda | --emit=asm generates PTX code that runs on NVIDIA GPUs| 2*|❌ |  ❓ | ❓  |  ❓ |
+| riscv32i-unknown-none-elf | Bare RISC-V (RV32I ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| riscv32imac-unknown-none-elf | Bare RISC-V (RV32IMAC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| riscv32imc-unknown-none-elf | Bare RISC-V (RV32IMC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| riscv64gc-unknown-none-elf | Bare RISC-V (RV64IMAFDC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| riscv64imac-unknown-none-elf | Bare RISC-V (RV64IMAC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| sparc64-unknown-linux-gnu | SPARC Linux (kernel 4.4, glibc 2.23)| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| sparcv9-sun-solaris | SPARC Solaris 10/11, illumos| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv6m-none-eabi | Bare Cortex-M0, M0+, M1| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv7em-none-eabi | Bare Cortex-M4, M7| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv7em-none-eabihf | Bare Cortex-M4F, M7F, FPU, hardfloat| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv7m-none-eabi | Bare Cortex-M3| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv7neon-linux-androideabi | Thumb2-mode ARMv7a Android with NEON| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
+| thumbv7neon-unknown-linux-gnueabihf | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc | 2.23)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| thumbv8m.base-none-eabi | ARMv8-M Baseline| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv8m.main-none-eabi | ARMv8-M Mainline| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| thumbv8m.main-none-eabihf | ARMv8-M Mainline, hardfloat| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
+| wasm32-unknown-emscripten | WebAssembly via Emscripten| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| wasm32-unknown-unknown | WebAssembly| 2*|❌ |  ❓ | ❓  |  ❓ |
+| wasm32-wasi | WebAssembly with WASI| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-apple-ios | 64-bit x86 iOS| 2*|🧪 | 🧪 | 🧪 | 🧪 |
+| x86_64-fortanix-unknown-sgx | Fortanix ABI for 64-bit Intel SGX| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-fuchsia | Alias for x86_64-unknown-fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-fuchsia | 64-bit Fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-linux-android | 64-bit x86 Android| 2*|🚧  | 🚧  | 🚧   | 🚧  |
+| x86_64-pc-solaris | 64-bit Solaris 10/11, illumos| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-linux-gnux32 | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-none | Freestanding/bare-metal x86_64, softfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-redox | Redox OS| 2*|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-uefi | 64-bit UEFI| 2*|❌ |  ❓ | ❓  |  ❓ |
+| ---- | ---- | --- | ---- | --- | --- | --- |
+| aarch64-apple-ios-macabi |  Apple Catalyst on ARM64|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-apple-tvos |  ARM64 tvOS|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-apple-watchos-sim |  ARM64 Apple WatchOS Simulator|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-kmc-solid_asp3 |  ARM64 SOLID with TOPPERS/ASP3|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-nintendo-switch-freestanding |  ARM64 Nintendo Switch, Horizon|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-pc-windows-gnullvm | | |3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-linux-ohos |  ARM64 OpenHarmony|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-nto-qnx710 |  ARM64 QNX Neutrino 7.1 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-freebsd | | ARM64 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-hermit |  ARM64 HermitCore|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-linux-gnu_ilp32 | | ARM64 Linux (ILP32 ABI)|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-netbsd | | |3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-openbsd | | ARM64 OpenBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-unknown-redox |  ARM64 Redox OS|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64_be-unknown-linux-gnu_ilp32 | | ARM64 Linux (big-endian, ILP32 ABI)|3|❌ |  ❓ | ❓  |  ❓ |
+| aarch64_be-unknown-linux-gnu | | ARM64 Linux (big-endian)|3|❌ |  ❓ | ❓  |  ❓ |
+| arm64_32-apple-watchos |  ARM Apple WatchOS 64-bit with 32-bit pointers|3|❌ |  ❓ | ❓  |  ❓ |
+| armeb-unknown-linux-gnueabi | | ARM BE8 the default ARM big-endian architecture since | ARMv6.|3|❌ |  ❓ | ❓  |  ❓ |
+| armv4t-none-eabi |  ARMv4T A32|3|❌ |  ❓ | ❓  |  ❓ |
+| armv4t-unknown-linux-gnueabi |  |3|❌ |  ❓ | ❓  |  ❓ |
+| armv5te-none-eabi |  ARMv5TE A32|3|❌ |  ❓ | ❓  |  ❓ |
+| armv5te-unknown-linux-uclibceabi |  ARMv5TE Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
+| armv6-unknown-freebsd | | ARMv6 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| armv6-unknown-netbsd-eabihf |  |3|❌ |  ❓ | ❓  |  ❓ |
+| armv6k-nintendo-3ds |  ARMv6K Nintendo 3DS, Horizon (Requires devkitARM toolchain)|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-apple-ios |  ARMv7 iOS, Cortex-a8|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-sony-vita-newlibeabihf |  ARM Cortex-A9 Sony PlayStation Vita (requires VITASDK | toolchain)|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-unknown-linux-ohos |  ARMv7 OpenHarmony|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-unknown-linux-uclibceabi | | ARMv7 Linux with uClibc, softfloat|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-unknown-linux-uclibceabihf | | ARMv7 Linux with uClibc, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-unknown-freebsd | | ARMv7 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-unknown-netbsd-eabihf | | |3|❌ |  ❓ | ❓  |  ❓ |
+| armv7-wrs-vxworks-eabihf |  |3|❌ |  ❓ | ❓  |  ❓ |
+| armv7a-kmc-solid_asp3-eabi |  ARM SOLID with TOPPERS/ASP3|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7a-kmc-solid_asp3-eabihf |  ARM SOLID with TOPPERS/ASP3, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7a-none-eabihf |  ARM Cortex-A, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7k-apple-watchos |  ARM Apple WatchOS|3|❌ |  ❓ | ❓  |  ❓ |
+| armv7s-apple-ios |  |3|❌ |  ❓ | ❓  |  ❓ |
+| avr-unknown-gnu-atmega328 |  AVR. Requires -Z build-std=core|3|❌ |  ❓ | ❓  |  ❓ |
+| bpfeb-unknown-none |  BPF (big endian)|3|❌ |  ❓ | ❓  |  ❓ |
+| bpfel-unknown-none |  BPF (little endian)|3|❌ |  ❓ | ❓  |  ❓ |
+| hexagon-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
+| i386-apple-ios |  32-bit x86 iOS|3|❌ |  ❓ | ❓  |  ❓ |
+| i586-pc-nto-qnx700 |  32-bit x86 QNX Neutrino 7.0 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
+| i686-apple-darwin | | 32-bit macOS (10.7+, Lion+)|3|❌ |  ❓ | ❓  |  ❓ |
+| i686-unknown-haiku | | 32-bit Haiku|3|❌ |  ❓ | ❓  |  ❓ |
+| i686-unknown-netbsd | | NetBSD/i386 with SSE2|3|❌ |  ❓ | ❓  |  ❓ |
+| i686-unknown-openbsd | | 32-bit OpenBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| i686-uwp-windows-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
+| i686-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
+| i686-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
+| loongarch64-unknown-linux-gnu |  LoongArch64 Linux (LP64D ABI)|3|❌ |  ❓ | ❓  |  ❓ |
+| m68k-unknown-linux-gnu |  Motorola 680x0 Linux|3|❌ |  ❓ | ❓  |  ❓ |
+| mips-unknown-linux-uclibc |  MIPS Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
+| mips64-openwrt-linux-musl |  MIPS64 for OpenWrt Linux MUSL|3|❌ |  ❓ | ❓  |  ❓ |
+| mipsel-sony-psp |  MIPS (LE) Sony PlayStation Portable (PSP)|3|❌ |  ❓ | ❓  |  ❓ |
+| mipsel-sony-psx |  MIPS (LE) Sony PlayStation 1 (PSX)|3|❌ |  ❓ | ❓  |  ❓ |
+| mipsel-unknown-linux-uclibc |  MIPS (LE) Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
+| mipsel-unknown-none |  Bare MIPS (LE) softfloat|3|❌ |  ❓ | ❓  |  ❓ |
+| mipsisa32r6-unknown-linux-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
+| mipsisa32r6el-unknown-linux-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
+| mipsisa64r6-unknown-linux-gnuabi64 |  |3|❌ |  ❓ | ❓  |  ❓ |
+| mipsisa64r6el-unknown-linux-gnuabi64 |  |3|❌ |  ❓ | ❓  |  ❓ |
+| msp430-none-elf |  16-bit MSP430 microcontrollers|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-linux-gnuspe |  PowerPC SPE Linux|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-netbsd | | |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-openbsd |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-wrs-vxworks-spe |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64-unknown-freebsd | | PPC64 FreeBSD (ELFv1 and ELFv2)|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64le-unknown-freebsd   PPC64LE FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc-unknown-freebsd   PowerPC FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64le-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64-unknown-openbsd | | OpenBSD/powerpc64|3|❌ |  ❓ | ❓  |  ❓ |
+| powerpc64-ibm-aix |  64-bit AIX (7.2 and newer)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv32gc-unknown-linux-gnu   RISC-V Linux (kernel 5.4, glibc 2.33)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv32gc-unknown-linux-musl   RISC-V Linux (kernel 5.4, musl + RISCV32 support | patches)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv32im-unknown-none-elf |  Bare RISC-V (RV32IM ISA)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv32imac-unknown-xous-elf |  RISC-V Xous (RV32IMAC ISA)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv32imc-esp-espidf |  RISC-V ESP-IDF|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv64gc-unknown-freebsd   RISC-V FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv64gc-unknown-fuchsia   RISC-V Fuchsia|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv64gc-unknown-linux-musl   RISC-V Linux (kernel 4.20, musl 1.2.0)|3|❌ |  ❓ | ❓  |  ❓ |
+| riscv64gc-unknown-openbsd | | OpenBSD/riscv64|3|❌ |  ❓ | ❓  |  ❓ |
+| s390x-unknown-linux-musl   S390x Linux (kernel 3.2, MUSL)|3|❌ |  ❓ | ❓  |  ❓ |
+| sparc-unknown-linux-gnu |  32-bit SPARC Linux|3|❌ |  ❓ | ❓  |  ❓ |
+| sparc64-unknown-netbsd | | NetBSD/sparc64|3|❌ |  ❓ | ❓  |  ❓ |
+| sparc64-unknown-openbsd | | OpenBSD/sparc64|3|❌ |  ❓ | ❓  |  ❓ |
+| thumbv4t-none-eabi |  ARMv4T T32|3|❌ |  ❓ | ❓  |  ❓ |
+| thumbv5te-none-eabi |  ARMv5TE T32|3|❌ |  ❓ | ❓  |  ❓ |
+| thumbv7a-pc-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
+| thumbv7a-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
+| thumbv7neon-unknown-linux-musleabihf |  Thumb2-mode ARMv7a Linux with NEON, MUSL|3|❌ |  ❓ | ❓  |  ❓ |
+| wasm64-unknown-unknown |  WebAssembly|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-apple-ios-macabi |  Apple Catalyst on x86_64|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-apple-tvos |  x86 64-bit tvOS|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-apple-watchos-sim |  x86 64-bit Apple WatchOS simulator|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-pc-nto-qnx710 |  x86 64-bit QNX Neutrino 7.1 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-pc-windows-gnullvm | | |3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64-sun-solaris |  Deprecated target for 64-bit Solaris 10/11, illumos|3| 🚧  | 🚧  | 🚧   | 🚧  |
+| x86_64-unknown-dragonfly | | 64-bit DragonFlyBSD|3| 🚧  | 🚧  | 🚧   | 🚧  |
+| x86_64-unknown-haiku | | 64-bit Haiku|3|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-hermit |  HermitCore|3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-l4re-uclibc |  |3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64-unknown-openbsd | | 64-bit OpenBSD|❌ |  ❓ | ❓  |  ❓ |
+| x86_64-uwp-windows-gnu |  |3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64-uwp-windows-msvc |  |3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64-wrs-vxworks |  |3| ❌ |  ❓ | ❓  |  ❓ |
+| x86_64h-apple-darwin | | macOS with late-gen Intel (at least Haswell)|3| ❌ |  ❓ | ❓  |  ❓ |

--- a/rust/Dockerfile.cli.alpine
+++ b/rust/Dockerfile.cli.alpine
@@ -1,0 +1,55 @@
+ARG ALPINE_VERSION 3
+FROM alpine:${ALPINE_VERSION} AS base
+## Available node alpine images
+# linux/amd64
+# linux/arm/v6
+# linux/arm/v7
+# linux/arm64/v8
+# linux/ppc64le
+# linux/s390x
+
+ARG PACT_TOOL=pact_verifier_cli
+ARG PACT_TOOL_VERSION=0.10.9
+ENV DOWNLOAD_LOCATION=https://github.com/pact-foundation/pact-reference/releases/download/${PACT_TOOL}-v${PACT_TOOL_VERSION}/
+FROM base AS base-amd64
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-x86_64-unknown-linux-musl.gz
+FROM base AS base-arm64
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-aarch64-unknown-linux-musl.gz
+FROM base AS base-armv7
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-armv7-unknown-linux-musleabi.gz
+# ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL_VERSION}-armv7-unknown-linux-musleabihf.gz
+FROM base AS base-arm
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-arm-unknown-linux-musleabi.gz
+# ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL_VERSION}-arm-unknown-linux-musleabihf.gz
+FROM base AS base-armv6
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-arm-unknown-linux-musleabi.gz
+# ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL_VERSION}-arm-unknown-linux-musleabihf.gz
+FROM base AS base-armv5te
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-armv5te-unknown-linux-musleabi.gz
+FROM base AS base-i586
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-i586-unknown-linux-musl.gz
+FROM base AS base-i686
+ARG PACT_TOOL_VERSION
+ENV PACT_ARCHIVE_FILENAME=${PACT_TOOL}-i686-unknown-linux-musl.gz
+ARG TARGETARCH
+FROM base-$TARGETARCH AS pb-dev
+
+RUN env
+
+ARG TARGETARCH
+ARG PACT_TOOL_VERSION
+ARG PACT_TOOL
+
+RUN wget -O - "$DOWNLOAD_LOCATION$PACT_ARCHIVE_FILENAME" | gunzip -c > $PACT_TOOL \
+ && chmod +x "$PACT_TOOL" \
+ && mv "$PACT_TOOL" "/usr/local/bin/${PACT_TOOL}"
+
+RUN "$PACT_TOOL" --version
+ENTRYPOINT [ "pact_verifier_cli" ]

--- a/rust/pact_ffi/build-cross.sh
+++ b/rust/pact_ffi/build-cross.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+set -e
+
+echo -Setup directories --
+# cargo clean
+mkdir -p ../target/artifacts
+
+echo -Install latest version of cross --
+cargo install cross --git https://github.com/cross-rs/cross
+
+echo -Install latest version of cross --
+linux_targets=(
+  x86_64-unknown-linux-gnu
+  x86_64-unknown-linux-musl
+  aarch64-unknown-linux-gnu
+  aarch64-unknown-linux-musl
+  arm-unknown-linux-gnueabi
+  arm-unknown-linux-gnueabihf
+  arm-unknown-linux-musleabi
+  arm-unknown-linux-musleabihf
+  armv7-unknown-linux-gnueabi
+  armv7-unknown-linux-gnueabihf
+  armv7-unknown-linux-musleabi
+  armv7-unknown-linux-musleabihf
+  i586-unknown-linux-gnu
+  i686-unknown-linux-gnu
+  x86_64-unknown-netbsd
+  x86_64-unknown-freebsd
+  armv5te-unknown-linux-gnueabi
+  armv5te-unknown-linux-musleabi
+  arm-linux-androideabi
+  armv7-linux-androideabi
+  aarch64-linux-android
+  i686-linux-android
+  x86_64-linux-android
+  thumbv7neon-linux-androideabi
+  thumbv7neon-unknown-linux-gnueabihf
+)
+
+macos_targets=(
+  aarch64-apple-darwin
+  x86_64-apple-darwin
+  aarch64-apple-ios
+  aarch64-apple-ios-sim
+  x86_64-apple-ios
+)
+windows_targets=(
+  x86_64-pc-windows-msvc
+  aarch64-pc-windows-msvc
+  i686-pc-windows-msvc
+  x86_64-pc-windows-gnu
+)
+
+echo -Setup targets --
+if [[ ! -n $target ]]; then
+  # only build for specific targets on particular os's
+  # limited list, due to github actions not supporting
+  # docker on macos or windows, so unable to use cross
+  # this list is probably different if running locally
+  # list taken from .github/workflows/x-plat.yml
+  case "$(uname -s)" in
+  Darwin)
+    targets=("${macos_targets[@]}")
+    ;;
+  Linux)
+    targets=("${linux_targets[@]}")
+    ;;
+  CYGWIN* | MINGW32* | MSYS* | MINGW*)
+    targets=("${windows_targets[@]}")
+    ;;
+  *)
+    echo "ERROR: $(uname -s) is not a supported operating system"
+    exit 1
+    ;;
+  esac
+  echo "building for following targets:"
+  for target in "${targets[@]}"; do
+    echo "${target}"
+  done
+else
+  targets=($target)
+fi
+
+for target in "${targets[@]}"; do
+
+  if [[ $target == "aarch64-pc-windows-msvc" ]]; then
+    ## The following is a workaround until ring 16 supports windows arm64 or rustls moves to ring 17 (post release)
+    ## It also relies on ../cargo.toml having the [patch.crates-io] section at the bottom of the file
+    # https://github.com/briansmith/ring/issues/1514#issuecomment-1258562375
+    # https://github.com/briansmith/ring/pull/1554
+    # https://github.com/rust-lang/rustup/issues/2612#issuecomment-1433876793
+    # https://github.com/rustls/rustls/pull/1108
+    echo "ring override for aarch64-pc-windows-msvc"
+    echo ring = { git = \"https://github.com/awakecoding/ring\", branch = \"0.16.20_alpha\" } >>../cargo.toml
+    cd .. && cargo update
+    cd pact_ffi
+  fi
+
+  if [[ $target == *"musl"* ]]; then
+    echo "building for musl $target"
+    # https://github.com/rust-lang/cargo/issues/7154
+    RUSTFLAGS="-C target-feature=-crt-static" cross build --target "${target}" --release
+  elif [[ ($CI == "true" && $(uname -s) != "Linux") || $CIRRUS_CI = "true" ]]; then
+    # no docker on github actions macos / windows
+    # no docker in docker in cirrus
+    echo "building for $target with cargo"
+    cargo build --target "${target}" --release
+  else
+    echo "building for $target with cross"
+    cross build --target "${target}" --release
+  fi
+
+  if [[ $target == *"windows"* ]]; then
+    lib_ext=dll
+    lib_name=pact_ffi
+  elif [[ $target == *"darwin"* ]]; then
+    lib_ext=dylib
+    lib_name=libpact_ffi
+  elif [[ $target == *"ios"* ]]; then
+    lib_ext=a
+    lib_name=libpact_ffi
+  else
+    lib_ext=so
+    lib_name=libpact_ffi
+  fi
+
+  echo "showing cargo release build for lib${lib_name}.${lib_ext} and checksum for target ${target}"
+  ls ../target/${target}/release
+
+  # if [[ $target == *"windows"* ]]; then
+  ## Skipping uploading pact_ffi.lib and pact_ffi.dll.lib
+  ## only reference to pact_ffi.dll.lib is with pact-js-core
+  ## still need to test if this is neccesary
+  # if [[ $target != *"gnu"* ]]; then
+  #   ## dll.lib
+  #   lib_ext=dll.lib
+  #   gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+  #   openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+  #   ## lib
+  #   lib_ext=lib
+  #   gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+  #   openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+  # fi
+  # fi
+
+  ## cdylib - shared lib .so / .dll / .dylib / .a depending on platform
+  echo "preparing shared lib${lib_name}.${lib_ext} and checksum for target ${target}"
+  gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+  openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+done
+echo "showing final release artefacts"
+ls ../target/artifacts

--- a/rust/pact_ffi/build-headers.sh
+++ b/rust/pact_ffi/build-headers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+
+set -e
+
+mkdir -p ../target/artifacts
+          echo -- Generate the header files --
+          rustup toolchain install nightly
+          rustup component add rustfmt --toolchain nightly
+          rustup run nightly cbindgen \
+            --config cbindgen.toml \
+            --crate pact_ffi \
+            --output include/pact.h
+          rustup run nightly cbindgen \
+            --config cbindgen-c++.toml \
+            --crate pact_ffi \
+            --output include/pact-cpp.h
+          cp include/*.h ../target/artifacts
+          ls ../target/artifacts

--- a/rust/scripts/build-cross.sh
+++ b/rust/scripts/build-cross.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+set -e
+
+echo -Setup directories --
+cargo clean
+mkdir -p ../target/artifacts
+
+echo -Install latest version of cross --
+cargo install cross --git https://github.com/cross-rs/cross
+
+echo -Install latest version of cross --
+linux_targets=(
+  x86_64-unknown-linux-gnu
+  x86_64-unknown-linux-musl
+  aarch64-unknown-linux-gnu
+  aarch64-unknown-linux-musl
+  arm-unknown-linux-gnueabi
+  arm-unknown-linux-gnueabihf
+  arm-unknown-linux-musleabi
+  arm-unknown-linux-musleabihf
+  armv7-unknown-linux-gnueabi
+  armv7-unknown-linux-gnueabihf
+  armv7-unknown-linux-musleabi
+  armv7-unknown-linux-musleabihf
+  i586-unknown-linux-gnu
+  i686-unknown-linux-gnu
+  x86_64-unknown-netbsd
+  x86_64-unknown-freebsd
+  armv5te-unknown-linux-gnueabi
+  armv5te-unknown-linux-musleabi
+  arm-linux-androideabi
+  armv7-linux-androideabi
+  aarch64-linux-android
+  i686-linux-android
+  x86_64-linux-android
+  thumbv7neon-linux-androideabi
+  thumbv7neon-unknown-linux-gnueabihf
+)
+
+macos_targets=(
+  aarch64-apple-darwin
+  x86_64-apple-darwin
+  aarch64-apple-ios
+  aarch64-apple-ios-sim
+  x86_64-apple-ios
+)
+windows_targets=(
+  x86_64-pc-windows-msvc
+  aarch64-pc-windows-msvc
+  i686-pc-windows-msvc
+  x86_64-pc-windows-gnu
+)
+
+echo -Setup targets --
+if [[ ! -n $target ]]; then
+  # only build for specific targets on particular os's
+  # limited list, due to github actions not supporting
+  # docker on macos or windows, so unable to use cross
+  # this list is probably different if running locally
+  # list taken from .github/workflows/x-plat.yml
+  case "$(uname -s)" in
+  Darwin)
+    targets=("${macos_targets[@]}")
+    ;;
+  Linux)
+    targets=("${linux_targets[@]}")
+    ;;
+  CYGWIN* | MINGW32* | MSYS* | MINGW*)
+    targets=("${windows_targets[@]}")
+    ;;
+  *)
+    echo "ERROR: $(uname -s) is not a supported operating system"
+    exit 1
+    ;;
+  esac
+  echo "building for following targets:"
+  for target in "${targets[@]}"; do
+    echo "${target}"
+  done
+else
+  targets=($target)
+fi
+
+for target in "${targets[@]}"; do
+
+  if [[ $target == "aarch64-pc-windows-msvc" ]]; then
+    ## The following is a workaround until ring 16 supports windows arm64 or rustls moves to ring 17 (post release)
+    ## It also relies on ../cargo.toml having the [patch.crates-io] section at the bottom of the file
+    # https://github.com/briansmith/ring/issues/1514#issuecomment-1258562375
+    # https://github.com/briansmith/ring/pull/1554
+    # https://github.com/rust-lang/rustup/issues/2612#issuecomment-1433876793
+    # https://github.com/rustls/rustls/pull/1108
+    echo "ring override for aarch64-pc-windows-msvc"
+    echo ring = { git = \"https://github.com/awakecoding/ring\", branch = \"0.16.20_alpha\" } >>../cargo.toml
+    cd .. && cargo update
+    cd $crate
+  fi
+
+  if [[ $target == *"musl"* && $crate == 'pact_ffi' ]]; then
+    echo "building for musl $target"
+    # https://github.com/rust-lang/cargo/issues/7154
+    RUSTFLAGS="-C target-feature=-crt-static" cross build --target "${target}" --release
+  elif [[ ($CI == "true" && $(uname -s) != "Linux") || $CIRRUS_CI = "true" ]]; then
+    # no docker on github actions macos / windows
+    # no docker in docker in cirrus
+    echo "building for $target with cargo"
+    cargo build --target "${target}" --release
+  else
+    echo "building for $target with cross"
+    cross build --target "${target}" --release
+  fi
+
+  if [[ $crate == 'pact_ffi' ]];then
+    
+
+    if [[ $target == *"windows"* ]]; then
+      lib_ext=dll
+      lib_name=pact_ffi
+    elif [[ $target == *"darwin"* ]]; then
+      lib_ext=dylib
+      lib_name=libpact_ffi
+    elif [[ $target == *"ios"* ]]; then
+      lib_ext=a
+      lib_name=libpact_ffi
+    else
+      lib_ext=so
+      lib_name=libpact_ffi
+    fi
+
+    echo "showing cargo release build for lib${lib_name}.${lib_ext} and checksum for target ${target}"
+    ls ../target/${target}/release
+
+    if [[ $target == *"windows"* ]]; then
+      if [[ $target != *"gnu"* ]]; then
+        ## dll.lib
+        lib_ext=dll.lib
+        gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+        openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+        ## lib
+        lib_ext=lib
+        gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+        openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+      fi
+    fi
+
+    ## cdylib - shared lib .so / .dll / .dylib / .a depending on platform
+    echo "preparing shared lib${lib_name}.${lib_ext} and checksum for target ${target}"
+    gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+    openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+
+    ## static lib .a
+    ## only prepare the static lib if it exists
+    lib_ext=a
+    if [[ -f ../target/${target}/release/${lib_name}.${lib_ext} ]]; then
+      echo "preparing static lib${lib_name}.${lib_ext} and checksum for target ${target}"
+      gzip -c ../target/${target}/release/${lib_name}.${lib_ext} >../target/artifacts/${lib_name}-${target}.${lib_ext}.gz
+      openssl dgst -sha256 -r ../target/artifacts/${lib_name}-${target}.${lib_ext}.gz >../target/artifacts/${lib_name}-${target}.${lib_ext}.sha256
+    fi
+
+  else if [[ $crate == 'pact_verifier_cli' || $crate == 'pact_mock_server_cli' ]]; then
+      if [[ $target == *"windows"* ]]; then
+        ext=.exe
+      fi
+      gzip -c target/$target/release/$crate$ext > target/artifacts/$crate-$target$ext.gz
+      openssl dgst -sha256 -r target/artifacts/$crate-$target.exe.gz > target/artifacts/$crate-$target$ext.gz.sha256
+  fi
+done
+echo "showing final release artefacts"
+ls ../target/artifacts

--- a/rust/scripts/test-alpine.sh
+++ b/rust/scripts/test-alpine.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# linux/386
+# linux/amd64
+# linux/arm/v6
+# linux/arm/v7
+# linux/arm64/v8
+# linux/ppc64le
+# linux/s390x
+platform="linux"
+for arch in arm64 amd64 arm/v6 arm/v7; do 
+    for version in 3.17 3.16 3.15 3.14; do 
+        docker build . -f Dockerfile.cli.alpine \
+            --build-arg=ALPINE_VERSION=$version \
+            -t pact-alpine-$platform-$arch-$version \
+            --platform=linux/$arch
+        docker run --rm -it pact-alpine-$platform-$arch-$version --version
+        docker run --rm -it pact-alpine-$platform-$arch-$version --help
+    done
+done


### PR DESCRIPTION
- Use cross to build for all available platforms, that will currently build.
- Drops uploading of (and can very easily be added back in)
  - `dll.lib` for windows, everything I've seen uses `dll` only
  - `.a`, used for musl builds? not sure how, would love to hear from Alpine users, I had to generate an `.so` file and use it that way
- generates `.so` file for alpine
- generates the same targets for `pact_ffi` / `pact_verifier_cli` / `pact_mock_server_cli`
  - edit - to be added from another branch, as the build step for the FFI can be reused across all three with some minor tweaks
- release workflow would be made redundant by this workflow as it is also catered for.
  
  Warrants a conversation about nomenclature with regards to platform / architecture. I've got a few thoughts.
  
  
# Pact-Reference Supported Platforms / Architectures

## Legend

- ✅ : Builds with cross and officially supported
- 🧪 : Builds with cross and unofficially released for testing
- 🚧 : Cross image available, doesn't build
- ❌ : doesn't build, (or no cross image available)
- ❓ : Untested
- 👷🏽 : Locally built and tested

## Pact-Reference Target Matrix

| target | notes | tier | cross | pact_ffi | pact_verifier_cli | pact_mock_server_cli
| ---- | ---- | --- | ---- | --- | --- | --- |
| x86_64-pc-windows-msvc| 64-bit MSVC (Windows 7+) | 1 |  ✅ | ✅ | ✅ | ✅ |
| x86_64-apple-darwin |64-bit macOS (10.7+, Lion+)| 1 | ✅ | ✅ | ✅ | ✅ |
| x86_64-unknown-linux-gnu |64-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
| aarch64-unknown-linux-gnu |ARM64 Linux (kernel 4.1, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
| aarch64-apple-darwin |ARM64 macOS (11.0+, Big Sur+)| 2 | ❌ | ✅ |  ✅ |   ✅|
| x86_64-unknown-linux-musl |64-bit Linux with MUSL| 2 | ✅ | ✅ | 🚧 | 🚧 |

## Unofficial Pact-Reference Target Matrix

target lists taken from

- Rust Platform support list <https://doc.rust-lang.org/nightly/rustc/platform-support.html>
- Cross <https://github.com/cross-rs/cross>
- Cargo-xWin <https://github.com/rust-cross/cargo-xwin>

| target | notes | tier | cross | pact_ffi | pact_verifier_cli | pact_mock_server_cli
| ---- | ---- | --- | ---- | --- | --- | --- |
| aarch64-unknown-linux-gnu |ARM64 Linux (kernel 4.1, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
| i686-pc-windows-gnu| 32-bit MinGW (Windows 7+) | 1 |🧪 | 🧪 | 🧪 | 🧪 |
| i686-pc-windows-msvc |32-bit MSVC (Windows 7+) | 1 | 🧪 | 🧪 | 🧪 | 🧪 |
| i686-unknown-linux-gnu| 32-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | 🧪 | 🧪 | 🧪 | 🧪 |
| x86_64-apple-darwin |64-bit macOS (10.7+, Lion+)| 1 | ✅ | ✅ | ✅ | ✅ |
| x86_64-pc-windows-gnu |64-bit MinGW (Windows 7+) | 1 | 🧪 | 🧪 | 🧪 | 🧪 |
| x86_64-pc-windows-msvc| 64-bit MSVC (Windows 7+) | 1 |  ✅ | ✅ | ✅ | ✅ |
| x86_64-unknown-linux-gnu |64-bit Linux (kernel 3.2+, glibc 2.17+)| 1 | ✅ | ✅ | ✅ | ✅ |
| ---- | ---- | --- | ---- | --- | --- | --- |
| aarch64-apple-darwin |ARM64 macOS (11.0+, Big Sur+)| 2 | ❌ | ✅ |  ✅ |   ✅|
| aarch64-pc-windows-msvc| ARM64 Windows MSVC| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
| aarch64-unknown-linux-musl |ARM64 Linux with MUSL| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
| arm-unknown-linux-gnueabi |ARMv6 Linux (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
| arm-unknown-linux-gnueabihf |ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
| armv7-unknown-linux-gnueabihf |ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)| 2 | 🧪 | 🧪 | 🧪 | 🧪 |
| mips-unknown-linux-gnu| MIPS Linux (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
| mips64-unknown-linux-gnuabi64| MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
| mips64el-unknown-linux-gnuabi64| MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
| mipsel-unknown-linux-gnu |MIPS (LE) Linux (kernel 4.4, glibc 2.23)| 2|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-linux-gnu| PowerPC Linux (kernel 3.2, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
| powerpc64-unknown-linux-gnu| PPC64 Linux (kernel 3.2, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
| powerpc64le-unknown-linux-gnu |PPC64LE Linux (kernel 3.10, glibc 2.17)| 2 |🚧  | 🚧  | 🚧   | 🚧  |
| riscv64gc-unknown-linux-gnu| RISC-V Linux (kernel 4.20, glibc 2.29)| 2 | 🚧  | 🚧  | 🚧   | 🚧  |
| s390x-unknown-linux-gnu| S390x Linux (kernel 3.2, glibc 2.17)| 2 | 🚧  | 🚧  | 🚧   | 🚧  |
| x86_64-unknown-freebsd| 64-bit FreeBSD| 2 |🧪 | 🧪 | 🧪 | 🧪 |
| x86_64-unknown-illumos| illumos| 2 |🚧  | 🚧  | 🚧   | 🚧  |
| x86_64-unknown-linux-musl |64-bit Linux with MUSL| 2 | ✅ | ✅ | 🚧 | 🚧 |
| x86_64-unknown-netbsd| NetBSD/amd64| 2 |🧪 | 🧪 | 🧪 | 🧪 |
| ---- | ---- | --- | ---- | --- | --- | --- |
| aarch64-apple-ios | ARM64 iOS| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
| aarch64-apple-ios-sim | Apple iOS Simulator on ARM64| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| aarch64-fuchsia | Alias for aarch64-unknown-fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-fuchsia | ARM64 Fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
| aarch64-linux-android | ARM64 Android| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| aarch64-unknown-none-softfloat | Bare ARM64, softfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-none | Bare ARM64, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-uefi | ARM64 UEFI| 2*|❌ |  ❓ | ❓  |  ❓ |
| arm-linux-androideabi | ARMv7 Android| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
| arm-unknown-linux-musleabi | ARMv6 Linux with MUSL| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
| arm-unknown-linux-musleabihf | ARMv6 Linux with MUSL, hardfloat| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armebv7r-none-eabi | Bare ARMv7-R, Big Endian| 2*|❌ |  ❓ | ❓  |  ❓ |
| armebv7r-none-eabihf | Bare ARMv7-R, Big Endian, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
| armv5te-unknown-linux-gnueabi | ARMv5TE Linux (kernel 4.4, glibc 2.23)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armv5te-unknown-linux-musleabi | ARMv5TE Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armv7-linux-androideabi | ARMv7a Android| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
| armv7-unknown-linux-gnueabi | ARMv7 Linux (kernel 4.15, glibc 2.27)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armv7-unknown-linux-musleabi | ARMv7 Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armv7-unknown-linux-musleabihf | ARMv7 Linux with MUSL, hardfloat| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| armv7a-none-eabi | Bare ARMv7-A| 2*|❌ |  ❓ | ❓  |  ❓ |
| armv7r-none-eabi | Bare ARMv7-R| 2*|❌ |  ❓ | ❓  |  ❓ |
| armv7r-none-eabihf | Bare ARMv7-R, hardfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
| asmjs-unknown-emscripten | asm.js via Emscripten| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| i586-pc-windows-msvc | 32-bit Windows w/o SSE| 2*|❌ |  ❓ | ❓  |  ❓ |
| i586-unknown-linux-gnu | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| i586-unknown-linux-musl | 32-bit Linux w/o SSE, MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| i686-linux-android | 32-bit x86 Android| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| i686-unknown-freebsd | 32-bit FreeBSD| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| i686-unknown-linux-musl | 32-bit Linux with MUSL| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| i686-unknown-uefi | 32-bit UEFIV| 2*|❌ |  ❓ | ❓  |  ❓ |
| mips-unknown-linux-musl | MIPS Linux with MUSL| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| mips64-unknown-linux-muslabi64 | MIPS64 Linux, n64 ABI, MUSL| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| mips64el-unknown-linux-muslabi64 | MIPS64 (LE) Linux, n64 ABI, MUSL| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| mipsel-unknown-linux-musl | MIPS (LE) Linux with MUSL| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| nvptx64-nvidia-cuda | --emit=asm generates PTX code that runs on NVIDIA GPUs| 2*|❌ |  ❓ | ❓  |  ❓ |
| riscv32i-unknown-none-elf | Bare RISC-V (RV32I ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
| riscv32imac-unknown-none-elf | Bare RISC-V (RV32IMAC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
| riscv32imc-unknown-none-elf | Bare RISC-V (RV32IMC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
| riscv64gc-unknown-none-elf | Bare RISC-V (RV64IMAFDC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
| riscv64imac-unknown-none-elf | Bare RISC-V (RV64IMAC ISA)| 2*|❌ |  ❓ | ❓  |  ❓ |
| sparc64-unknown-linux-gnu | SPARC Linux (kernel 4.4, glibc 2.23)| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| sparcv9-sun-solaris | SPARC Solaris 10/11, illumos| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv6m-none-eabi | Bare Cortex-M0, M0+, M1| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| thumbv7em-none-eabi | Bare Cortex-M4, M7| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv7em-none-eabihf | Bare Cortex-M4F, M7F, FPU, hardfloat| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv7m-none-eabi | Bare Cortex-M3| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv7neon-linux-androideabi | Thumb2-mode ARMv7a Android with NEON| 2*| 🧪 | 🧪 | 🧪 | 🧪 |
| thumbv7neon-unknown-linux-gnueabihf | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc | 2.23)| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| thumbv8m.base-none-eabi | ARMv8-M Baseline| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv8m.main-none-eabi | ARMv8-M Mainline| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| thumbv8m.main-none-eabihf | ARMv8-M Mainline, hardfloat| 2*| 🚧  | 🚧  | 🚧   | 🚧  |
| wasm32-unknown-emscripten | WebAssembly via Emscripten| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| wasm32-unknown-unknown | WebAssembly| 2*|❌ |  ❓ | ❓  |  ❓ |
| wasm32-wasi | WebAssembly with WASI| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-apple-ios | 64-bit x86 iOS| 2*|🧪 | 🧪 | 🧪 | 🧪 |
| x86_64-fortanix-unknown-sgx | Fortanix ABI for 64-bit Intel SGX| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-fuchsia | Alias for x86_64-unknown-fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-fuchsia | 64-bit Fuchsia| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-linux-android | 64-bit x86 Android| 2*|🚧  | 🚧  | 🚧   | 🚧  |
| x86_64-pc-solaris | 64-bit Solaris 10/11, illumos| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-linux-gnux32 | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-none | Freestanding/bare-metal x86_64, softfloat| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-redox | Redox OS| 2*|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-uefi | 64-bit UEFI| 2*|❌ |  ❓ | ❓  |  ❓ |
| ---- | ---- | --- | ---- | --- | --- | --- |
| aarch64-apple-ios-macabi |  Apple Catalyst on ARM64|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-apple-tvos |  ARM64 tvOS|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-apple-watchos-sim |  ARM64 Apple WatchOS Simulator|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-kmc-solid_asp3 |  ARM64 SOLID with TOPPERS/ASP3|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-nintendo-switch-freestanding |  ARM64 Nintendo Switch, Horizon|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-pc-windows-gnullvm | | |3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-linux-ohos |  ARM64 OpenHarmony|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-nto-qnx710 |  ARM64 QNX Neutrino 7.1 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-freebsd | | ARM64 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-hermit |  ARM64 HermitCore|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-linux-gnu_ilp32 | | ARM64 Linux (ILP32 ABI)|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-netbsd | | |3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-openbsd | | ARM64 OpenBSD|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-unknown-redox |  ARM64 Redox OS|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
| aarch64-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
| aarch64_be-unknown-linux-gnu_ilp32 | | ARM64 Linux (big-endian, ILP32 ABI)|3|❌ |  ❓ | ❓  |  ❓ |
| aarch64_be-unknown-linux-gnu | | ARM64 Linux (big-endian)|3|❌ |  ❓ | ❓  |  ❓ |
| arm64_32-apple-watchos |  ARM Apple WatchOS 64-bit with 32-bit pointers|3|❌ |  ❓ | ❓  |  ❓ |
| armeb-unknown-linux-gnueabi | | ARM BE8 the default ARM big-endian architecture since | ARMv6.|3|❌ |  ❓ | ❓  |  ❓ |
| armv4t-none-eabi |  ARMv4T A32|3|❌ |  ❓ | ❓  |  ❓ |
| armv4t-unknown-linux-gnueabi |  |3|❌ |  ❓ | ❓  |  ❓ |
| armv5te-none-eabi |  ARMv5TE A32|3|❌ |  ❓ | ❓  |  ❓ |
| armv5te-unknown-linux-uclibceabi |  ARMv5TE Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
| armv6-unknown-freebsd | | ARMv6 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| armv6-unknown-netbsd-eabihf |  |3|❌ |  ❓ | ❓  |  ❓ |
| armv6k-nintendo-3ds |  ARMv6K Nintendo 3DS, Horizon (Requires devkitARM toolchain)|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-apple-ios |  ARMv7 iOS, Cortex-a8|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-sony-vita-newlibeabihf |  ARM Cortex-A9 Sony PlayStation Vita (requires VITASDK | toolchain)|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-unknown-linux-ohos |  ARMv7 OpenHarmony|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-unknown-linux-uclibceabi | | ARMv7 Linux with uClibc, softfloat|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-unknown-linux-uclibceabihf | | ARMv7 Linux with uClibc, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-unknown-freebsd | | ARMv7 FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| armv7-unknown-netbsd-eabihf | | |3|❌ |  ❓ | ❓  |  ❓ |
| armv7-wrs-vxworks-eabihf |  |3|❌ |  ❓ | ❓  |  ❓ |
| armv7a-kmc-solid_asp3-eabi |  ARM SOLID with TOPPERS/ASP3|3|❌ |  ❓ | ❓  |  ❓ |
| armv7a-kmc-solid_asp3-eabihf |  ARM SOLID with TOPPERS/ASP3, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
| armv7a-none-eabihf |  ARM Cortex-A, hardfloat|3|❌ |  ❓ | ❓  |  ❓ |
| armv7k-apple-watchos |  ARM Apple WatchOS|3|❌ |  ❓ | ❓  |  ❓ |
| armv7s-apple-ios |  |3|❌ |  ❓ | ❓  |  ❓ |
| avr-unknown-gnu-atmega328 |  AVR. Requires -Z build-std=core|3|❌ |  ❓ | ❓  |  ❓ |
| bpfeb-unknown-none |  BPF (big endian)|3|❌ |  ❓ | ❓  |  ❓ |
| bpfel-unknown-none |  BPF (little endian)|3|❌ |  ❓ | ❓  |  ❓ |
| hexagon-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
| i386-apple-ios |  32-bit x86 iOS|3|❌ |  ❓ | ❓  |  ❓ |
| i586-pc-nto-qnx700 |  32-bit x86 QNX Neutrino 7.0 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
| i686-apple-darwin | | 32-bit macOS (10.7+, Lion+)|3|❌ |  ❓ | ❓  |  ❓ |
| i686-unknown-haiku | | 32-bit Haiku|3|❌ |  ❓ | ❓  |  ❓ |
| i686-unknown-netbsd | | NetBSD/i386 with SSE2|3|❌ |  ❓ | ❓  |  ❓ |
| i686-unknown-openbsd | | 32-bit OpenBSD|3|❌ |  ❓ | ❓  |  ❓ |
| i686-uwp-windows-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
| i686-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
| i686-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
| loongarch64-unknown-linux-gnu |  LoongArch64 Linux (LP64D ABI)|3|❌ |  ❓ | ❓  |  ❓ |
| m68k-unknown-linux-gnu |  Motorola 680x0 Linux|3|❌ |  ❓ | ❓  |  ❓ |
| mips-unknown-linux-uclibc |  MIPS Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
| mips64-openwrt-linux-musl |  MIPS64 for OpenWrt Linux MUSL|3|❌ |  ❓ | ❓  |  ❓ |
| mipsel-sony-psp |  MIPS (LE) Sony PlayStation Portable (PSP)|3|❌ |  ❓ | ❓  |  ❓ |
| mipsel-sony-psx |  MIPS (LE) Sony PlayStation 1 (PSX)|3|❌ |  ❓ | ❓  |  ❓ |
| mipsel-unknown-linux-uclibc |  MIPS (LE) Linux with uClibc|3|❌ |  ❓ | ❓  |  ❓ |
| mipsel-unknown-none |  Bare MIPS (LE) softfloat|3|❌ |  ❓ | ❓  |  ❓ |
| mipsisa32r6-unknown-linux-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
| mipsisa32r6el-unknown-linux-gnu |  |3|❌ |  ❓ | ❓  |  ❓ |
| mipsisa64r6-unknown-linux-gnuabi64 |  |3|❌ |  ❓ | ❓  |  ❓ |
| mipsisa64r6el-unknown-linux-gnuabi64 |  |3|❌ |  ❓ | ❓  |  ❓ |
| msp430-none-elf |  16-bit MSP430 microcontrollers|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-linux-gnuspe |  PowerPC SPE Linux|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-netbsd | | |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-openbsd |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-wrs-vxworks-spe |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64-unknown-freebsd | | PPC64 FreeBSD (ELFv1 and ELFv2)|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64le-unknown-freebsd   PPC64LE FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc-unknown-freebsd   PowerPC FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64-wrs-vxworks |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64le-unknown-linux-musl |  |3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64-unknown-openbsd | | OpenBSD/powerpc64|3|❌ |  ❓ | ❓  |  ❓ |
| powerpc64-ibm-aix |  64-bit AIX (7.2 and newer)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv32gc-unknown-linux-gnu   RISC-V Linux (kernel 5.4, glibc 2.33)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv32gc-unknown-linux-musl   RISC-V Linux (kernel 5.4, musl + RISCV32 support | patches)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv32im-unknown-none-elf |  Bare RISC-V (RV32IM ISA)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv32imac-unknown-xous-elf |  RISC-V Xous (RV32IMAC ISA)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv32imc-esp-espidf |  RISC-V ESP-IDF|3|❌ |  ❓ | ❓  |  ❓ |
| riscv64gc-unknown-freebsd   RISC-V FreeBSD|3|❌ |  ❓ | ❓  |  ❓ |
| riscv64gc-unknown-fuchsia   RISC-V Fuchsia|3|❌ |  ❓ | ❓  |  ❓ |
| riscv64gc-unknown-linux-musl   RISC-V Linux (kernel 4.20, musl 1.2.0)|3|❌ |  ❓ | ❓  |  ❓ |
| riscv64gc-unknown-openbsd | | OpenBSD/riscv64|3|❌ |  ❓ | ❓  |  ❓ |
| s390x-unknown-linux-musl   S390x Linux (kernel 3.2, MUSL)|3|❌ |  ❓ | ❓  |  ❓ |
| sparc-unknown-linux-gnu |  32-bit SPARC Linux|3|❌ |  ❓ | ❓  |  ❓ |
| sparc64-unknown-netbsd | | NetBSD/sparc64|3|❌ |  ❓ | ❓  |  ❓ |
| sparc64-unknown-openbsd | | OpenBSD/sparc64|3|❌ |  ❓ | ❓  |  ❓ |
| thumbv4t-none-eabi |  ARMv4T T32|3|❌ |  ❓ | ❓  |  ❓ |
| thumbv5te-none-eabi |  ARMv5TE T32|3|❌ |  ❓ | ❓  |  ❓ |
| thumbv7a-pc-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
| thumbv7a-uwp-windows-msvc |  |3|❌ |  ❓ | ❓  |  ❓ |
| thumbv7neon-unknown-linux-musleabihf |  Thumb2-mode ARMv7a Linux with NEON, MUSL|3|❌ |  ❓ | ❓  |  ❓ |
| wasm64-unknown-unknown |  WebAssembly|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-apple-ios-macabi |  Apple Catalyst on x86_64|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-apple-tvos |  x86 64-bit tvOS|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-apple-watchos-sim |  x86 64-bit Apple WatchOS simulator|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-pc-nto-qnx710 |  x86 64-bit QNX Neutrino 7.1 RTOS|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-pc-windows-gnullvm | | |3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64-sun-solaris |  Deprecated target for 64-bit Solaris 10/11, illumos|3| 🚧  | 🚧  | 🚧   | 🚧  |
| x86_64-unknown-dragonfly | | 64-bit DragonFlyBSD|3| 🚧  | 🚧  | 🚧   | 🚧  |
| x86_64-unknown-haiku | | 64-bit Haiku|3|❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-hermit |  HermitCore|3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-l4re-uclibc |  |3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64-unknown-openbsd | | 64-bit OpenBSD|❌ |  ❓ | ❓  |  ❓ |
| x86_64-uwp-windows-gnu |  |3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64-uwp-windows-msvc |  |3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64-wrs-vxworks |  |3| ❌ |  ❓ | ❓  |  ❓ |
| x86_64h-apple-darwin | | macOS with late-gen Intel (at least Haswell)|3| ❌ |  ❓ | ❓  |  ❓ | 