### PR TITLE
fix: binary body lifetime issue

### DIFF
--- a/rust/pact_ffi/src/mock_server/handles.rs
+++ b/rust/pact_ffi/src/mock_server/handles.rs
@@ -2233,7 +2233,7 @@ fn convert_ptr_to_body(body: *const u8, size: size_t, content_type: Option<Conte
   } else if size == 0 {
     OptionalBody::Empty
   } else {
-    OptionalBody::Present(Bytes::from(unsafe { std::slice::from_raw_parts(body, size) }), content_type, None)
+    OptionalBody::Present(Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(body, size) }), content_type, None)
   }
 }
 


### PR DESCRIPTION
There's a subtle lifetime issue created in the original code. The original code uses:

- `Bytes::from(&'static [u8])`
- `from_raw_parts<'a, T>(*const T, usize) -> &'a [T]`

Which requires the `*const T` pointer be a static pointer. Being provided through the FFI, this is unreasonable, and we should expect it to last only as long as the function call itself.

By simply replacing `Bytes::from` with `Bytes::from_from_slice`, we narrow down the lifetime from `'static` to `'a`, allowing for the underlying `*const T` pointer to be deallocated once the function has returned.