### PR TITLE
Feat/composing matching rules

### DIFF
--- a/rust/pact_ffi/IntegrationJson.md
+++ b/rust/pact_ffi/IntegrationJson.md
@@ -157,3 +157,86 @@ Here the `interests` attribute would be expanded to
   }
 }
 ```
+
+## Supporting multiple matching rules
+
+Matching rules can be combined. These rules will be evaluated with an AND (i.e. all the rules must match successfully 
+for the result to be successful). The main reason to do this is to combine the `EachKey` and `EachValue` matching rules
+on a map structure, but other rules make sense to combine (like the `include` matcher).
+
+To provide multiple matchers, you need to provide an array format. 
+
+For example, assume you have an API that returns results for a document store where the documents are keyed based on some index:
+```json
+{
+  "results": {
+    "AUK-155332": {
+      "title": "...",
+      "description": "...",
+      "link": "http://....",
+      "relatesTo": ["BAF-88654"]
+    }
+  }
+}
+```
+
+Here you may want to provide a matching rule for the keys that they conform to the `AAA-NNNNNNN...` format, as well
+as a type matcher for the values.
+
+So the resulting intermediate JSON would be something like:
+```json
+{
+  "results": {
+    "pact:matcher:type": [
+      {
+        "pact:matcher:type": "each-key",
+        "value": "AUK-155332",
+        "rules": [
+          {
+            "pact:matcher:type": "regex",
+            "regex": "\\w{3}-\\d+"
+          }
+        ]
+      }, {
+        "pact:matcher:type": "each-value",
+        "rules": [
+          {
+            "pact:matcher:type": "type"
+          }
+        ]
+      }
+    ],
+    "AUK-155332": {
+      "title": "...",
+      "description": "...",
+      "link": "http://....",
+      "relatesTo": ["BAF-88654"]
+    }
+  }
+}
+```
+
+## Supporting matching rule definitions
+
+You can use the [matching rule definition expressions](https://docs.rs/pact_models/latest/pact_models/matchingrules/expressions/index.html) 
+in the `pact:matcher:type` field.
+
+For example, with the previous document result JSON, you could then use the following for the `relatesTo` field:
+
+```json
+{
+  "relatesTo": {
+    "pact:matcher:type": "eachValue(matching(regex, '\\w{3}-\\d+', 'BAF-88654'))"
+  }
+}
+```
+
+You can then also combine matchers:
+
+```json
+{
+  "relatesTo": {
+    "pact:matcher:type": "atLeast(1), atMost(10), eachValue(matching(regex, '\\w{3}-\\d+', 'BAF-88654'))"
+  }
+}
+```

--- a/rust/pact_ffi/src/mock_server/bodies.rs
+++ b/rust/pact_ffi/src/mock_server/bodies.rs
@@ -195,8 +195,9 @@ pub fn matchers_from_integration_json(m: &Map<String, Value>) -> anyhow::Result<
             Some(t) => {
               let val = json_to_string(t);
               let rule = MatchingRule::create(val.as_str(), &v)
-                .inspect_err(|err| {
+                .map_err(|err| {
                   error!("Failed to create matching rule from JSON '{:?}': {}", m, err);
+                  err
                 })?;
               rules.push(rule);
             }
@@ -212,8 +213,9 @@ pub fn matchers_from_integration_json(m: &Map<String, Value>) -> anyhow::Result<
         let val = json_to_string(value);
         MatchingRule::create(val.as_str(), &Value::Object(m.clone()))
           .map(|r| vec![r])
-          .inspect_err(|err| {
+          .map_err(|err| {
             error!("Failed to create matching rule from JSON '{:?}': {}", m, err);
+            err
           })
       }
     },

--- a/rust/pact_ffi/src/mock_server/handles.rs
+++ b/rust/pact_ffi/src/mock_server/handles.rs
@@ -970,17 +970,17 @@ fn from_integration_json_v2(
   let query_or_header = [Category::QUERY, Category::HEADER].contains(&matching_rules.name);
 
   match serde_json::from_str(value) {
-    Ok(mut json) => match &mut json {
+    Ok(json) => match &json {
       Value::Object(map) => {
         let result = if map.contains_key("pact:matcher:type") {
           debug!("detected pact:matcher:type, will configure any matchers");
           let rules = matchers_from_integration_json(map);
           trace!("matching_rules = {rules:?}");
 
-          let (path, result_value) = match map.get_mut("value") {
+          let (path, result_value) = match map.get("value") {
             Some(val) => match val {
               Value::Array(array) => {
-                let array = process_array(array.as_mut_slice(), matching_rules, generators, path.clone(), true, false);
+                let array = process_array(array.as_slice(), matching_rules, generators, path.clone(), true, false);
                 (path.clone(), array)
               },
               _ => (path.clone(), val.clone())
@@ -1062,7 +1062,7 @@ fn from_integration_json_v2(
 pub(crate) fn process_xml(body: String, matching_rules: &mut MatchingRuleCategory, generators: &mut Generators) -> Result<Vec<u8>, String> {
   trace!("process_xml");
   match serde_json::from_str(&body) {
-    Ok(mut json) => match &mut json {
+    Ok(json) => match &json {
       Value::Object(map) => xml::generate_xml_body(map, matching_rules, generators),
       _ => Err(format!("JSON document is invalid (expected an Object), have {}", json))
     },

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -9,7 +9,6 @@ use bytes::Bytes;
 use expectest::prelude::*;
 use itertools::Itertools;
 use libc::c_char;
-use log::LevelFilter;
 use maplit::*;
 use pact_models::bodies::OptionalBody;
 use pact_models::PactSpecification;
@@ -27,8 +26,7 @@ use pact_ffi::mock_server::{
   pactffi_create_mock_server,
   pactffi_create_mock_server_for_pact,
   pactffi_mock_server_mismatches,
-  pactffi_write_pact_file,
-  pactffi_mock_server_logs
+  pactffi_write_pact_file
 };
 #[allow(deprecated)]
 use pact_ffi::mock_server::handles::{
@@ -76,7 +74,6 @@ use pact_ffi::verifier::{
   pactffi_verifier_set_provider_info,
   pactffi_verifier_shutdown
 };
-use pact_ffi::log::pactffi_log_to_buffer;
 
 #[test]
 fn post_to_mock_server_with_mismatches() {


### PR DESCRIPTION
Implements #399 

TLDR - This allows an array to be specified with the `pact:matcher:type` attribute to be able to have multiple matching rules.

For example, you could do something like (just making this up, may not be valid):

```json
{
    "pact:matcher:type": [
        { "pact:matcher:type": "regex", "regex": "\\w{3}-\\d+" },
        { "pact:matcher:type": "include", "value": "XYZ" }
    ]
}
```