### PR TITLE
chore: update artifact path for aarch64 musl pact_ffi

### DIFF
--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -39,8 +39,8 @@ openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-x86_64-musl.a.gz 
 cargo install cross@0.2.5
 echo -- Build the musl aarch64 release artifacts --
 cross build --release --target=aarch64-unknown-linux-musl
-gzip -c ../target/aarch64-unknown-linux-musl/release/libpact_ffi.a > ../target/artifacts/libpact_ffi-linux-aarch64-musl.a.gz
-openssl dgst -sha256 -r ../target/artifacts/libpact_ffi-linux-aarch64-musl.a.gz > ../target/artifacts/libpact_ffi-linux-aarch64-musl.a.gz.sha256
+gzip -c ../target/aarch64-unknown-linux-musl/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz
+openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz > ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz.sha256
 
 echo -- Build the aarch64 release artifacts --
 cargo clean


### PR DESCRIPTION
One change didn't make the cut when I split my changes into multiple PR's meaning the aarch64 musl artifacts are generated but missing from the release