### PR TITLE
feat: convert musl static .a to .so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: runner.os == 'Linux'
+        uses: docker/setup-buildx-action@v3
       - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'Linux'
         run: ./release-linux.sh
         working-directory: rust/pact_mock_server_cli


### PR DESCRIPTION
This allows client libraries which only provide the ability to load dynamically shared libraries `*.so` to utilise the pact ffi functionality.

Tested in Ruby, PHP and .NET as part of https://github.com/pact-foundation/devrel/issues/30

This PR also builds the x86_64 musl artifact with cross 0.2.5 as per the aarch64 musl artifact. I'm happy to remove this if required, but it seems to make sense to align them across our artifacts if they build.

Happy to make any changes or take anything out