### PR TITLE
chore: renable verifier aarch64 linux

### DIFF
--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -37,7 +37,7 @@ gzip -c ../target/x86_64-unknown-linux-musl/release/libpact_ffi.a > ../target/ar
 openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-linux-x86_64-musl.a.gz > ../target/artifacts/libpact_ffi-linux-x86_64-musl.a.gz.sha256
 
 echo -- Build the aarch64 release artifacts --
-cargo install cross --git https://github.com/cross-rs/cross
+cargo install cross@0.2.5
 cross build --target aarch64-unknown-linux-gnu --release
 gzip -c ../target/aarch64-unknown-linux-gnu/release/libpact_ffi.so > ../target/artifacts/libpact_ffi-linux-aarch64.so.gz
 openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-linux-aarch64.so.gz > ../target/artifacts/libpact_ffi-linux-aarch64.so.gz.sha256

--- a/rust/pact_ffi/release-osx.sh
+++ b/rust/pact_ffi/release-osx.sh
@@ -9,11 +9,10 @@ gzip -c ../target/release/libpact_ffi.a > ../target/artifacts/libpact_ffi-osx-x8
 openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-osx-x86_64.a.gz > ../target/artifacts/libpact_ffi-osx-x86_64.a.gz.sha256
 
 # M1
-#export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-#export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-#cargo build --target aarch64-apple-darwin --release
-cargo install cross --git https://github.com/cross-rs/cross
-cross build --target aarch64-apple-darwin --release
+export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+cargo install cross@0.2.5
+cargo build --target aarch64-apple-darwin --release
 
 gzip -c ../target/aarch64-apple-darwin/release/libpact_ffi.dylib > ../target/artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz
 openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz > ../target/artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz.sha256

--- a/rust/pact_ffi/release-osx.sh
+++ b/rust/pact_ffi/release-osx.sh
@@ -11,7 +11,6 @@ openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-osx-x86_64.a.gz > ../tar
 # M1
 export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
 export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-cargo install cross@0.2.5
 cargo build --target aarch64-apple-darwin --release
 
 gzip -c ../target/aarch64-apple-darwin/release/libpact_ffi.dylib > ../target/artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz

--- a/rust/pact_mock_server_cli/release-linux.sh
+++ b/rust/pact_mock_server_cli/release-linux.sh
@@ -8,7 +8,7 @@ gzip -c ../target/release/pact_mock_server_cli > ../target/artifacts/pact_mock_s
 openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-linux-x86_64.gz > ../target/artifacts/pact_mock_server_cli-linux-x86_64.gz.sha256
 
 echo -- Build the aarch64 release artifacts --
-cargo install cross
+cargo install cross@0.2.5
 cross build --target aarch64-unknown-linux-gnu --release
 gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_mock_server_cli > ../target/artifacts/pact_mock_server_cli-linux-aarch64.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_mock_server_cli-linux-aarch64.gz > ../target/artifacts/pact_mock_server_cli-linux-aarch64.gz.sha256

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -9,7 +9,8 @@ openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-linux-x86_64.gz > 
 
 # aarch64 is failing to build on Rust 1.70+, and the dependencies need Rust 1.70+
 #echo -- Build the aarch64 release artifacts --
-#cargo install cross
+
+#cargo install cross@0.2.5
 #cross build --target aarch64-unknown-linux-gnu --release
 #gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_verifier_cli > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz
 #openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-linux-aarch64.gz > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz.sha256

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -7,10 +7,9 @@ cargo build --release
 gzip -c ../target/release/pact_verifier_cli > ../target/artifacts/pact_verifier_cli-linux-x86_64.gz
 openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-linux-x86_64.gz > ../target/artifacts/pact_verifier_cli-linux-x86_64.gz.sha256
 
-# aarch64 is failing to build on Rust 1.70+, and the dependencies need Rust 1.70+
-#echo -- Build the aarch64 release artifacts --
+echo -- Build the aarch64 release artifacts --
 
-#cargo install cross@0.2.5
-#cross build --target aarch64-unknown-linux-gnu --release
-#gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_verifier_cli > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz
-#openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-linux-aarch64.gz > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz.sha256
+cargo install cross@0.2.5
+cross build --target aarch64-unknown-linux-gnu --release
+gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_verifier_cli > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz
+openssl dgst -sha256 -r ../target/artifacts/pact_verifier_cli-linux-aarch64.gz > ../target/artifacts/pact_verifier_cli-linux-aarch64.gz.sha256


### PR DESCRIPTION
Appears to build correctly when pinning to Cross 0.2.5