### PR TITLE
fix: Fallback to always generate a value to fix 'Could not generate a random TYPE from null'

### DIFF
--- a/rust/pact_models/src/generators/mod.rs
+++ b/rust/pact_models/src/generators/mod.rs
@@ -1000,16 +1000,32 @@ impl GenerateValue<Value> for Generator {
     matcher: &Box<dyn VariantMatcher + Send + Sync>
   ) -> anyhow::Result<Value> {
     debug!(context = ?context, "Generating value from {:?}", self);
-    let mut rnd = rand::thread_rng();
     let result = match self {
-      Generator::RandomInt(min, max) => Ok(json!(format!("{}", rnd.gen_range(*min..max.saturating_add(1))))),
-      Generator::Uuid(format) => match format.unwrap_or_default() {
-        UuidFormat::Simple => Ok(json!(Uuid::new_v4().as_simple().to_string())),
-        UuidFormat::LowerCaseHyphenated => Ok(json!(Uuid::new_v4().as_hyphenated().to_string())),
-        UuidFormat::UpperCaseHyphenated => Ok(json!(Uuid::new_v4().as_hyphenated().to_string().to_uppercase())),
-        UuidFormat::Urn => Ok(json!(Uuid::new_v4().as_urn().to_string()))
+      Generator::RandomInt(min, max) => {
+        let rand_int = rand::thread_rng().gen_range(*min..max.saturating_add(1));
+        match value {
+          Value::String(_) => Ok(json!(format!("{}", rand_int))),
+          Value::Number(_) => Ok(json!(rand_int)),
+          _ => Ok(json!(rand_int))
+        }
       },
-      Generator::RandomDecimal(digits) => Ok(json!(generate_decimal(*digits as usize))),
+      Generator::Uuid(format) => match value {
+        Value::String(_) => match format.unwrap_or_default() {
+          UuidFormat::Simple => Ok(json!(Uuid::new_v4().as_simple().to_string())),
+          UuidFormat::LowerCaseHyphenated => Ok(json!(Uuid::new_v4().as_hyphenated().to_string())),
+          UuidFormat::UpperCaseHyphenated => Ok(json!(Uuid::new_v4().as_hyphenated().to_string().to_uppercase())),
+          UuidFormat::Urn => Ok(json!(Uuid::new_v4().as_urn().to_string()))
+        },
+        _ => Ok(json!(Uuid::new_v4().as_hyphenated().to_string()))
+      },
+      Generator::RandomDecimal(digits) => match value {
+        Value::String(_) => Ok(json!(generate_decimal(*digits as usize))),
+        Value::Number(_) => match generate_decimal(*digits as usize).parse::<f64>() {
+          Ok(val) => Ok(json!(val)),
+          Err(err) => Err(anyhow!("Could not generate a random decimal from {} - {}", value, err))
+        },
+        _ => Ok(json!(generate_decimal(*digits as usize)))
+      },
       Generator::RandomHexadecimal(digits) => Ok(json!(generate_hexadecimal(*digits as usize))),
       Generator::RandomString(size) => Ok(json!(generate_ascii_string(*size as usize))),
       Generator::Regex(ref regex) => {


### PR DESCRIPTION
Remove the errors similar to `Could not generate a random decimal from null`.

It then allow to use integration json like this:

```
{
    "pact:matcher:type": "null",
    "pact:generator:type": "RandomDecimal"
}
```

This change is for implementing compatibility suite in pact-php (and probably other languages that use FFI calls as well).

For more information, please take a look at this [discussion](https://pact-foundation.slack.com/archives/C02BXLDJ7JR/p1698980611664139)