### PR TITLE
[FFI] Functions for v4/http_consumer compatibility suite

### DIFF
--- a/rust/pact_ffi/src/mock_server/handles.rs
+++ b/rust/pact_ffi/src/mock_server/handles.rs
@@ -2110,6 +2110,33 @@ ffi_fn!{
   }
 }
 
+ffi_fn!{
+  /// Mark the interaction as pending.
+  ///
+  /// * `interaction` - Interaction handle to modify.
+  /// * `pending` - Boolean value to toggle the pending state of the interaction.
+  ///
+  /// This function will return `true` if the key was successfully updated.
+  fn pactffi_set_pending(interaction: InteractionHandle, pending: bool) -> bool {
+    interaction.with_interaction(&|_, _, inner| {
+      if let Some(reqres) = inner.as_v4_http_mut() {
+        reqres.pending = pending;
+        Ok(())
+      } else if let Some(message) = inner.as_v4_async_message_mut() {
+        message.pending = pending;
+        Ok(())
+      } else if let Some(sync_message) = inner.as_v4_sync_message_mut() {
+        sync_message.pending = pending;
+        Ok(())
+      } else {
+        error!("Interaction is an unknown type, is {}", inner.type_of());
+        Err(anyhow!("Interaction is an unknown type, is {}", inner.type_of()))
+      }
+    }).unwrap_or(Err(anyhow!("Not value to unwrap"))).is_ok()
+  } {
+    false
+  }
+}
 
 fn convert_ptr_to_body(body: *const u8, size: size_t, content_type: Option<ContentType>) -> OptionalBody {
   if body.is_null() {

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -41,8 +41,8 @@ use pact_ffi::mock_server::handles::{
   pactffi_new_message,
   pactffi_new_message_pact,
   pactffi_new_pact,
-  pactffi_with_specification,
   pactffi_response_status,
+  pactffi_set_key,
   pactffi_upon_receiving,
   pactffi_with_binary_file,
   pactffi_with_body,
@@ -51,6 +51,7 @@ use pact_ffi::mock_server::handles::{
   pactffi_with_multipart_file_v2,
   pactffi_with_query_parameter_v2,
   pactffi_with_request,
+  pactffi_with_specification,
   pactffi_write_message_pact_file
 };
 use pact_ffi::mock_server::handles::{pact_default_file_name, pactffi_free_pact_handle, pactffi_given_with_params, pactffi_pact_handle_write_file, pactffi_with_header_v2, PactHandle};
@@ -227,6 +228,34 @@ fn create_multipart_file_v2() {
     boundary = boundary
   ));
   assert_eq!(expected_req_body, body);
+}
+
+#[test]
+fn set_key() {
+  let consumer_name = CString::new("consumer").unwrap();
+  let provider_name = CString::new("provider").unwrap();
+  let pact_handle = pactffi_new_pact(consumer_name.as_ptr(), provider_name.as_ptr());
+  let description = CString::new("set_key").unwrap();
+  let interaction = pactffi_new_interaction(pact_handle, description.as_ptr());
+  let key = CString::new("foobar").unwrap();
+
+  assert!(pactffi_set_key(interaction, key.as_ptr()));
+
+  interaction.with_interaction(&|_, _, i| {
+    assert_eq!(
+      i.as_v4_http().unwrap().key,
+      Some("foobar".to_string())
+    )
+  });
+
+  assert!(pactffi_set_key(interaction, null()));
+
+  interaction.with_interaction(&|_, _, i| {
+    assert_eq!(
+      i.as_v4_http().unwrap().key,
+      None
+    )
+  });
 }
 
 #[test_log::test]

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -31,6 +31,10 @@ use pact_ffi::mock_server::{
 #[allow(deprecated)]
 use pact_ffi::mock_server::handles::{
   InteractionPart,
+  PactHandle,
+  pact_default_file_name,
+  pactffi_free_pact_handle,
+  pactffi_given_with_params,
   pactffi_message_expects_to_receive,
   pactffi_message_given,
   pactffi_message_reify,
@@ -41,20 +45,22 @@ use pact_ffi::mock_server::handles::{
   pactffi_new_message,
   pactffi_new_message_pact,
   pactffi_new_pact,
+  pactffi_pact_handle_write_file,
   pactffi_response_status,
   pactffi_set_key,
+  pactffi_set_pending,
   pactffi_upon_receiving,
   pactffi_with_binary_file,
   pactffi_with_body,
   pactffi_with_header,
+  pactffi_with_header_v2,
   pactffi_with_multipart_file,
   pactffi_with_multipart_file_v2,
   pactffi_with_query_parameter_v2,
   pactffi_with_request,
   pactffi_with_specification,
-  pactffi_write_message_pact_file
+  pactffi_write_message_pact_file,
 };
-use pact_ffi::mock_server::handles::{pact_default_file_name, pactffi_free_pact_handle, pactffi_given_with_params, pactffi_pact_handle_write_file, pactffi_with_header_v2, PactHandle};
 use pact_ffi::verifier::{
   OptionsFlags,
   pactffi_verifier_add_directory_source,
@@ -254,6 +260,33 @@ fn set_key() {
     assert_eq!(
       i.as_v4_http().unwrap().key,
       None
+    )
+  });
+}
+
+#[test]
+fn set_pending() {
+  let consumer_name = CString::new("consumer").unwrap();
+  let provider_name = CString::new("provider").unwrap();
+  let pact_handle = pactffi_new_pact(consumer_name.as_ptr(), provider_name.as_ptr());
+  let description = CString::new("set_pending").unwrap();
+  let interaction = pactffi_new_interaction(pact_handle, description.as_ptr());
+
+  assert!(pactffi_set_pending(interaction, true));
+
+  interaction.with_interaction(&|_, _, i| {
+    assert_eq!(
+      i.as_v4_http().unwrap().pending,
+      true,
+    )
+  });
+
+  assert!(pactffi_set_pending(interaction, false));
+
+  interaction.with_interaction(&|_, _, i| {
+    assert_eq!(
+      i.as_v4_http().unwrap().pending,
+      false,
     )
   });
 }

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -47,6 +47,7 @@ use pact_ffi::mock_server::handles::{
   pactffi_new_pact,
   pactffi_pact_handle_write_file,
   pactffi_response_status,
+  pactffi_set_comment,
   pactffi_set_key,
   pactffi_set_pending,
   pactffi_upon_receiving,
@@ -287,6 +288,60 @@ fn set_pending() {
     assert_eq!(
       i.as_v4_http().unwrap().pending,
       false,
+    )
+  });
+}
+
+#[test]
+fn set_comment() {
+  let consumer_name = CString::new("consumer").unwrap();
+  let provider_name = CString::new("provider").unwrap();
+  let pact_handle = pactffi_new_pact(consumer_name.as_ptr(), provider_name.as_ptr());
+  let description = CString::new("set_comment").unwrap();
+  let interaction = pactffi_new_interaction(pact_handle, description.as_ptr());
+
+  let key_int = CString::new("key_int").unwrap();
+  let value_int = CString::new("1234").unwrap();
+  let key_str = CString::new("key_str").unwrap();
+  let value_str = CString::new("some string").unwrap();
+  let key_bool = CString::new("key_bool").unwrap();
+  let value_bool = CString::new("true").unwrap();
+  let key_float = CString::new("key_float").unwrap();
+  let value_float = CString::new("12.34").unwrap();
+  let key_array = CString::new("key_array").unwrap();
+  let value_array = CString::new("[1, 2, 3]").unwrap();
+  let key_obj = CString::new("key_object").unwrap();
+  let value_obj = CString::new("{\"key\": \"value\"}").unwrap();
+
+  assert!(pactffi_set_comment(interaction, key_int.as_ptr(), value_int.as_ptr()));
+  assert!(pactffi_set_comment(interaction, key_str.as_ptr(), value_str.as_ptr()));
+  assert!(pactffi_set_comment(interaction, key_bool.as_ptr(), value_bool.as_ptr()));
+  assert!(pactffi_set_comment(interaction, key_float.as_ptr(), value_float.as_ptr()));
+  assert!(pactffi_set_comment(interaction, key_array.as_ptr(), value_array.as_ptr()));
+  assert!(pactffi_set_comment(interaction, key_obj.as_ptr(), value_obj.as_ptr()));
+
+  interaction.with_interaction(&|_, _, i| {
+    let interaction = i.as_v4_http().unwrap();
+    assert_eq!(interaction.comments["key_int"], json!(1234));
+    assert_eq!(interaction.comments["key_str"], json!("some string"));
+    assert_eq!(interaction.comments["key_bool"], json!(true));
+    assert_eq!(interaction.comments["key_float"], json!(12.34));
+    assert_eq!(interaction.comments["key_array"], json!([1, 2, 3]));
+    assert_eq!(interaction.comments["key_object"], json!({"key": "value"}));
+  });
+
+  assert!(pactffi_set_comment(interaction, key_int.as_ptr(), null()));
+  assert!(pactffi_set_comment(interaction, key_str.as_ptr(), null()));
+  assert!(pactffi_set_comment(interaction, key_bool.as_ptr(), null()));
+  assert!(pactffi_set_comment(interaction, key_float.as_ptr(), null()));
+  assert!(pactffi_set_comment(interaction, key_array.as_ptr(), null()));
+  assert!(pactffi_set_comment(interaction, key_obj.as_ptr(), null()));
+
+  interaction.with_interaction(&|_, _, i| {
+    let interaction = i.as_v4_http().unwrap();
+    assert_eq!(
+      interaction.comments,
+      hashmap!{}
     )
   });
 }


### PR DESCRIPTION
## Summary

Add three new FFI methods:

- `pactffi_set_key(interaction: InteractionHandle, value: &const c_char)`
- `pactffi_set_pending(interaction: InteractionHandle: pending: bool)`
- `pactffi_set_comment(interaction: interactionHandle, key: &const c_char, value: &const c_char)`

These update an interactions key, pending status, and comments respectively.

## Motivation

While implementing the HTTP Consumer V4 compatibility suite, I realise there was no straightforward way to update these attributes of an interaction.

## AI Summary

This pull request primarily focuses on enhancing the interaction handling capabilities in the `rust/pact_ffi` library. The changes include the addition of new functions to set key attributes, mark interactions as pending, and add comments to interactions. The tests have also been updated to reflect these new functionalities.

New functionalities added:

* [`rust/pact_ffi/src/mock_server/handles.rs`](diffhunk://#diff-d2ed99251aebcb3c325d1e2650a83cec3b1a8d470d9b524784b0797073b47fbdR2067-R2209): Added three new functions `pactffi_set_key`, `pactffi_set_pending`, and `pactffi_set_comment` to allow users to set key attributes, mark interactions as pending, and add comments to interactions respectively. These functions take in an interaction handle and the necessary parameters, perform the required operations, and return a boolean indicating the success of the operation.

Updates in tests:

* [`rust/pact_ffi/tests/tests.rs`](diffhunk://#diff-d6fdf640e7952e605d5a425978e18d3aa2606501c1b9743426f76dc5989178daR34-R37): Imported the newly added functions from `pact_ffi::mock_server::handles` and added new tests to verify their functionality. The tests `set_key`, `set_pending`, and `set_comment` ensure that the respective functions correctly modify the interaction's properties and handle edge cases, such as clearing the key or comments. [[1]](diffhunk://#diff-d6fdf640e7952e605d5a425978e18d3aa2606501c1b9743426f76dc5989178daR34-R37) [[2]](diffhunk://#diff-d6fdf640e7952e605d5a425978e18d3aa2606501c1b9743426f76dc5989178daL44-L56) [[3]](diffhunk://#diff-d6fdf640e7952e605d5a425978e18d3aa2606501c1b9743426f76dc5989178daR240-R353)