### PR TITLE
chore: update 'could not load pacts' message to 'no pacts found'

### DIFF
--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -1257,9 +1257,9 @@ async fn fetch_pact(
           buffer
         },
         Err(err) => {
-          error!("Could not load pacts from pact broker '{}': {}", broker_url, err);
+          error!("No pacts found in pact broker '{}': {}", broker_url, err);
           vec![
-            Err(anyhow!(err).context(format!("Could not load pacts from pact broker '{}'", broker_url)))
+            Err(anyhow!(err).context(format!("No pacts found in pact broker '{}'", broker_url)))
           ]
         }
       }
@@ -1300,9 +1300,9 @@ async fn fetch_pact(
           buffer
         },
         Err(err) => {
-          error!("Could not load pacts from pact broker '{}': {}", broker_url, err);
+          error!("No pacts found in pact broker '{}': {}", broker_url, err);
           vec![
-            Err(err.context(format!("Could not load pacts from pact broker '{}'", broker_url)))
+            Err(err.context(format!("No pacts found in pact broker '{}'", broker_url)))
           ]
         }
       }


### PR DESCRIPTION
What I'm trying to achieve is to change the message from "Could not load pacts from the pact broker" to "No pacts found matching the given consumer version selectors in pact broker" when there are no pacts returned in the pacts-for-verification response. The current message makes it sound like there was a problem during the actual fetching process. 

I don't think this is the right place, because this code seems to be handling an error, rather than dealing with a `pacts.length == 0` scenario, but I thought I'd start somewhere!