### PR TITLE
test(pact_matching): Test more cases for ContentType matcher

### DIFF
--- a/rust/pact_ffi/src/matching.rs
+++ b/rust/pact_ffi/src/matching.rs
@@ -386,19 +386,4 @@ mod tests {
     let string = unsafe { CString::from_raw(err_result as *mut c_char) };
     expect!(string.to_string_lossy()).to(be_equal_to("Failed to parse actual JSON: EOF while parsing a string at line 1 column 11"));
   }
-
-  #[test_log::test]
-  fn pactffi_matches_string_value_using_content_type_matching_rule_test() {
-    let rule = MatchingRule::ContentType("text/plain".to_string());
-    let rule_ptr = &rule as *const MatchingRule;
-    let value = CString::new("testing").unwrap();
-
-    let exact_value = CString::new("testing").unwrap();
-    let exact_result = pactffi_matches_string_value(rule_ptr, value.as_ptr(), exact_value.as_ptr(), 0);
-    expect!(exact_result.is_null()).to(be_true());
-
-    let different_value = CString::new("testing_123").unwrap();
-    let different_result = pactffi_matches_string_value(rule_ptr, value.as_ptr(), different_value.as_ptr(), 0);
-    expect!(different_result.is_null()).to(be_true());
-  }
 }

--- a/rust/pact_matching/src/json.rs
+++ b/rust/pact_matching/src/json.rs
@@ -977,6 +977,26 @@ mod tests {
     expect!(Value::String("100".into()).matches_with(&Value::Null, &matcher, false)).to(be_ok());
   }
 
+  #[test]
+  fn content_type_matcher_test() {
+    let matcher = MatchingRule::ContentType("text/plain".to_string());
+    expect!(Value::String("plain text".into()).matches_with(&Value::String("plain text".into()), &matcher, false)).to(be_ok());
+    expect!(Value::String("plain text".into()).matches_with(&Value::String("different text".into()), &matcher, false)).to(be_ok());
+    expect!(Value::String("plain text".into()).matches_with(&json!(100), &matcher, false)).to(be_ok());
+    expect!(Value::String("plain text".into()).matches_with(&json!(100.01), &matcher, false)).to(be_ok());
+    #[cfg(not(windows))]
+    {
+      let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+      <note>
+        <to>Tove</to>
+        <from>Jani</from>
+        <heading>Reminder</heading>
+        <body>Don't forget me this weekend!</body>
+      </note>"#;
+      expect!(Value::String("plain text".into()).matches_with(Value::String(xml.into()), &matcher, false)).to(be_err());
+    }
+  }
+
   #[test_log::test]
   fn compare_maps_handles_wildcard_matchers() {
     let val1 = request!(r#"

--- a/rust/pact_matching/src/matchers.rs
+++ b/rust/pact_matching/src/matchers.rs
@@ -1231,4 +1231,23 @@ mod tests {
     expect!(json!("1.0.0").matches_with(&json!("1.0.0"), &matcher, false)).to(be_ok());
     expect!(json!("1.0.0").matches_with(&json!("1"), &matcher, false)).to(be_err());
   }
+
+  #[test]
+  fn content_type_matcher_test() {
+    let matcher = MatchingRule::ContentType("text/plain".to_string());
+    expect!("plain text".matches_with("plain text", &matcher, false)).to(be_ok());
+    expect!("plain text".matches_with("different text", &matcher, false)).to(be_ok());
+    expect!("plain text".matches_with(100, &matcher, false)).to(be_err());
+    #[cfg(not(windows))]
+    {
+      let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+      <note>
+        <to>Tove</to>
+        <from>Jani</from>
+        <heading>Reminder</heading>
+        <body>Don't forget me this weekend!</body>
+      </note>"#;
+      expect!("plain text".matches_with(xml, &matcher, false)).to(be_err());
+    }
+  }
 }


### PR DESCRIPTION
I added `pactffi_matches_string_value_using_content_type_matching_rule_test` before, but it only test 2 cases but need a lot lines of code.

I found a shorter way to test, so I refactor + add more cases to it.