### PR TITLE
Chore/fix pactffi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,88 +2,142 @@ name: Release workflow
 
 on:
   release:
-    types: [published]
+    types:
+      - published
+
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-release:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, windows-latest, macos-11]
+        include:
+          - operating-system: ubuntu-20.04
+            targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
+          - operating-system: windows-2019
+            targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
+          - operating-system: macos-12
+            targets: aarch64-apple-darwin,x86_64-apple-darwin
+      fail-fast: false
+
     env:
       pact_do_not_track: true
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Install stable Rust toolchain
-        if: runner.os == 'Linux'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          targets: aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl
-      - name: Install stable Rust toolchain
-        if: runner.os == 'Windows'
-        uses: dtolnay/rust-toolchain@stable
+          targets: ${{ matrix.targets }}
+
+      - name: Rust caching
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
-          targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
-      - name: Install stable Rust toolchain
-        if: runner.os == 'MacOS'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 12.4
-        if: runner.os == 'MacOS'
+          workspaces: rust
+
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: runner.os == 'Linux'
         uses: docker/setup-buildx-action@v3
-      - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'Linux'
-        run: ./release-linux.sh
+
+      - name: Platform abbreviation
+        id: platform-abbreviation
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" = "Linux" ]]; then
+            echo "platform=linux" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ runner.os }}" = "Windows" ]]; then
+            echo "platform=win" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ runner.os }}" = "macOS" ]]; then
+            echo "platform=osx" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unknown platform"
+            exit 1
+          fi
+
+      - name: Cargo flags
+        id: cargo-flags
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" = "release" ]]; then
+            echo "flags=--release" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build mock server CLI
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+        shell: bash
+        run: |
+          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+            ${{ steps.cargo-flags.outputs.flags }}
         working-directory: rust/pact_mock_server_cli
-      - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'Windows'
-        run: ./release-win.sh
+
+      - name: Build verifier CLI
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          startsWith(github.ref, 'refs/tags/pact_verifier_cli')
         shell: bash
-        working-directory: rust/pact_mock_server_cli
-      - if: startsWith(github.ref, 'refs/tags/pact_mock_server_cli') && runner.os == 'macOS'
-        run: ./release-osx.sh
-        shell: bash
-        working-directory: rust/pact_mock_server_cli
-      - if: startsWith(github.ref, 'refs/tags/pact_verifier_cli') && runner.os == 'Linux'
-        run: ./release-linux.sh
+        run: |
+          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+            ${{ steps.cargo-flags.outputs.flags }}
         working-directory: rust/pact_verifier_cli
-      - if: startsWith(github.ref, 'refs/tags/pact_verifier_cli') && runner.os == 'Windows'
-        run: ./release-win.sh
+
+      - name: Build FFI library
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          startsWith(github.ref, 'refs/tags/libpact_ffi')
         shell: bash
-        working-directory: rust/pact_verifier_cli
-      - if: startsWith(github.ref, 'refs/tags/pact_verifier_cli') && runner.os == 'macOS'
-        run: ./release-osx.sh
-        shell: bash
-        working-directory: rust/pact_verifier_cli
-      - if: startsWith(github.ref, 'refs/tags/libpact_ffi') && runner.os == 'Linux'
-        run: ./release-linux.sh
+        run: |
+          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+            ${{ steps.cargo-flags.outputs.flags }}
         working-directory: rust/pact_ffi
-      - if: startsWith(github.ref, 'refs/tags/libpact_ffi') && runner.os == 'Windows'
-        run: ./release-win.sh
-        shell: bash
-        working-directory: rust/pact_ffi
-      - if: startsWith(github.ref, 'refs/tags/libpact_ffi') && runner.os == 'macOS'
-        run: ./release-osx.sh
-        shell: bash
-        working-directory: rust/pact_ffi
+
       - name: Upload the artifacts
-        if: startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
-        uses: actions/upload-artifact@v3.1.2
+        if: |
+          startsWith(github.ref, 'refs/tags/libpact_ffi')  ||
+          startsWith(github.ref, 'refs/tags/pact_verifier_cli') ||
+          startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+        uses: actions/upload-artifact@v4
         with:
-          name: release-artifacts
+          name: release-artifacts-${{ matrix.operating-system }}
           path: rust/release_artifacts
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.ref, 'refs/tags/libpact_ffi')  ||
+      startsWith(github.ref, 'refs/tags/pact_verifier_cli') ||
+      startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+    needs: build-release
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-artifacts-*
+          path: rust/release_artifacts
+
       - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/libpact_ffi')  || startsWith(github.ref, 'refs/tags/pact_verifier_cli') || startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
-        uses: svenstaro/upload-release-action@2.5.0
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/release_artifacts/*

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -1,75 +1,124 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -e
+set -x
 
-echo -- Setup directories --
-cargo clean
-mkdir -p ../release_artifacts
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-echo -- Build the Docker build image --
-docker build -f Dockerfile.linux-build -t pact-ffi-build .
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
-echo -- Build the release artifacts --
-docker run -t --rm --user "$(id -u)":"$(id -g)" -v $(pwd)/..:/workspace -w /workspace/pact_ffi pact-ffi-build -c 'cargo build --release'
-gzip -c ../target/release/libpact_ffi.so > ../release_artifacts/libpact_ffi-linux-x86_64.so.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-x86_64.so.gz > ../release_artifacts/libpact_ffi-linux-x86_64.so.gz.sha256
-gzip -c ../target/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-linux-x86_64.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-x86_64.a.gz > ../release_artifacts/libpact_ffi-linux-x86_64.a.gz.sha256
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
 
-echo -- Generate the header files --
-rustup toolchain install nightly
-rustup component add rustfmt --toolchain nightly
-rustup run nightly cbindgen \
-  --config cbindgen.toml \
-  --crate pact_ffi \
-  --output include/pact.h
-rustup run nightly cbindgen \
-  --config cbindgen-c++.toml \
-  --crate pact_ffi \
-  --output include/pact-cpp.h
-cp include/*.h ../release_artifacts
+# Build the x86_64 GNU linux release
+build_x86_64_gnu() {
+    cargo build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
 
-echo -- Build the musl release artifacts --
-cargo install cross@0.2.5
-cross build --release --target=x86_64-unknown-linux-musl
-gzip -c ../target/x86_64-unknown-linux-musl/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-linux-x86_64-musl.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-x86_64-musl.a.gz > ../release_artifacts/libpact_ffi-linux-x86_64-musl.a.gz.sha256
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.a.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.so.gz"
+    fi
+}
 
-mkdir tmp 
-cp ../target/x86_64-unknown-linux-musl/release/libpact_ffi.a tmp/
-docker run --platform=linux/amd64 --rm -v $PWD/tmp:/scratch alpine /bin/sh -c 'apk add --no-cache musl-dev gcc && \ 
+build_x86_64_musl() {
+    sudo apt-get install -y musl-tools
+    cargo build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        BUILD_SCRIPT=$(cat <<EOM
+apk add --no-cache musl-dev gcc && \
 cd /scratch && \
-    ar -x libpact_ffi.a && \
-    gcc -shared *.o -o libpact_ffi.so && \
-    rm -f *.o'
+ar -x libpact_ffi.a && \
+gcc -shared *.o -o libpact_ffi.so && \
+rm -f *.o
+EOM
+        )
 
-gzip -c tmp/libpact_ffi.so > ../release_artifacts/libpact_ffi-linux-x86_64-musl.so.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-x86_64-musl.so.gz > ../release_artifacts/libpact_ffi-linux-x86_64-musl.so.gz.sha256
-rm -rf tmp
+        docker run \
+            --platform=linux/amd64 \
+            --rm \
+            -v "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release:/scratch" \
+            alpine \
+            /bin/sh -c "$BUILD_SCRIPT"
 
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.a.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.so.gz"
+    fi
+}
 
-echo -- Build the musl aarch64 release artifacts --
-cargo clean
-cross build --release --target=aarch64-unknown-linux-musl
-gzip -c ../target/aarch64-unknown-linux-musl/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz > ../release_artifacts/libpact_ffi-linux-aarch64-musl.a.gz.sha256
+install_cross() {
+    cargo install cross@0.2.5
+}
 
-mkdir tmp 
-cp ../target/aarch64-unknown-linux-musl/release/libpact_ffi.a tmp/
-docker run --platform=linux/arm64 --rm -v $PWD/tmp:/scratch alpine /bin/sh -c 'apk add --no-cache musl-dev gcc && \ 
+build_aarch64_gnu() {
+    install_cross
+    cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.a.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.so.gz"
+    fi
+}
+
+build_aarch64_musl() {
+    install_cross
+    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        BUILD_SCRIPT=$(cat <<EOM
+apk add --no-cache musl-dev gcc && \
 cd /scratch && \
-    ar -x libpact_ffi.a && \
-    gcc -shared *.o -o libpact_ffi.so && \
-    rm -f *.o'
+ar -x libpact_ffi.a && \
+gcc -shared *.o -o libpact_ffi.so && \
+rm -f *.o
+EOM
+        )
 
-gzip -c tmp/libpact_ffi.so > ../release_artifacts/libpact_ffi-linux-aarch64-musl.so.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-aarch64-musl.so.gz > ../release_artifacts/libpact_ffi-linux-aarch64-musl.so.gz.sha256
-rm -rf tmp
+        docker run \
+            --platform=linux/arm64 \
+            --rm \
+            -v "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release:/scratch" \
+            alpine \
+            /bin/sh -c "$BUILD_SCRIPT"
 
-echo -- Build the aarch64 release artifacts --
-cargo clean
-cross build --target aarch64-unknown-linux-gnu --release
-gzip -c ../target/aarch64-unknown-linux-gnu/release/libpact_ffi.so > ../release_artifacts/libpact_ffi-linux-aarch64.so.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-aarch64.so.gz > ../release_artifacts/libpact_ffi-linux-aarch64.so.gz.sha256
-gzip -c ../target/aarch64-unknown-linux-gnu/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-linux-aarch64.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-linux-aarch64.a.gz > ../release_artifacts/libpact_ffi-linux-aarch64.a.gz.sha256
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.a.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.so.gz"
+    fi
+}
+
+build_header() {
+    rustup toolchain install nightly
+    rustup run nightly cbindgen \
+        --config cbindgen.toml \
+        --crate pact_ffi \
+        --output "$ARTIFACTS_DIR/pact.h"
+    rustup run nightly cbindgen \
+        --config cbindgen-c++.toml \
+        --crate pact_ffi \
+        --output "$ARTIFACTS_DIR/pact-cpp.h"
+}
+
+build_x86_64_gnu
+build_x86_64_musl
+build_aarch64_gnu
+build_aarch64_musl
+build_header

--- a/rust/pact_ffi/release-osx.sh
+++ b/rust/pact_ffi/release-osx.sh
@@ -1,19 +1,48 @@
-#!/bin/bash -e
+#!/bin/bash
 
-cargo clean
-cargo build --release
-mkdir -p ../release_artifacts
-gzip -c ../target/release/libpact_ffi.dylib > ../release_artifacts/libpact_ffi-osx-x86_64.dylib.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-osx-x86_64.dylib.gz > ../release_artifacts/libpact_ffi-osx-x86_64.dylib.gz.sha256
-gzip -c ../target/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-osx-x86_64.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-osx-x86_64.a.gz > ../release_artifacts/libpact_ffi-osx-x86_64.a.gz.sha256
+set -e
+set -x
 
-# M1
-export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-cargo build --target aarch64-apple-darwin --release
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-gzip -c ../target/aarch64-apple-darwin/release/libpact_ffi.dylib > ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz > ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz.sha256
-gzip -c ../target/aarch64-apple-darwin/release/libpact_ffi.a > ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.a.gz
-openssl dgst -sha256 -r ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.a.gz > ../release_artifacts/libpact_ffi-osx-aarch64-apple-darwin.a.gz.sha256
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
+# We target the oldest supported version of macOS.
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}
+
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+
+# Build the x86_64 darwin release
+build_x86_64() {
+    cargo build --target x86_64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/libpact_ffi.dylib" \
+            "$ARTIFACTS_DIR/libpact_ffi-osx-x86_64.dylib.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-osx-x86_64.a"
+    fi
+}
+
+# Build the aarch64 darwin release
+build_aarch64() {
+    cargo build --target aarch64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/libpact_ffi.dylib" \
+            "$ARTIFACTS_DIR/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-osx-aarch64-apple-darwin.a"
+    fi
+}
+
+build_x86_64
+build_aarch64

--- a/rust/pact_ffi/release-win.sh
+++ b/rust/pact_ffi/release-win.sh
@@ -1,21 +1,52 @@
-#!/bin/bash -e
+#!/bin/bash
 
-cargo clean
-cargo build --release
-mkdir -p ../release_artifacts
+set -e
+set -x
 
-gzip -c ../target/release/pact_ffi.dll > ../release_artifacts/pact_ffi-windows-x86_64.dll.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-x86_64.dll.gz > ../release_artifacts/pact_ffi-windows-x86_64.dll.gz.sha256
-gzip -c ../target/release/pact_ffi.dll.lib > ../release_artifacts/pact_ffi-windows-x86_64.dll.lib.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-x86_64.dll.lib.gz > ../release_artifacts/pact_ffi-windows-x86_64.dll.lib.gz.sha256
-gzip -c ../target/release/pact_ffi.lib > ../release_artifacts/pact_ffi-windows-x86_64.lib.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-x86_64.lib.gz > ../release_artifacts/pact_ffi-windows-x86_64.lib.gz.sha256
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-echo -- Build the aarch64 release artifacts --
-cargo build --target aarch64-pc-windows-msvc --release
-gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.dll > ../release_artifacts/pact_ffi-windows-aarch64.dll.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-aarch64.dll.gz > ../release_artifacts/pact_ffi-windows-aarch64.dll.gz.sha256
-gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.dll.lib > ../release_artifacts/pact_ffi-windows-aarch64.dll.lib.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-aarch64.dll.lib.gz > ../release_artifacts/pact_ffi-windows-aarch64.dll.lib.gz.sha256
-gzip -c ../target/aarch64-pc-windows-msvc/release/pact_ffi.lib > ../release_artifacts/pact_ffi-windows-aarch64.lib.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_ffi-windows-aarch64.lib.gz > ../release_artifacts/pact_ffi-windows-aarch64.lib.gz.sha256
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+
+# Build the x86_64 windows release
+build_x86_64() {
+    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+
+    # If --release in cargo flags, then gzip and sum the release artifacts
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_ffi.dll" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-x86_64.dll.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_ffi.dll.lib" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-x86_64.dll.lib.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_ffi.lib" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-x86_64.lib.gz"
+    fi
+}
+
+# Build the aarch64 windows release
+build_aarch64() {
+    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_ffi.dll" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-aarch64.dll.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_ffi.dll.lib" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-aarch64.dll.lib.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_ffi.lib" \
+            "$ARTIFACTS_DIR/pact_ffi-windows-aarch64.lib.gz"
+    fi
+}
+
+build_x86_64
+build_aarch64

--- a/rust/pact_mock_server_cli/release-linux.sh
+++ b/rust/pact_mock_server_cli/release-linux.sh
@@ -1,28 +1,66 @@
-#!/bin/bash -xe
+#!/bin/bash
 
-cargo clean
+set -e
+set -x
 
-mkdir -p ../release_artifacts
-cargo build --release
-gzip -c ../target/release/pact_mock_server_cli > ../release_artifacts/pact_mock_server_cli-linux-x86_64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-linux-x86_64.gz > ../release_artifacts/pact_mock_server_cli-linux-x86_64.gz.sha256
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-echo -- Build the aarch64 release artifacts --
-cargo install cross@0.2.5
-cargo clean
-cross build --target aarch64-unknown-linux-gnu --release
-gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_mock_server_cli > ../release_artifacts/pact_mock_server_cli-linux-aarch64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-linux-aarch64.gz > ../release_artifacts/pact_mock_server_cli-linux-aarch64.gz.sha256
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
-echo -- Build the musl release artifacts --
-sudo apt install musl-tools
-rustup target add x86_64-unknown-linux-musl
-cargo build --release --target=x86_64-unknown-linux-musl
-gzip -c ../target/x86_64-unknown-linux-musl/release/pact_mock_server_cli > ../release_artifacts/pact_mock_server_cli-linux-x86_64-musl.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-linux-x86_64-musl.gz > ../release_artifacts/pact_mock_server_cli-linux-x86_64-musl.gz.sha256
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
 
-echo -- Build the musl aarch64 release artifacts --
-cargo clean
-cross build --release --target=aarch64-unknown-linux-musl
-gzip -c ../target/aarch64-unknown-linux-musl/release/pact_mock_server_cli > ../release_artifacts/pact_mock_server_cli-linux-aarch64-musl.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-linux-aarch64-musl.gz > ../release_artifacts/pact_mock_server_cli-linux-aarch64-musl.gz.sha256
+build_x86_64_gnu() {
+    cargo build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/pact_mock_server_cli" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-linux-x86_64.gz"
+    fi
+}
+
+build_x86_64_musl() {
+    sudo apt-get install -y musl-tools
+    cargo build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/pact_mock_server_cli" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-linux-x86_64-musl.gz"
+    fi
+}
+
+install_cross() {
+    cargo install cross@0.2.5
+}
+
+build_aarch64_gnu() {
+    install_cross
+    cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/pact_mock_server_cli" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-linux-aarch64.gz"
+    fi
+}
+
+build_aarch64_musl() {
+    install_cross
+    cross build --target=aarch64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/pact_mock_server_cli" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-linux-aarch64-musl.gz"
+    fi
+}
+
+build_x86_64_gnu
+build_x86_64_musl
+build_aarch64_gnu
+build_aarch64_musl

--- a/rust/pact_mock_server_cli/release-win.sh
+++ b/rust/pact_mock_server_cli/release-win.sh
@@ -1,13 +1,40 @@
 #!/bin/bash
 
-cargo clean
-mkdir -p ../release_artifacts
-cargo build --release
-gzip -c ../target/release/pact_mock_server_cli.exe > ../release_artifacts/pact_mock_server_cli-windows-x86_64.exe.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-windows-x86_64.exe.gz > ../release_artifacts/pact_mock_server_cli-windows-x86_64.exe.gz.sha256
+set -e
+set -x
 
-echo -- Build the aarch64 release artifacts --
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-cargo build --target aarch64-pc-windows-msvc --release
-gzip -c ../target/aarch64-pc-windows-msvc/release/pact_mock_server_cli.exe > ../release_artifacts/pact_mock_server_cli-windows-aarch64.exe.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_mock_server_cli-windows-aarch64.exe.gz > ../release_artifacts/pact_mock_server_cli-windows-aarch64.exe.gz.sha256
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+
+# Build the x86_64 windows release
+build_x86_64() {
+    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+
+    # If --release in cargo flags, then gzip and sum the release artifacts
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_mock_server_cli.exe" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-windows-x86_64.exe.gz"
+    fi
+}
+
+# Build the aarch64 windows release
+build_aarch64() {
+    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_mock_server_cli.exe" \
+            "$ARTIFACTS_DIR/pact_mock_server_cli-windows-aarch64.exe.gz"
+    fi
+}
+
+build_x86_64
+build_aarch64

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -1,29 +1,65 @@
-#!/bin/bash -xe
+#!/bin/bash
 
-cargo clean
+set -e
+set -x
 
-mkdir -p ../release_artifacts
-cargo build --release
-gzip -c ../target/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-linux-x86_64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-linux-x86_64.gz > ../release_artifacts/pact_verifier_cli-linux-x86_64.gz.sha256
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-echo -- Build the aarch64 release artifacts --
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
-cargo install cross@0.2.5
-cargo clean
-cross build --target aarch64-unknown-linux-gnu --release
-gzip -c ../target/aarch64-unknown-linux-gnu/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-linux-aarch64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-linux-aarch64.gz > ../release_artifacts/pact_verifier_cli-linux-aarch64.gz.sha256
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
 
-echo -- Build the musl release artifacts --
-sudo apt install musl-tools
-rustup target add x86_64-unknown-linux-musl
-cargo build --release --target=x86_64-unknown-linux-musl
-gzip -c ../target/x86_64-unknown-linux-musl/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-linux-x86_64-musl.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-linux-x86_64-musl.gz > ../release_artifacts/pact_verifier_cli-linux-x86_64-musl.gz.sha256
+build_x86_64_gnu() {
+    cargo build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
 
-echo -- Build the musl aarch64 release artifacts --
-cargo clean
-cross build --release --target=aarch64-unknown-linux-musl
-gzip -c ../target/aarch64-unknown-linux-musl/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-linux-aarch64-musl.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-linux-aarch64-musl.gz > ../release_artifacts/pact_verifier_cli-linux-aarch64-musl.gz.sha256
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/pact_verifier_cli" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-linux-x86_64.gz"
+    fi
+}
+
+build_x86_64_musl() {
+    sudo apt-get install -y musl-tools
+    cargo build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-linux-x86_64-musl.gz"
+    fi
+}
+
+install_cross() {
+    cargo install cross@0.2.5
+}
+
+build_aarch64_gnu() {
+    install_cross
+    cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/pact_verifier_cli" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-linux-aarch64.gz"
+    fi
+}
+
+build_aarch64_musl() {
+    install_cross
+    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
+        "$ARTIFACTS_DIR/pact_verifier_cli-linux-aarch64-musl.gz"
+    fi
+}
+
+build_x86_64_gnu
+build_x86_64_musl
+build_aarch64_gnu
+build_aarch64_musl

--- a/rust/pact_verifier_cli/release-osx.sh
+++ b/rust/pact_verifier_cli/release-osx.sh
@@ -1,14 +1,42 @@
-#!/bin/bash -xe
+#!/bin/bash
 
-mkdir -p ../release_artifacts
-cargo build --release
-gzip -c ../target/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-osx-x86_64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-osx-x86_64.gz > ../release_artifacts/pact_verifier_cli-osx-x86_64.gz.sha256
+set -e
+set -x
 
-# M1
-export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
-cargo build --target aarch64-apple-darwin --release
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-gzip -c ../target/aarch64-apple-darwin/release/pact_verifier_cli > ../release_artifacts/pact_verifier_cli-osx-aarch64.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-osx-aarch64.gz > ../release_artifacts/pact_verifier_cli-osx-aarch64.gz.sha256
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
+# We target the oldest supported version of macOS.
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}
+
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
+
+# Build the x86_64 darwin release
+build_x86_64() {
+    cargo build --target x86_64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/pact_verifier_cli" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-osx-x86_64.gz"
+    fi
+}
+
+# Build the aarch64 darwin release
+build_aarch64() {
+    cargo build --target aarch64-apple-darwin "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR//aarch64-apple-darwin/release/pact_verifier_cli" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-osx-aarch64.gz"
+    fi
+}
+
+build_x86_64
+build_aarch64

--- a/rust/pact_verifier_cli/release-win.sh
+++ b/rust/pact_verifier_cli/release-win.sh
@@ -1,14 +1,39 @@
 #!/bin/bash
 
-mkdir -p ../release_artifacts
-cargo build --release
+set -e
+set -x
 
-gzip -c ../target/release/pact_verifier_cli.exe > ../release_artifacts/pact_verifier_cli-windows-x86_64.exe.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-windows-x86_64.exe.gz > ../release_artifacts/pact_verifier_cli-windows-x86_64.exe.gz.sha256
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 
-echo -- Build the aarch64 release artifacts --
+source "$RUST_DIR/scripts/gzip-and-sum.sh"
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
+mkdir -p "$ARTIFACTS_DIR"
+export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
-cargo build --target aarch64-pc-windows-msvc --release
-gzip -c ../target/aarch64-pc-windows-msvc/release/pact_verifier_cli.exe > ../release_artifacts/pact_verifier_cli-windows-aarch64.exe.gz
-openssl dgst -sha256 -r ../release_artifacts/pact_verifier_cli-windows-aarch64.exe.gz > ../release_artifacts/pact_verifier_cli-windows-aarch64.exe.gz.sha256
+# All flags passed to this script are passed to cargo.
+cargo_flags=( "$@" )
 
+# Build the x86_64 windows release
+build_x86_64() {
+    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_verifier_cli.exe" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-windows-x86_64.exe.gz"
+    fi
+}
+
+# Build the aarch64 windows release
+build_aarch64() {
+    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
+
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_verifier_cli.exe" \
+            "$ARTIFACTS_DIR/pact_verifier_cli-windows-aarch64.exe.gz"
+    fi
+}
+
+build_x86_64
+build_aarch64

--- a/rust/scripts/gzip-and-sum.sh
+++ b/rust/scripts/gzip-and-sum.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Gzip and sum a file.
+#
+# Usage: gzip_and_sum <orig_file> <target_file> [<digest_file>]
+#
+# - orig_file: the file to gzip and sum
+# - target_file: the file to write the gzipped file to
+# - digest_file: the file to write the digest to. If not provided, defaults to
+#   <target_file>.sha256
+gzip_and_sum() {
+    orig_file=$1
+    target_file=$2
+    digest_file=${3:-$target_file.sha256}
+
+    gzip --stdout --best "$orig_file" > "$target_file"
+    openssl dgst -sha256 -r "$target_file" > "$digest_file"
+}


### PR DESCRIPTION
## Summary

Hopefully fixes the issue with the release pipeline discovered when creating `0.4.18`.

The main changes:

- A refactor of the `release-osx.sh` script (primarily DRYing code), and importantly **removes the setting of `SDKROOT` and `MAXOSX_DEPLOYMENT_TARGET`**. @YOU54F, I believe you added these, so please let me know if that is likely to cause an issue.
- A refactor of the release pipeline (primarily DRYing code)
- Updating to using the latest OS runners

## Motivation

Hopefully, to resolve the release script failure.

I was thinking of updating the release script to run on PRs as well (to detect failures, though without the creation of artefacts), but ultimately opted not to do so as the pipeline can be slow and may not be necessary if the other pipeline succeed.