### PR TITLE
fix(pact_verifier): Fix missing PATCH version in plugin's version

### DIFF
--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -484,7 +484,7 @@ fn test_missing_plugin() {
   pactffi_verifier_shutdown(handle);
 
   expect!(result).to(be_equal_to(2));
-  expect!(output.to_string_lossy().contains("Verification execution failed: Plugin missing-csv:0.0 was not found")).to(be_true());
+  expect!(output.to_string_lossy().contains("Verification execution failed: Plugin missing-csv:0.0.3 was not found")).to(be_true());
 }
 
 // Issue #299

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -980,7 +980,7 @@ pub async fn verify_provider_async<F: RequestFilterExecutor, S: ProviderStateExe
             info!("Pact file requires plugins, will load those now");
             for plugin_details in pact.plugin_data() {
               let version = plugin_details.version.split('.')
-                .take(2)
+                .take(3)
                 .join(".");
               load_plugin(&PluginDependency {
                 name: plugin_details.name.clone(),


### PR DESCRIPTION
Fix https://github.com/pact-foundation/pact-plugins/issues/44

~~I don't know how to write test for this. Please show me how if it's required.~~ I guess the 'missing plugin' test is enough to cover this change?