### PR TITLE
chore(ci): fix upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           pattern: release-artifacts-*
           path: rust/release_artifacts
+          merge-multiple: true
 
       - name: Upload Release Assets
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Fix an issue resulting in no artifacts being uploaded to the release. The issue is two-fold:

- The `download-artifact` action by default, when there are multiple sources, is to extract each artifact in its own subdirectory.
- The `upload-release-action` only matches for files in the `rust/release_artifacts` directory, and importantly not any subdirectory.

The fix here is to simply toggle the `merge-multiple` to prevent artifacts from being extracted into separate subdirectories.