### PR TITLE
ci(fix): add setup-xcode action to pin to 12.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 12.4
+        if: runner.os == 'MacOS'
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
github action runner images appear to have been updated and despite mentioning xcode 12.4 in the runner image readme

https://github.com/actions/runner-images/blob/macOS-11/20240127.1/images/macos/macos-11-Readme.md#xcode

It is no longer being found and causes x86_64 builds for macos to fail

Relates to #391 

Has been tested in my fork (albeit with additional changes to pull in the musl aware version of the pact-plugin-driver, updated index and some tweaks to reduce the size of the output binaries)

https://github.com/YOU54F/pact-reference/releases/tag/libpact_ffi-v0.4.18