### PR TITLE
chore(ci): verifier - fix ref to build_aarch64 func post building wit…

### DIFF
--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -28,7 +28,7 @@ install_cross() {
     cargo install cross@0.2.5
 }
 
-build_aarch64_musl() {
+build_aarch64() {
     install_cross
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
 


### PR DESCRIPTION
…h musl only

Thanks @rholshausen for building our executables with musl for both architectures on linux, dropping the need to retain two sets of binaries for linux 

Failure seen here

https://github.com/pact-foundation/pact-reference/actions/runs/8291686804/job/22691789837