### PR TITLE
feat: Print provider name in 'no pacts found' message to help debugging

### DIFF
--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -1273,9 +1273,9 @@ async fn fetch_pact(
           buffer
         },
         Err(err) => {
-          error!("No pacts found in pact broker '{}': {}", broker_url, err);
+          error!("No pacts found for provider '{}' in pact broker '{}': {}", provider_name, broker_url, err);
           vec![
-            Err(anyhow!(err).context(format!("No pacts found in pact broker '{}'", broker_url)))
+            Err(anyhow!(err).context(format!("No pacts found for provider '{}' in pact broker '{}'", provider_name, broker_url)))
           ]
         }
       }
@@ -1316,9 +1316,9 @@ async fn fetch_pact(
           buffer
         },
         Err(err) => {
-          error!("No pacts found matching the given consumer version selectors in pact broker '{}': {}", broker_url, err);
+          error!("No pacts found for provider '{}' matching the given consumer version selectors in pact broker '{}': {}", provider_name, broker_url, err);
           vec![
-            Err(err.context(format!("No pacts found matching the given consumer version selectors in pact broker '{}'", broker_url)))
+            Err(err.context(format!("No pacts found for provider '{}' matching the given consumer version selectors in pact broker '{}'", provider_name, broker_url)))
           ]
         }
       }


### PR DESCRIPTION
Provider name is optional, and default value is 'provider'.

When verifier is configured without provider name (probably new user not knowing it, or forget about it), and there is (high chance that) no provider has the name 'provider', verifier print this message:

`No pacts found matching the given consumer version selectors in pact broker`

This message is not wrong, but it is hard to debug in this situation
