### PR TITLE
feat: Rephrase the content type matching error message

### DIFF
--- a/rust/pact_matching/src/json.rs
+++ b/rust/pact_matching/src/json.rs
@@ -257,7 +257,7 @@ impl Matches<&Value> for Value {
       },
       MatchingRule::ContentType(ref expected_content_type) => {
         match_content_type(&convert_data(actual), expected_content_type)
-          .map_err(|err| anyhow!("Expected data to have a content type of '{}' but was {}", expected_content_type, err))
+          .map_err(|err| anyhow!("Failed to match data to have a content type of '{}': {}", expected_content_type, err))
       }
       MatchingRule::Boolean => match actual {
         Value::Bool(_) => Ok(()),

--- a/rust/pact_matching/src/matchingrules.rs
+++ b/rust/pact_matching/src/matchingrules.rs
@@ -148,7 +148,7 @@ impl Matches<&[u8]> for Vec<u8> {
       }
       MatchingRule::ContentType(ref expected_content_type) => {
         match_content_type(actual, expected_content_type)
-          .map_err(|err| anyhow!("Expected data to have a content type of '{}' but was {}", expected_content_type, err))
+          .map_err(|err| anyhow!("Failed to match data to have a content type of '{}': {}", expected_content_type, err))
       }
       MatchingRule::NotEmpty => {
         if actual.is_empty() {


### PR DESCRIPTION
The old error message is a little bit confusing:

`Expected data to have a content type of 'text/html' but was Expected binary contents to have content type 'text/html' but detected contents was 'text/plain'`

The updated one will be:

`Failed to match data to have a content type of 'text/html': Expected binary contents to have content type 'text/html' but detected contents was 'text/plain'`