### PR TITLE
feat: update content_type_matching logic for binary payloads

### DIFF
--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
         rust: [ stable ]
     env:
       pact_do_not_track: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,9 @@ jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
         rust: [ stable ]
     env:
       pact_do_not_track: true

--- a/.github/workflows/compatability-suite.yml
+++ b/.github/workflows/compatability-suite.yml
@@ -7,7 +7,11 @@ env:
 
 jobs:
   v1:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@stable
@@ -15,7 +19,11 @@ jobs:
       run: cargo test --test v1*
       working-directory: compatibility-suite
   v2:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
@@ -23,7 +31,11 @@ jobs:
         run: cargo test --test v2*
         working-directory: compatibility-suite
   v3:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +43,11 @@ jobs:
         run: cargo test --test v3*
         working-directory: compatibility-suite
   v4:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable

--- a/compatibility-suite/Cargo.lock
+++ b/compatibility-suite/Cargo.lock
@@ -502,8 +502,8 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact_consumer",
- "pact_matching",
- "pact_mock_server",
+ "pact_matching 1.2.3",
+ "pact_mock_server 1.2.7",
  "pact_models",
  "pact_verifier",
  "pretty_assertions",
@@ -2004,8 +2004,8 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching",
- "pact_mock_server",
+ "pact_matching 1.2.3",
+ "pact_mock_server 1.2.8",
  "pact_models",
  "regex",
  "serde_json",
@@ -2013,6 +2013,45 @@ dependencies = [
  "tracing",
  "tracing-core",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "pact_matching"
+version = "1.2.3"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "difference",
+ "futures",
+ "hex",
+ "http 1.1.0",
+ "infer",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lenient_semver",
+ "maplit",
+ "md5",
+ "mime",
+ "multer 3.1.0",
+ "nom",
+ "onig",
+ "pact-plugin-driver",
+ "pact_models",
+ "rand",
+ "reqwest 0.12.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sxd-document",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tree_magic_mini",
  "uuid",
 ]
 
@@ -2058,6 +2097,36 @@ dependencies = [
 
 [[package]]
 name = "pact_mock_server"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb43567a0954ecba3b91d70543617923d9217a98ea3f5f0a5149648b46f0aa55"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "itertools 0.12.1",
+ "lazy_static",
+ "maplit",
+ "pact-plugin-driver",
+ "pact_matching 1.2.3",
+ "pact_models",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "tracing-core",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "pact_mock_server"
 version = "1.2.8"
 source = "git+https://github.com/you54f/pact-core-mock-server.git?branch=main#090eb1ab3d6d201247cb016b57269f390a37e830"
 dependencies = [
@@ -2070,7 +2139,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching",
+ "pact_matching 1.2.3 (git+https://github.com/you54f/pact-reference.git?branch=master)",
  "pact_models",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -2142,7 +2211,7 @@ dependencies = [
  "maplit",
  "mime",
  "pact-plugin-driver",
- "pact_matching",
+ "pact_matching 1.2.3",
  "pact_models",
  "regex",
  "reqwest 0.12.4",
@@ -2437,7 +2506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -3716,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ee137597cdb361b55a4746983e4ac1b35ab6024396a419944ad473bb915265"
+checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
 dependencies = [
  "fnv",
  "home",
@@ -4295,7 +4364,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "pact_matching"
-version = "1.2.3"

--- a/compatibility-suite/Cargo.lock
+++ b/compatibility-suite/Cargo.lock
@@ -380,6 +380,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2019,7 @@ dependencies = [
 [[package]]
 name = "pact_matching"
 version = "1.2.3"
+source = "git+https://github.com/you54f/pact-reference.git?branch=master#5e363b9447e4b929fe3614940f23a6a8fd556310"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2009,6 +2030,7 @@ dependencies = [
  "futures",
  "hex",
  "http 1.1.0",
+ "infer",
  "itertools 0.12.1",
  "lazy_static",
  "lenient_semver",
@@ -2036,9 +2058,8 @@ dependencies = [
 
 [[package]]
 name = "pact_mock_server"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb43567a0954ecba3b91d70543617923d9217a98ea3f5f0a5149648b46f0aa55"
+version = "1.2.8"
+source = "git+https://github.com/you54f/pact-core-mock-server.git?branch=main#090eb1ab3d6d201247cb016b57269f390a37e830"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2416,7 +2437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -4274,3 +4295,7 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "pact_matching"
+version = "1.2.3"

--- a/compatibility-suite/pact-compatibility-suite/features/V3/matching_rules.feature
+++ b/compatibility-suite/pact-compatibility-suite/features/V3/matching_rules.feature
@@ -212,7 +212,7 @@ Feature: V3 era Matching Rules
       | application/octet-stream | file: sample.pdf |
     When the request is compared to the expected one
     Then the comparison should NOT be OK
-    And the mismatches will contain a mismatch with error "$" -> "Expected binary contents to have content type 'image/jpeg' but detected contents was 'application/pdf'"
+    And the mismatches will contain a mismatch with error "$" -> "Expected binary contents to have content type 'image/jpeg' but inferred contents are 'application/pdf', magic contents are 'application/pdf'"
 
   Scenario: Supports a Values matcher (positive case, ignores missing and additional keys)
     Given an expected request configured with the following:

--- a/compatibility-suite/pact-compatibility-suite/features/V3/matching_rules.feature
+++ b/compatibility-suite/pact-compatibility-suite/features/V3/matching_rules.feature
@@ -212,7 +212,7 @@ Feature: V3 era Matching Rules
       | application/octet-stream | file: sample.pdf |
     When the request is compared to the expected one
     Then the comparison should NOT be OK
-    And the mismatches will contain a mismatch with error "$" -> "Expected binary contents to have content type 'image/jpeg' but inferred contents are 'application/pdf', magic contents are 'application/pdf'"
+    And the mismatches will contain a mismatch with error "$" -> "Expected binary contents to have content type 'image/jpeg' but detected contents was 'application/pdf'"
 
   Scenario: Supports a Values matcher (positive case, ignores missing and additional keys)
     Given an expected request configured with the following:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "tree_magic_mini 3.1.4 (git+https://github.com/YOU54F/tree_magic.git?branch=mini)",
+ "tree_magic_mini",
  "uuid",
 ]
 
@@ -2062,7 +2062,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
- "tree_magic_mini 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_magic_mini",
  "uuid",
 ]
 
@@ -3762,22 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ee137597cdb361b55a4746983e4ac1b35ab6024396a419944ad473bb915265"
-dependencies = [
- "fnv",
- "home",
- "memchr",
- "nom",
- "once_cell",
- "petgraph",
-]
-
-[[package]]
-name = "tree_magic_mini"
-version = "3.1.4"
-source = "git+https://github.com/YOU54F/tree_magic.git?branch=mini#f77cc2bcd3a920bed0225c6cb207c1af45b623e7"
+checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
 dependencies = [
  "fnv",
  "home",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -348,6 +348,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,46 +1980,6 @@ dependencies = [
 
 [[package]]
 name = "pact_matching"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9183bf02dfc92afae178174c5c2bf64787e7fdb98081742ca6f2318f3e7af5a5"
-dependencies = [
- "ansi_term",
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "difference",
- "futures",
- "hex",
- "http 1.1.0",
- "itertools 0.12.1",
- "lazy_static",
- "lenient_semver",
- "maplit",
- "md5",
- "mime",
- "multer",
- "nom",
- "onig",
- "pact-plugin-driver",
- "pact_models 1.2.0",
- "rand",
- "reqwest 0.12.4",
- "semver",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sxd-document",
- "tokio",
- "tracing",
- "tracing-core",
- "tree_magic_mini",
- "uuid",
-]
-
-[[package]]
-name = "pact_matching"
 version = "1.2.3"
 dependencies = [
  "ansi_term",
@@ -2014,6 +1994,7 @@ dependencies = [
  "hamcrest2",
  "hex",
  "http 1.1.0",
+ "infer",
  "itertools 0.12.1",
  "lazy_static",
  "lenient_semver",
@@ -2041,15 +2022,54 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "tree_magic_mini",
+ "tree_magic_mini 3.1.4 (git+https://github.com/YOU54F/tree_magic.git?branch=mini)",
+ "uuid",
+]
+
+[[package]]
+name = "pact_matching"
+version = "1.2.3"
+source = "git+https://github.com/you54f/pact-reference.git#5e363b9447e4b929fe3614940f23a6a8fd556310"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "difference",
+ "futures",
+ "hex",
+ "http 1.1.0",
+ "infer",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lenient_semver",
+ "maplit",
+ "md5",
+ "mime",
+ "multer",
+ "nom",
+ "onig",
+ "pact-plugin-driver",
+ "pact_models 1.2.0",
+ "rand",
+ "reqwest 0.12.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sxd-document",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tree_magic_mini 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
 ]
 
 [[package]]
 name = "pact_mock_server"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb43567a0954ecba3b91d70543617923d9217a98ea3f5f0a5149648b46f0aa55"
+version = "1.2.8"
+source = "git+https://github.com/you54f/pact-core-mock-server.git?branch=main#48a8a979a7d71d80e435bf45e88302a68f6d60ab"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2060,7 +2080,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching 1.2.2",
+ "pact_matching 1.2.3 (git+https://github.com/you54f/pact-reference.git)",
  "pact_models 1.2.0",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -3745,6 +3765,19 @@ name = "tree_magic_mini"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ee137597cdb361b55a4746983e4ac1b35ab6024396a419944ad473bb915265"
+dependencies = [
+ "fnv",
+ "home",
+ "memchr",
+ "nom",
+ "once_cell",
+ "petgraph",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.1.4"
+source = "git+https://github.com/YOU54F/tree_magic.git?branch=mini#f77cc2bcd3a920bed0225c6cb207c1af45b623e7"
 dependencies = [
  "fnv",
  "home",

--- a/rust/pact_consumer/Cargo.toml
+++ b/rust/pact_consumer/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.12.1"
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 pact_matching = { version = "~1.2.2", path = "../pact_matching", default-features = false }
-pact_mock_server = { version = "~1.2.6", default-features = false }
+pact_mock_server = { version = "=1.2.8", default-features = false, git = "https://github.com/you54f/pact-core-mock-server.git", branch = "main" }
 pact_models = { version = "~1.2.0", default-features = false }
 pact-plugin-driver = { version = "~0.6.1", optional = true, default-features = false }
 regex = "1.10.4"

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -31,7 +31,8 @@ maplit = "1.0.2"
 multipart = { version = "0.18.0", default-features = false, features = ["client", "mock"] }
 onig = { version = "6.4.0", default-features = false }
 pact_matching = { version = "~1.2.2", path = "../pact_matching" }
-pact_mock_server = { version = "~1.2.6" }
+pact_mock_server = { version = "=1.2.8", git = "https://github.com/you54f/pact-core-mock-server.git", branch = "main" }
+# pact_mock_server = { version = "=1.2.8", path = "../../../pact-core-mock-server/pact_mock_server" }
 pact_models = { version = "~1.2.0" }
 pact-plugin-driver = { version = "~0.6.1" }
 pact_verifier = { version = "~1.2.1", path = "../pact_verifier" }

--- a/rust/pact_ffi/src/matching.rs
+++ b/rust/pact_ffi/src/matching.rs
@@ -350,7 +350,6 @@ mod tests {
   ];
 
   #[test_log::test]
-  #[cfg(not(windows))]
   fn pactffi_matches_binary_value_test() {
     let rule = MatchingRule::ContentType("image/gif".to_string());
     let rule_ptr = &rule as *const MatchingRule;
@@ -363,7 +362,13 @@ mod tests {
     let rule_ptr = &rule as *const MatchingRule;
     let err_result = pactffi_matches_binary_value(rule_ptr, value, 35, value, 35, 0);
     let string = unsafe { CString::from_raw(err_result as *mut c_char) };
-    expect!(string.to_string_lossy()).to(be_equal_to("Expected binary contents to have content type 'image/png' but detected contents was 'image/gif'"));
+    // required if shared-mime-info not installed, not installed on windows easily
+    #[cfg(not(windows))]
+    let magic_content_type = "image/gif";
+    #[cfg(windows)]
+    let magic_content_type = "application/octet-stream";
+
+    expect!(string.to_string_lossy()).to(be_equal_to(format!("Expected binary contents to have content type 'image/png' but inferred contents are 'image/gif', magic contents are '{}'", magic_content_type)));
   }
 
   #[test_log::test]

--- a/rust/pact_ffi/src/matching.rs
+++ b/rust/pact_ffi/src/matching.rs
@@ -362,13 +362,8 @@ mod tests {
     let rule_ptr = &rule as *const MatchingRule;
     let err_result = pactffi_matches_binary_value(rule_ptr, value, 35, value, 35, 0);
     let string = unsafe { CString::from_raw(err_result as *mut c_char) };
-    // required if shared-mime-info not installed, not installed on windows easily
-    #[cfg(not(windows))]
-    let magic_content_type = "image/gif";
-    #[cfg(windows)]
-    let magic_content_type = "application/octet-stream";
 
-    expect!(string.to_string_lossy()).to(be_equal_to(format!("Expected binary contents to have content type 'image/png' but inferred contents are 'image/gif', magic contents are '{}'", magic_content_type)));
+    expect!(string.to_string_lossy()).to(be_equal_to("Expected binary contents to have content type 'image/png' but detected contents was 'image/gif'"));
   }
 
   #[test_log::test]

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -641,7 +641,6 @@ fn fixture_path(path: &str) -> PathBuf {
     .to_owned()
 }
 
-#[cfg(not(windows))]
 #[rstest(
   specification,                                          expected_value,
   case::specification_unknown(PactSpecification::Unknown, false),
@@ -687,13 +686,15 @@ fn pactffi_with_binary_file_feature_test(specification: PactSpecification, expec
 
   let client = Client::default();
   let result = client.post(format!("http://127.0.0.1:{}/upload", port).as_str())
-    .header("Content-Type", "image/gif")
-    .body(buffer)
+  .header("Content-Type", "image/gif")
+  .body(buffer)
     .send();
 
   let mismatches = unsafe {
     CStr::from_ptr(pactffi_mock_server_mismatches(port)).to_string_lossy().into_owned()
   };
+
+  println!("{}",mismatches);
 
   match result {
     Ok(res) => {

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -686,16 +686,15 @@ fn pactffi_with_binary_file_feature_test(specification: PactSpecification, expec
 
   let client = Client::default();
   let result = client.post(format!("http://127.0.0.1:{}/upload", port).as_str())
-  .header("Content-Type", "image/gif")
-  .body(buffer)
+    .header("Content-Type", "image/gif")
+    .body(buffer)
     .send();
 
   let mismatches = unsafe {
     CStr::from_ptr(pactffi_mock_server_mismatches(port)).to_string_lossy().into_owned()
   };
 
-  println!("{}",mismatches);
-
+  println!("pactffi_with_binary_file_feature_test v{}: {}", specification, mismatches);
   match result {
     Ok(res) => {
       let status = res.status();

--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -52,11 +52,9 @@ sxd-document = { version = "0.3.2", optional = true }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-core = "0.1.32"
-tree_magic_mini = {version = "3.1.4", git = "https://github.com/YOU54F/tree_magic.git", branch = "mini" }
-# tree_magic_mini = {version = "3.1.4", path = "../../../tree_magic" }
 infer = "0.15.0"
+tree_magic_mini = "3.1.5"
 uuid = { version = "1.8.0", features = ["v4"] }
-# indexmap = { version = "1.9.3", features = ["std"] } # for errors x-compiling from macos without cross
 
 [dev-dependencies]
 quickcheck = "1"

--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -52,8 +52,11 @@ sxd-document = { version = "0.3.2", optional = true }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-core = "0.1.32"
-tree_magic_mini = "3.1.4"
+tree_magic_mini = {version = "3.1.4", git = "https://github.com/YOU54F/tree_magic.git", branch = "mini" }
+# tree_magic_mini = {version = "3.1.4", path = "../../../tree_magic" }
+infer = "0.15.0"
 uuid = { version = "1.8.0", features = ["v4"] }
+# indexmap = { version = "1.9.3", features = ["std"] } # for errors x-compiling from macos without cross
 
 [dev-dependencies]
 quickcheck = "1"

--- a/rust/pact_matching/README.md
+++ b/rust/pact_matching/README.md
@@ -510,6 +510,33 @@ Example:
 matching(contentType, 'application/json', '{}')
 ```
 
+###### Content Type - Detection Mechanisms for Binary Content
+
+`pact_matching` currently performs the following for matching Binary content-types
+
+1. Determines `expected` `Content-Type` header requested by user in test
+2. Read content buffer with `infer` library, and guess `Content-Type` based on magic bytes
+3. If unsuccessful
+   1. Read content buffer with `tree_magic_mini` library, and guess `Content-Type` based on shared-mime-info DB
+      1. MagicDB is not shipped with pact_matching, due to GPL restrictions, users can add manually
+         1. Linux Alpine - `apk add shared-mime-info`
+         2. MacOS `brew install shared-mime-info`
+            1. `arm64` MacOS requires `tree_magic_mini` [fork](https://github.com/you54f/tree_magic) 
+         3. Linux - Debian`apt-get install -y shared-mime-info`
+4. If either result returns `text/plain`, then manually read bytes using `detect_content_type_from_bytes` function in `pact_models`
+5. If all of `2`, `3`, or `4` fails, then throw error, otherwise return `Ok`
+
+Rust libraries used:
+
+- https://github.com/mbrubeck/tree_magic
+  - fork https://github.com/you54f/tree_magic
+- https://github.com/bojand/infer
+- Explore:- https://github.com/ebassi/xdg-mime-rs
+
+TODO:
+
+Provide user full opt-out of content-type matching?
+
 ##### Matching an example type by reference
 
 Type matching can also be specified by a reference to an example. References are defined by a dollar (`$`) followed by

--- a/rust/pact_matching/README.md
+++ b/rust/pact_matching/README.md
@@ -529,13 +529,7 @@ matching(contentType, 'application/json', '{}')
 Rust libraries used:
 
 - https://github.com/mbrubeck/tree_magic
-  - fork https://github.com/you54f/tree_magic
 - https://github.com/bojand/infer
-- Explore:- https://github.com/ebassi/xdg-mime-rs
-
-TODO:
-
-Provide user full opt-out of content-type matching?
 
 ##### Matching an example type by reference
 

--- a/rust/pact_matching/src/binary_utils.rs
+++ b/rust/pact_matching/src/binary_utils.rs
@@ -39,6 +39,7 @@ where
     S: Into<String>,
 {
     let expected = expected_content_type.into();
+
     // Use infer crate to detect via magic bytes
     let inferred_content_type = infer::get(data)
         .map(|result| result.mime_type())
@@ -49,13 +50,17 @@ where
     if inferred_match {
         return Ok(());
     }
-    // Use tree_magic_mini crate to detect via magic bytes using mime-db (requires user to install)
-    let magic_content_type = tree_magic_mini::from_u8(data);
-    let magic_match = magic_content_type == expected;
-    debug!("Matching binary contents by content type: expected '{}', detection method: tree_magic_mini '{}' -> {}",
-  expected, magic_content_type, magic_match);
-    if magic_match && magic_content_type != "text/plain" {
-        return Ok(());
+
+    let mut magic_content_type = "";
+    if inferred_content_type == "" {
+      // Use tree_magic_mini crate to detect via magic bytes using mime-db (requires user to install)
+      magic_content_type = tree_magic_mini::from_u8(data);
+      let magic_match = magic_content_type == expected;
+      debug!("Matching binary contents by content type: expected '{}', detection method: tree_magic_mini '{}' -> {}",
+    expected, magic_content_type, magic_match);
+      if magic_match && magic_content_type != "text/plain" {
+          return Ok(());
+      }
     }
 
     // Where we have detected text/plain, check content type against our own detection from bytes

--- a/rust/pact_matching/src/binary_utils.rs
+++ b/rust/pact_matching/src/binary_utils.rs
@@ -60,7 +60,7 @@ where
 
     // Where we have detected text/plain, check content type against our own detection from bytes
     let detected_content_type: &str = {
-        if inferred_match {
+        if inferred_content_type != "" {
             inferred_content_type
         } else {
             magic_content_type

--- a/rust/pact_matching/src/binary_utils.rs
+++ b/rust/pact_matching/src/binary_utils.rs
@@ -35,24 +35,43 @@ use crate::matchers::Matches;
 /// Compares the binary data using a magic test and comparing the resulting detected content
 /// type against the expected content type
 pub fn match_content_type<S>(data: &[u8], expected_content_type: S) -> anyhow::Result<()>
-  where S: Into<String> {
-  let result = tree_magic_mini::from_u8(data);
-  let expected = expected_content_type.into();
-  let matches = result == expected;
-  debug!("Matching binary contents by content type: expected '{}', detected '{}' -> {}",
-         expected, result, matches);
-  if matches {
-    Ok(())
-  } else if result == "text/plain" {
-    detect_content_type_from_bytes(data)
-      .and_then(|ct| if ct ==  ContentType::from(&expected) { Some(()) } else { None })
-      .ok_or_else(|| anyhow!("Expected binary contents to have content type '{}' but detected contents was '{}'",
-        expected, result))
-  } else {
-    Err(anyhow!("Expected binary contents to have content type '{}' but detected contents was '{}'",
-      expected, result))
-  }
+where
+    S: Into<String>,
+{
+    let expected = expected_content_type.into();
+    let inferred_content_type = infer::get(data)
+        .map(|result| result.mime_type())
+        .unwrap_or_default();
+    let inferred_match = inferred_content_type == expected;
+    debug!("Matching binary contents by content type: expected '{}', detection method: infer '{}' -> {}",
+  expected, inferred_match, inferred_match);
+    if inferred_match {
+        return Ok(());
+    }
+    let magic_content_type = tree_magic_mini::from_u8(data);
+    let magic_match = magic_content_type == expected;
+    debug!("Matching binary contents by content type: expected '{}', detection method: tree_magic_mini '{}' -> {}",
+  expected, magic_content_type, magic_match);
+    if magic_match && magic_content_type != "text/plain" {
+        return Ok(());
+    }
+    // this assumes user is expecting text/plain but is actually getting text
+    if inferred_content_type == "text/plain" || magic_content_type == "text/plain" {
+        let bytes_detected_content_type = detect_content_type_from_bytes(data);
+        if bytes_detected_content_type.is_some() {
+            let bytes_detected_content_type = bytes_detected_content_type.unwrap();
+            let bytes_match = bytes_detected_content_type == ContentType::from(&expected);
+            debug!("Matching binary contents by content type: expected '{}', detection method: detect_content_type_from_bytes '{}' -> {}",
+      expected, bytes_detected_content_type, bytes_match);
+            if bytes_match {
+                return Ok(());
+            }
+        }
+    }
+    return Err(anyhow!("Expected binary contents to have content type '{}' but inferred contents are '{}', magic contents are '{}'",
+      expected, inferred_content_type, magic_content_type));
 }
+
 
 pub(crate) fn convert_data(data: &Value) -> Vec<u8> {
   match data {
@@ -1027,7 +1046,6 @@ mod tests {
 
   #[test]
   #[cfg(feature = "multipart")]
-  #[cfg(not(target_os = "windows"))] // Requires shared mime-info db, not available on Windows
   fn match_mime_multipart_content_type_matcher() {
     let expected_body = Bytes::from("--1234\r\n\
       Content-Type: text/plain\r\n\
@@ -1084,7 +1102,6 @@ mod tests {
 
   #[test]
   #[cfg(feature = "multipart")]
-  #[cfg(not(target_os = "windows"))] // Requires shared mime-info db, not available on Windows
   fn match_mime_multipart_content_type_matcher_with_mismatch() {
     let expected_body = Bytes::from("--1234\r\n\
       Content-Type: text/plain\r\n\
@@ -1132,13 +1149,12 @@ mod tests {
 
     let mismatches = result.unwrap_err();
     expect!(mismatches.iter().map(|m| mismatch(m)).collect::<Vec<&str>>()).to(be_equal_to(vec![
-      "MIME part \'file\': Expected binary contents to have content type \'application/jpeg\' but detected contents was \'text/plain\'"
+      "MIME part \'file\': Expected binary contents to have content type \'application/jpeg\' but inferred contents are '', magic contents are 'text/plain'"
     ]));
   }
 
   #[test]
   #[cfg(feature = "multipart")]
-  #[cfg(not(target_os = "windows"))] // Requires shared mime-info db, not available on Windows
   fn match_content_type_equals() {
     expect!(match_content_type("some text".as_bytes(), "text/plain")).to(be_ok());
 
@@ -1151,7 +1167,6 @@ mod tests {
 
   #[test]
   #[cfg(feature = "multipart")]
-  #[cfg(not(target_os = "windows"))] // Requires shared mime-info db, not available on Windows
   fn match_content_type_common_text_types() {
     expect!(match_content_type("{\"val\": \"some text\"}".as_bytes(), "application/json")).to(be_ok());
     expect!(match_content_type("<xml version=\"1.0\"><a/>".as_bytes(), "application/xml")).to(be_ok());

--- a/rust/pact_matching/src/json.rs
+++ b/rust/pact_matching/src/json.rs
@@ -975,8 +975,8 @@ mod tests {
     let matcher = MatchingRule::ContentType("text/plain".to_string());
     expect!(Value::String("plain text".into()).matches_with(&Value::String("plain text".into()), &matcher, false)).to(be_ok());
     expect!(Value::String("plain text".into()).matches_with(&Value::String("different text".into()), &matcher, false)).to(be_ok());
-    expect!(Value::String("plain text".into()).matches_with(&json!(100), &matcher, false)).to(be_err());
-    expect!(Value::String("plain text".into()).matches_with(&json!(100.01), &matcher, false)).to(be_err());
+    expect!(Value::String("plain text".into()).matches_with(&json!(100), &matcher, false)).to(be_ok());
+    expect!(Value::String("plain text".into()).matches_with(&json!(100.01), &matcher, false)).to(be_ok());
     {
       let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
       <note>

--- a/rust/pact_matching/src/json.rs
+++ b/rust/pact_matching/src/json.rs
@@ -975,9 +975,8 @@ mod tests {
     let matcher = MatchingRule::ContentType("text/plain".to_string());
     expect!(Value::String("plain text".into()).matches_with(&Value::String("plain text".into()), &matcher, false)).to(be_ok());
     expect!(Value::String("plain text".into()).matches_with(&Value::String("different text".into()), &matcher, false)).to(be_ok());
-    expect!(Value::String("plain text".into()).matches_with(&json!(100), &matcher, false)).to(be_ok());
-    expect!(Value::String("plain text".into()).matches_with(&json!(100.01), &matcher, false)).to(be_ok());
-    #[cfg(not(windows))]
+    expect!(Value::String("plain text".into()).matches_with(&json!(100), &matcher, false)).to(be_err());
+    expect!(Value::String("plain text".into()).matches_with(&json!(100.01), &matcher, false)).to(be_err());
     {
       let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
       <note>

--- a/rust/pact_matching/src/matchers.rs
+++ b/rust/pact_matching/src/matchers.rs
@@ -1238,7 +1238,6 @@ mod tests {
     expect!("plain text".matches_with("plain text", &matcher, false)).to(be_ok());
     expect!("plain text".matches_with("different text", &matcher, false)).to(be_ok());
     expect!("plain text".matches_with(100, &matcher, false)).to(be_err());
-    #[cfg(not(windows))]
     {
       let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
       <note>

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -897,13 +897,9 @@ fn compare_bodies_core_should_check_for_content_type_matcher() {
   );
 
   let result = compare_bodies_core(&content_type, &expected, &actual, &context);
-  // required if shared-mime-info not installed, not installed on windows easily
-  #[cfg(not(windows))]
-  let magic_content_type = "image/gif";
-  #[cfg(windows)]
-  let magic_content_type = "application/octet-stream";
+
   expect!(result.len()).to(be_equal_to(1));
-  expect!(result.first().unwrap().description()).to(be_equal_to(format!("$ -> Expected binary contents to have content type 'application/gif' but inferred contents are 'image/gif', magic contents are '{}'", magic_content_type)));
+  expect!(result.first().unwrap().description()).to(be_equal_to("$ -> Expected binary contents to have content type 'application/gif' but detected contents was 'image/gif'"));
 }
 
 #[test_log::test]

--- a/rust/pact_matching/src/tests.rs
+++ b/rust/pact_matching/src/tests.rs
@@ -878,7 +878,6 @@ fn values_matcher_defined() {
 
 const IMAGE_BYTES: [u8; 16] = [ 0o107, 0o111, 0o106, 0o070, 0o067, 0o141, 0o001, 0o000, 0o001, 0o000, 0o200, 0o000, 0o000, 0o377, 0o377, 0o377 ];
 
-#[cfg(not(windows))]
 #[test]
 fn compare_bodies_core_should_check_for_content_type_matcher() {
   let content_type = ContentType::parse("application/gif").unwrap();
@@ -898,9 +897,13 @@ fn compare_bodies_core_should_check_for_content_type_matcher() {
   );
 
   let result = compare_bodies_core(&content_type, &expected, &actual, &context);
-
+  // required if shared-mime-info not installed, not installed on windows easily
+  #[cfg(not(windows))]
+  let magic_content_type = "image/gif";
+  #[cfg(windows)]
+  let magic_content_type = "application/octet-stream";
   expect!(result.len()).to(be_equal_to(1));
-  expect!(result.first().unwrap().description()).to(be_equal_to("$ -> Expected binary contents to have content type 'application/gif' but detected contents was 'image/gif'"));
+  expect!(result.first().unwrap().description()).to(be_equal_to(format!("$ -> Expected binary contents to have content type 'application/gif' but inferred contents are 'image/gif', magic contents are '{}'", magic_content_type)));
 }
 
 #[test_log::test]

--- a/rust/pact_models/src/v4/http_parts.rs
+++ b/rust/pact_models/src/v4/http_parts.rs
@@ -344,6 +344,7 @@ pub fn body_from_json(json: &Value, attr_name: &str, headers: &Option<HashMap<St
                 if body_bytes.is_empty() {
                   OptionalBody::Empty
                 } else {
+                  // TODO:- use shared infer/tree_magic_mini here for consistency?
                   let content_type = content_type.unwrap_or_else(|| {
                     detect_content_type_from_bytes(&body_bytes).unwrap_or_default()
                   });

--- a/rust/pact_models/src/v4/mod.rs
+++ b/rust/pact_models/src/v4/mod.rs
@@ -70,6 +70,7 @@ pub fn calc_content_type(body: &OptionalBody, headers: &Option<HashMap<String, V
       }
     }).flatten())
     .or_else(|| if body.is_present() {
+      // TODO:- use shared infer/tree_magic_mini here for consistency?
       detect_content_type_from_bytes(&*body.value().unwrap_or_default())
     } else {
       None


### PR DESCRIPTION
fixes #171 

###### Content Type - Detection Mechanisms for Binary Content

`pact_matching` now performs the following for matching Binary content-types

1. Determines `expected` `Content-Type` header requested by user in test
2. Read content buffer with `infer` library, and guess `Content-Type` based on magic bytes
3. If unsuccessful
   1. Read content buffer with `tree_magic_mini` library, and guess `Content-Type` based on shared-mime-info DB
      1. MagicDB is not shipped with pact_matching, due to GPL restrictions, users can add manually
         1. Linux Alpine - `apk add shared-mime-info`
         2. MacOS `brew install shared-mime-info`
            1. `arm64` MacOS requires `tree_magic_mini` [fork](https://github.com/you54f/tree_magic) 
         3. Linux - Debian`apt-get install -y shared-mime-info`
4. If either result returns `text/plain`, then manually read bytes using `detect_content_type_from_bytes` function in `pact_models`
5. If all of `2`, `3`, or `4` fails, then throw error, otherwise return `Ok`

certainly better ways to implement this, but wanted to make sure I had a full round trip in all the consuming languages, and could remove the content-type hacks there.

The plus side is we have consistent behaviour in all of our test examples, on all supported platforms and architectures (win/lin/mac arm64 and amd64) without the use of tree_magic and the existence of shared-mime-info (which is great for container users, and great for avoiding GPL woes) 

Rust libraries used:

- https://github.com/mbrubeck/tree_magic
  - fork https://github.com/you54f/tree_magic (for m1 support), PR raised
- https://github.com/bojand/infer
- Explore (not used but worth a look at) - https://github.com/ebassi/xdg-mime-rs

Questions

1) Do we need tree_magic_mini, I don't seem to hit that check in the wild
2) We probably want some vendored format examples that are harder to detect
3) Provide user full opt-out of content-type matching, in case of things going weird?

Notes to merger

1) will need updating in pact_mock_server (use of pact_matching) which is then used in this repo, so I believe we will need to build/release pact_matching to crates.io, update pact_mock_server, release, and then back to pact_ref to do the works there

Tested in 

- pact rust
- pact rust compat suite
- pact-js-core
  - https://github.com/YOU54F/pact-js-core/pull/42
  - https://github.com/YOU54F/pact-js-core/pull/43
- pact-js
  - https://github.com/YOU54F/pact-js/pull/1
- pact-php
  - https://github.com/YOU54F/pact-php/pull/1
- pact-net
  - https://github.com/YOU54F/pact-net/pull/1 
- pact-ruby-ffi
  - https://github.com/YOU54F/pact-ruby-ffi/pull/3