### PR TITLE
Strip ANSI escapes from JUnit output

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2219,6 +2219,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.4",
  "serde_json",
+ "strip-ansi-escapes",
  "time",
  "tokio",
  "tracing",

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -18,8 +18,8 @@ default = ["datetime", "xml", "plugins", "multipart", "junit"]
 datetime = ["pact_models/datetime", "pact_verifier/datetime"] # Support for date/time matchers and expressions
 xml = ["pact_models/xml", "pact_verifier/xml"] # support for matching XML documents
 plugins = ["pact_verifier/plugins"]
-multipart = ["pact_verifier/multipart"] # suport for MIME multipart bodies
-junit = ["dep:junit-report"] # suport for MIME multipart bodies
+multipart = ["pact_verifier/multipart"] # support for MIME multipart bodies
+junit = ["dep:junit-report", "dep:strip-ansi-escapes"] # support for Junit format reports
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -34,6 +34,7 @@ pact_verifier = { version = "~1.2.1", path = "../pact_verifier", default-feature
 regex = "1.10.2"
 reqwest = { version = "0.12.4", default-features = false, features = ["rustls-tls-native-roots", "blocking", "json"] }
 serde_json = "1.0.108"
+strip-ansi-escapes = { version = "0.2.0", optional = true }
 time = "0.3.31"
 tokio = { version = "1.35.1", features = ["full"] }
 tracing = "0.1.40"


### PR DESCRIPTION
When coloured output is enabled, output strings contain ANSI escapes, sequences of binary data that communicate with a terminal to control colours. Remove these sequences when producing a JUnit report, because the ESC bytecode (0x1B) is not a valid codepoint in XML documents.

Fixes #421
