### PR TITLE
feat: build aarch64-pc-windows-msvc target (ffi/mock_server/verifier)

### DIFF
--- a/rust/pact_ffi/release-win.sh
+++ b/rust/pact_ffi/release-win.sh
@@ -9,3 +9,12 @@ gzip -c ../target/release/pact_ffi.dll.lib > ../target/artifacts/pact_ffi-window
 openssl dgst -sha256 -r ../target/artifacts/pact_ffi-windows-x86_64.dll.lib.gz > ../target/artifacts/pact_ffi-windows-x86_64.dll.lib.gz.sha256
 gzip -c ../target/release/pact_ffi.lib > ../target/artifacts/pact_ffi-windows-x86_64.lib.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_ffi-windows-x86_64.lib.gz > ../target/artifacts/pact_ffi-windows-x86_64.lib.gz.sha256
+
+echo -- Build the aarch64 release artifacts --
+cargo build --target aarch64-pc-windows-msvc --release
+gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.dll > ../target/artifacts/pact_ffi-windows-aarch64.dll.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_ffi-windows-aarch64.dll.gz > ../target/artifacts/pact_ffi-windows-aarch64.dll.gz.sha256
+gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.dll.lib > ../target/artifacts/pact_ffi-windows-aarch64.dll.lib.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_ffi-windows-aarch64.dll.lib.gz > ../target/artifacts/pact_ffi-windows-aarch64.dll.lib.gz.sha256
+gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.lib > ../target/artifacts/pact_ffi-windows-aarch64.lib.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_ffi-windows-aarch64.lib.gz > ../target/artifacts/pact_ffi-windows-aarch64.lib.gz.sha256

--- a/rust/pact_mock_server_cli/release-win.sh
+++ b/rust/pact_mock_server_cli/release-win.sh
@@ -5,3 +5,9 @@ mkdir -p ../target/artifacts
 cargo build --release
 gzip -c ../target/release/pact_mock_server_cli.exe > ../target/artifacts/pact_mock_server_cli-windows-x86_64.exe.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-windows-x86_64.exe.gz > ../target/artifacts/pact_mock_server_cli-windows-x86_64.exe.gz.sha256
+
+echo -- Build the aarch64 release artifacts --
+
+cargo build --target aarch64-pc-windows-msvc --release
+gzip -c ../target/aarch64-pc-windows-msvc/release/pact_mock_server_cli.exe > ../target/artifacts/pact_mock_server_cli-windows-aarch64.exe.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-windows-aarch64.exe.gz > ../target/artifacts/pact_mock_server_cli-windows-aarch64.exe.gz.sha256

--- a/rust/pact_verifier_cli/release-win.sh
+++ b/rust/pact_verifier_cli/release-win.sh
@@ -4,3 +4,9 @@ mkdir -p ../target/artifacts
 cargo build --release
 gzip -c ../target/release/pact_verifier_cli.exe > ../target/artifacts/pact_verifier_cli-windows-x86_64.exe.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-windows-x86_64.exe.gz > ../target/artifacts/pact_verifier_cli-windows-x86_64.exe.gz.sha256
+
+echo -- Build the aarch64 release artifacts --
+
+cargo build --target aarch64-pc-windows-msvc --release
+gzip -c ../target/aarch64-pc-windows-msvc/release/pact_verifier_cli.exe > ../target/artifacts/pact_verifier_cli-windows-aarch64.exe.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-windows-aarch64.exe.gz > ../target/artifacts/pact_verifier_cli-windows-aarch64.exe.gz.sha256


### PR DESCRIPTION
fixes #325 

Previously this was failing without a work-around due to an issue in ring 16.x but it has since been updated to use ring 17.x and CI builds successfully for all three of our distributed executables/libraries