### PR TITLE
feat: Apply generators to message's metadata

### DIFF
--- a/rust/pact_ffi/src/models/message.rs
+++ b/rust/pact_ffi/src/models/message.rs
@@ -534,6 +534,8 @@ ffi_fn! {
     /// # Safety
     ///
     /// The underlying data must not change during iteration.
+    /// This function must only ever be called from a foreign language. Calling it from a Rust function
+    /// that has a Tokio runtime in its call stack can result in a deadlock.
     ///
     /// # Error Handling
     ///

--- a/rust/pact_ffi/src/models/message.rs
+++ b/rust/pact_ffi/src/models/message.rs
@@ -540,11 +540,13 @@ ffi_fn! {
     /// If no further data is present, returns NULL.
     fn pactffi_message_metadata_iter_next(iter: *mut MessageMetadataIterator) -> *mut MessageMetadataPair {
         let iter = as_mut!(iter);
+        let generated_metadata;
 
         let metadata = match iter.message {
             Either::Left(message) => {
                 let message = as_ref!(message);
-                &message.metadata
+                generated_metadata = block_on(generate_message(message, &GeneratorTestMode::Consumer, &hashmap!{}, &vec![], &hashmap!{})).metadata;
+                &generated_metadata
             }
             Either::Right(contents) => {
                 let contents = as_ref!(contents);


### PR DESCRIPTION
Apply generators to `pactffi_message_metadata_iter_next`

Please review https://github.com/pact-foundation/pact-reference/pull/340 first

For #338