### PR TITLE
chore: build linux x86_64 ffi against glibc 2.23

### DIFF
--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
         rust: [ stable ]
     env:
       pact_do_not_track: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
         rust: [ stable ]
     env:
       pact_do_not_track: true

--- a/rust/Cross.toml
+++ b/rust/Cross.toml
@@ -1,3 +1,9 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build=[
+    "apt-get update && apt-get install --assume-yes wget unzip",
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+]
 [target.aarch64-unknown-linux-gnu]
 pre-build=[
     "dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes wget unzip",

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -15,7 +15,9 @@ cargo_flags=( "$@" )
 
 # Build the x86_64 GNU linux release
 build_x86_64_gnu() {
-    cargo build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
+    install_cross
+    cargo clean
+    cross build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
@@ -29,6 +31,7 @@ build_x86_64_gnu() {
 
 build_x86_64_musl() {
     sudo apt-get install -y musl-tools
+    cargo clean
     cargo build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -63,6 +66,7 @@ install_cross() {
 
 build_aarch64_gnu() {
     install_cross
+    cargo clean
     cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -77,6 +81,7 @@ build_aarch64_gnu() {
 
 build_aarch64_musl() {
     install_cross
+    cargo clean
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then


### PR DESCRIPTION
use cross 0.2.5 to build `x86_64-unknown-linux-gnu`

cargo clean prior to building

pr to trigger release workflow

fixes https://github.com/pact-foundation/pact-js-core/issues/502