### PR TITLE
refactor: Reuse matching rules and generators processing code

### DIFF
--- a/rust/pact_ffi/src/mock_server/bodies.rs
+++ b/rust/pact_ffi/src/mock_server/bodies.rs
@@ -148,6 +148,7 @@ fn process_matcher(
         Category::HEADER => &GeneratorCategory::HEADER,
         Category::PATH => &GeneratorCategory::PATH,
         Category::QUERY => &GeneratorCategory::QUERY,
+        Category::METADATA => &GeneratorCategory::METADATA,
         _ => {
           warn!("invalid generator category {} provided, defaulting to body", matching_rules.name);
           &GeneratorCategory::BODY

--- a/rust/pact_ffi/src/mock_server/handles.rs
+++ b/rust/pact_ffi/src/mock_server/handles.rs
@@ -2145,6 +2145,7 @@ pub extern fn pactffi_message_with_metadata(message_handle: MessageHandle, key: 
 pub extern fn pactffi_message_with_metadata_v2(message_handle: MessageHandle, key: *const c_char, value: *const c_char) {
   if let Some(key) = convert_cstr("key", key) {
     let value = convert_cstr("value", value).unwrap_or_default();
+    trace!("pactffi_message_with_metadata_v2(message_handle: {:?}, key: {:?}, value: {})", message_handle, key, value);
 
     message_handle.with_message(&|_, inner, _| {
       if let Some(message) = inner.as_v4_async_message_mut() {
@@ -2152,43 +2153,15 @@ pub extern fn pactffi_message_with_metadata_v2(message_handle: MessageHandle, ke
         let generators = &mut message.contents.generators;
         let value = match serde_json::from_str(value) {
           Ok(json) => match json {
-            Value::Object(ref obj) => {
-              if let Some(matcher_type) = obj.get("pact:matcher:type") {
-                debug!("detected pact:matcher:type, will configure a matcher");
-                let matcher_type = json_to_string(matcher_type);
-                let attributes = Value::Object(obj.clone());
-                let rule = MatchingRule::create(matcher_type.as_str(), &attributes).unwrap();
-                matching_rules.add_rule(DocPath::new(key).unwrap(), rule.clone(), RuleLogic::And);
-              }
-              if let Some(gen) = obj.get("pact:generator:type") {
-                debug!("detected pact:generator:type, will configure a generators");
-                if let Some(generator) = Generator::from_map(&json_to_string(gen), obj) {
-                  generators.add_generator_with_subcategory(&GeneratorCategory::METADATA, DocPath::new(key).unwrap(), generator);
-                }
-              }
-              match obj.get("value") {
-                Some(inner) => match inner {
-                  Value::Array(_) => {
-                    warn!("Array value is not supported");
-                    Value::Null
-                  }
-                  Value::Object(_) => {
-                    warn!("Object value is not supported");
-                    Value::Null
-                  }
-                  _ => inner.clone()
-                },
-                None => Value::Null
-              }
-            },
-            Value::String(string) => Value::String(string.to_string()),
-            _ => {
-              warn!("Only support object or string");
-              Value::String(value.to_string())
-            }
+            Value::Object(ref map) => process_object(map, matching_rules, generators, DocPath::new(key).unwrap(), false),
+            Value::Array(ref array) => process_array(array, matching_rules, generators, DocPath::new(key).unwrap(), false, false),
+            Value::Null => Value::Null,
+            Value::String(string) => Value::String(string),
+            Value::Bool(bool) => Value::Bool(bool),
+            Value::Number(number) => Value::Number(number),
           },
           Err(err) => {
-            warn!("Failed to parse metadata from JSON - {}", err);
+            warn!("Failed to parse metadata value '{}' as JSON - {}. Will treat it as string", value, err);
             Value::String(value.to_string())
           }
         };


### PR DESCRIPTION
Reuse code to:
* Support nested matching rules and generators instead of single level
* Support any types for metadata's value, not just string
* Fix `null` when `pact:matcher:type` is not set in JSON object e.g. `JSON: { "ID": "sjhdjkshsdjh", "weight": 100.5 }`