### PR TITLE
chore(ci): refactor indiv jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,38 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+
+  schedule:
+    - cron: 0 0 * * 4 # Midnight Wednesday
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-release:
+    name: build-release (${{ matrix.targets }})
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         include:
           - operating-system: ubuntu-20.04
-            targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
+            targets: x86_64-unknown-linux-gnu
+          - operating-system: ubuntu-20.04
+            targets: x86_64-unknown-linux-musl
+          - operating-system: ubuntu-20.04
+            targets: aarch64-unknown-linux-gnu
+          - operating-system: ubuntu-20.04
+            targets: aarch64-unknown-linux-musl
           - operating-system: windows-2019
-            targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
+            targets: x86_64-pc-windows-msvc
+          - operating-system: windows-2019
+            targets: aarch64-pc-windows-msvc
           - operating-system: macos-12
-            targets: aarch64-apple-darwin,x86_64-apple-darwin
+            targets: x86_64-apple-darwin
+          - operating-system: macos-14
+            targets: aarch64-apple-darwin
       fail-fast: false
 
     env:
@@ -43,6 +59,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+          key: ${{ matrix.targets }}
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -71,21 +88,17 @@ jobs:
         id: cargo-flags
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" = "release" ]]; then
-            echo "flags=--release" >> "$GITHUB_OUTPUT"
-          else
-            echo "flags=" >> "$GITHUB_OUTPUT"
-          fi
-
+          echo "flags=--release" >> "$GITHUB_OUTPUT"
 
       - name: Build verifier CLI
         if: |
           github.event_name == 'push' ||
           github.event_name == 'pull_request' ||
+          github.event_name == 'workflow_dispatch' ||
           startsWith(github.ref, 'refs/tags/pact_verifier_cli')
         shell: bash
         run: |
-          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh ${{ matrix.targets }} \
             ${{ steps.cargo-flags.outputs.flags }}
         working-directory: rust/pact_verifier_cli
 
@@ -93,30 +106,40 @@ jobs:
         if: |
           github.event_name == 'push' ||
           github.event_name == 'pull_request' ||
+          github.event_name == 'workflow_dispatch' ||
           startsWith(github.ref, 'refs/tags/libpact_ffi')
         shell: bash
         run: |
-          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh ${{ matrix.targets }} \
             ${{ steps.cargo-flags.outputs.flags }}
         working-directory: rust/pact_ffi
+
+      - name: Smoke Test FFI library
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          github.event_name == 'workflow_dispatch' ||
+          startsWith(github.ref, 'refs/tags/libpact_ffi')
+        shell: bash
+        run: |
+          ./smoke-test.sh ${{ matrix.targets }}
+        working-directory: ruby
 
       - name: Upload the artifacts
         if: |
           startsWith(github.ref, 'refs/tags/libpact_ffi')  ||
-          startsWith(github.ref, 'refs/tags/pact_verifier_cli') ||
-          startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+          startsWith(github.ref, 'refs/tags/pact_verifier_cli')
         uses: actions/upload-artifact@v4
         with:
-          name: release-artifacts-${{ matrix.operating-system }}
+          name: release-artifacts-${{ matrix.targets }}
           path: rust/release_artifacts
-          if-no-files-found: error
+          if-no-files-found: warn
 
   publish:
     runs-on: ubuntu-latest
     if: |
       startsWith(github.ref, 'refs/tags/libpact_ffi')  ||
-      startsWith(github.ref, 'refs/tags/pact_verifier_cli') ||
-      startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+      startsWith(github.ref, 'refs/tags/pact_verifier_cli')
     needs: build-release
 
     steps:

--- a/ruby/detect_os.rb
+++ b/ruby/detect_os.rb
@@ -1,0 +1,89 @@
+module DetectOS
+  def self.windows_arm?
+    return unless !(/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RbConfig::CONFIG['arch']).nil? && !(/arm64/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.windows?
+    return if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.mac_arm?
+    return unless !(/darwin/ =~ RbConfig::CONFIG['arch']).nil? && !(/arm64/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.mac?
+    return unless !(/darwin/ =~ RbConfig::CONFIG['arch']).nil? && !(/x86_64/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.linux_arm_musl?
+    return unless !(/linux/ =~ RbConfig::CONFIG['arch']).nil? && !(/aarch64/ =~ RbConfig::CONFIG['arch']).nil? && !(/musl/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.linux_musl?
+    return unless !(/linux/ =~ RbConfig::CONFIG['arch']).nil? && !(/x86_64/ =~ RbConfig::CONFIG['arch']).nil?&& !(/musl/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+  def self.linux_arm?
+    return unless !(/linux/ =~ RbConfig::CONFIG['arch']).nil? && !(/aarch64/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.linux?
+    return unless !(/linux/ =~ RbConfig::CONFIG['arch']).nil? && !(/x86_64/ =~ RbConfig::CONFIG['arch']).nil?
+    true
+  end
+
+  def self.debug?
+    return if ENV['DEBUG_TARGET'].nil?
+    true
+  end
+
+  def self.get_bin_path
+    if debug?
+      ENV['PACT_FFI_LIBRARY_PATH'].to_s
+    elsif windows_arm?
+      File.expand_path("#{__dir__}/../rust/target/aarch64-pc-windows-msvc/release/pact_ffi.dll")
+    elsif windows?
+      File.expand_path("#{__dir__}/../rust/target/x86_64-pc-windows-msvc/release/pact_ffi.dll")
+    elsif mac_arm?
+      File.expand_path("#{__dir__}/../rust/target/aarch64-apple-darwin/release/libpact_ffi.dylib")
+    elsif mac?
+      File.expand_path("#{__dir__}/../rust/target/x86_64-apple-darwin/release/libpact_ffi.dylib")
+    elsif linux_arm_musl?
+      File.expand_path("#{__dir__}/../rust/target/aarch64-unknown-linux-musl/release/libpact_ffi.so")
+    elsif linux_musl?
+      File.expand_path("#{__dir__}/../rust/target/x86_64-unknown-linux-musl/release/libpact_ffi.so")
+    elsif linux_arm?
+      File.expand_path("#{__dir__}/../rust/target/aarch64-unknown-linux-gnu/release/libpact_ffi.so")
+    elsif linux?
+      File.expand_path("#{__dir__}/../rust/target/x86_64-unknown-linux-gnu/release/libpact_ffi.so")
+    else
+      raise "Detected #{RbConfig::CONFIG['arch']}-- I have no idea what to do with that."
+    end
+  end
+
+  def self.get_os
+    if windows_arm?
+      'win-arm64'
+    elsif windows?
+      'win'
+    elsif mac_arm?
+      'macos-arm64'
+    elsif mac?
+      'linux-x8664'
+    elsif linux_arm?
+      'linux-aarch64'
+    elsif linux?
+      'linux-x8664'
+    else
+      raise "Detected #{RbConfig::CONFIG['arch']}-- I have no idea what to do with that."
+    end
+  end
+end
+
+ENV['PACT_DEBUG'] ? (puts "Detected platform: #{RbConfig::CONFIG['arch']} \nLoad Path: #{DetectOS.get_bin_path}" ): nil

--- a/ruby/smoke-test.sh
+++ b/ruby/smoke-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+set -x
+
+case $1 in
+x86_64-unknown-linux-musl)
+    docker run --platform=linux/amd64 --rm -v $(pwd)/..:/home -w /home/ruby ruby:alpine ruby test_ffi.rb
+    ;;
+aarch64-unknown-linux-musl)
+    docker run --platform=linux/arm64 --rm -v $(pwd)/..:/home -w /home/ruby ruby:alpine ruby test_ffi.rb
+    ;;
+x86_64-unknown-linux-gnu)
+    docker run --platform=linux/amd64 --rm -v $(pwd)/..:/home -w /home/ruby ruby:slim ruby test_ffi.rb
+    ;;
+aarch64-unknown-linux-gnu)
+    docker run --platform=linux/arm64 --rm -v $(pwd)/..:/home -w /home/ruby ruby:slim ruby test_ffi.rb
+    ;;
+aarch64-pc-windows-msvc)
+    echo unable to test in github actions
+    exit 0
+    ;;
+*) ruby test_ffi.rb ;;
+esac

--- a/ruby/test_ffi.rb
+++ b/ruby/test_ffi.rb
@@ -1,0 +1,35 @@
+require 'fiddle'
+require_relative 'detect_os'
+
+lib = Fiddle.dlopen(DetectOS.get_bin_path)
+
+pactffi_version = Fiddle::Function.new(
+  lib['pactffi_version'],
+  [],
+  Fiddle::TYPE_VOIDP
+)
+pactffi_logger_init = Fiddle::Function.new(
+  lib['pactffi_logger_init'],
+  [],
+  Fiddle::TYPE_VOIDP
+)
+pactffi_logger_apply = Fiddle::Function.new(
+  lib['pactffi_logger_apply'],
+  [],
+  Fiddle::TYPE_VOIDP
+)
+pactffi_logger_attach_sink = Fiddle::Function.new(
+  lib['pactffi_logger_attach_sink'],
+  [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT],
+  Fiddle::TYPE_VOIDP
+)
+pactffi_log_message = Fiddle::Function.new(
+  lib['pactffi_log_message'],
+  [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP],
+  Fiddle::TYPE_VOIDP
+)
+
+pactffi_logger_init.call
+pactffi_logger_attach_sink.call('stdout', 5)
+pactffi_logger_apply.call
+pactffi_log_message.call('pact-ruby-fiddle', 'INFO', "hello from ffi version: #{pactffi_version.call}, platform: #{RUBY_PLATFORM}")

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -3,40 +3,85 @@
 set -e
 set -x
 
-RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME=pact_verifier_cli
 
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
-cargo_flags=( "$@" )
+case $1 in
+x86_64-unknown-linux-musl)
+    TARGET=$1
+    shift
+    ;;
+aarch64-unknown-linux-musl)
+    TARGET=$1
+    shift
+    ;;
+x86_64-unknown-linux-gnu)
+    echo build x86_64-unknown-linux-musl target for musl/glibc compat bins
+    exit 0
+    ;;
+aarch64-unknown-linux-gnu)
+    echo build aarch64-unknown-linux-musl target for musl/glibc compat bins
+    exit 0
+    ;;
+*) ;;
+esac
+cargo_flags=("$@")
 
-build_x86_64() {
-    sudo apt-get install -y musl-tools
-    cargo build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+clean_cargo_release_build() {
+    rm -rf $CARGO_TARGET_DIR/release/build
+}
+
+build_target() {
+    TARGET=$1
+    cross build --target $TARGET "${cargo_flags[@]}"
+
+    case $TARGET in
+    x86_64-unknown-linux-musl)
+        FILE_SUFFIX=linux-x86_64
+        ;;
+    aarch64-unknown-linux-musl)
+        FILE_SUFFIX=linux-aarch64
+        ;;
+    *)
+        echo unknown target $TARGET
+        exit 1
+        ;;
+    esac
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-linux-x86_64.gz"
+        file "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME"
+        du -sh "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME"
+        gzip_and_sum "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME" \
+            "$ARTIFACTS_DIR/$APP_NAME-$FILE_SUFFIX.gz"
     fi
 }
 
 install_cross() {
-    cargo install cross@0.2.5
+    cargo install cross@0.2.5 --force
+}
+install_cross_latest() {
+    cargo install cross --git https://github.com/cross-rs/cross --force
 }
 
-build_aarch64() {
-    install_cross
-    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+install_cross
+if [ "$(uname -s)" == "Darwin" ]; then
+    install_cross_latest
+fi
 
-    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
-        "$ARTIFACTS_DIR/pact_verifier_cli-linux-aarch64.gz"
-    fi
-}
-
-build_x86_64
-build_aarch64
+if [ ! -z "$TARGET" ]; then
+    echo building for target $TARGET
+    build_target $TARGET
+else
+    echo building for all targets
+    clean_cargo_release_build
+    build_target x86_64-unknown-linux-musl
+    clean_cargo_release_build
+    build_target aarch64-unknown-linux-musl
+fi

--- a/rust/pact_verifier_cli/release-macos.sh
+++ b/rust/pact_verifier_cli/release-macos.sh
@@ -3,46 +3,61 @@
 set -e
 set -x
 
-RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME=pact_verifier_cli
 
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # We target the oldest supported version of macOS.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}
 
 # All flags passed to this script are passed to cargo.
-cargo_flags=( "$@" )
+case $1 in
+x86_64-apple-darwin)
+    TARGET=$1
+    shift
+    ;;
+aarch64-apple-darwin)
+    TARGET=$1
+    shift
+    ;;
+*) ;;
+esac
+cargo_flags=("$@")
 
-# Build the x86_64 darwin release
-build_x86_64() {
-    cargo build --target x86_64-apple-darwin "${cargo_flags[@]}"
+build_target() {
+    TARGET=$1
+    cargo build --target $TARGET "${cargo_flags[@]}"
+
+    case $TARGET in
+    x86_64-apple-darwin)
+        ARCH_SUFFIX=x86_64
+        ;;
+    aarch64-apple-darwin)
+        ARCH_SUFFIX=aarch64
+        ;;
+    *)
+        echo unknown target $TARGET
+        exit 1
+        ;;
+    esac
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/pact_verifier_cli" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-osx-x86_64.gz"
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-apple-darwin/release/pact_verifier_cli" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-macos-x86_64.gz"
+        file "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME"
+        du -sh "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME"
+        gzip_and_sum "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME" \
+            "$ARTIFACTS_DIR/$APP_NAME-macos-$ARCH_SUFFIX.gz"
     fi
 }
 
-# Build the aarch64 darwin release
-build_aarch64() {
-    cargo build --target aarch64-apple-darwin "${cargo_flags[@]}"
-
-    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR//aarch64-apple-darwin/release/pact_verifier_cli" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-osx-aarch64.gz"
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR//aarch64-apple-darwin/release/pact_verifier_cli" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-macos-aarch64.gz"
-    fi
-}
-
-build_x86_64
-build_aarch64
+if [ ! -z "$TARGET" ]; then
+    echo building for target $TARGET
+    build_target $TARGET
+else
+    echo building for all targets
+    build_target x86_64-apple-darwin
+    build_target aarch64-apple-darwin
+fi

--- a/rust/pact_verifier_cli/release-win.sh
+++ b/rust/pact_verifier_cli/release-win.sh
@@ -3,37 +3,57 @@
 set -e
 set -x
 
-RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
+RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME=pact_verifier_cli
 
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
-cargo_flags=( "$@" )
+case $1 in
+x86_64-pc-windows-msvc)
+    TARGET=$1
+    shift
+    ;;
+aarch64-pc-windows-msvc)
+    TARGET=$1
+    shift
+    ;;
+*) ;;
+esac
+cargo_flags=("$@")
 
-# Build the x86_64 windows release
-build_x86_64() {
-    cargo build --target x86_64-pc-windows-msvc "${cargo_flags[@]}"
+build_target() {
+    TARGET=$1
+
+    case $TARGET in
+    x86_64-pc-windows-msvc)
+        FILE_SUFFIX=windows-x86_64
+        ;;
+    aarch64-pc-windows-msvc)
+        FILE_SUFFIX=windows-aarch64
+        ;;
+    *)
+        echo unknown target $TARGET
+        exit 1
+        ;;
+    esac
+    cargo build --target $TARGET "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/release/pact_verifier_cli.exe" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-windows-x86_64.exe.gz"
+            "$CARGO_TARGET_DIR/$TARGET/release/$APP_NAME.exe" \
+            "$ARTIFACTS_DIR/$APP_NAME-$FILE_SUFFIX.exe.gz"
     fi
 }
 
-# Build the aarch64 windows release
-build_aarch64() {
-    cargo build --target aarch64-pc-windows-msvc "${cargo_flags[@]}"
-
-    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-pc-windows-msvc/release/pact_verifier_cli.exe" \
-            "$ARTIFACTS_DIR/pact_verifier_cli-windows-aarch64.exe.gz"
-    fi
-}
-
-build_x86_64
-build_aarch64
+if [ ! -z "$TARGET" ]; then
+    echo building for target $TARGET
+    build_target $TARGET
+else
+    echo building for all targets
+    build_target x86_64-pc-windows-msvc
+    build_target aarch64-pc-windows-msvc
+fi

--- a/rust/scripts/gzip-and-sum.sh
+++ b/rust/scripts/gzip-and-sum.sh
@@ -15,4 +15,11 @@ gzip_and_sum() {
 
     gzip --stdout --best "$orig_file" > "$target_file"
     openssl dgst -sha256 -r "$target_file" > "$digest_file"
+    basenamedir=$(basename $target_file)
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        # OSX requires an empty arg passed to -i, but this doesn't work on Lin/Win
+        sed -Ei '' "s|\*(.*)$|\*$basenamedir|" "$digest_file"
+    else
+        sed -Ei "s|\*(.*)$|\*$basenamedir|" "$digest_file"
+    fi
 }


### PR DESCRIPTION
Building individual targets allows us to identify where a single one fails, and gives us quicker feedback.

This mitigates some of the issues seen when building multiple targets with cross (wrong linker symbols), and allows us to enable per target caching which improves compile times.

Few other quality of life improvements are included (cron job, smoke test to weed out loading issues with the shared libraries)

- update release workflow to support
  - workflow_dispatch
  - cron schedule every wednesday
  - run each target in seperate job
  - add cache key per target

- update release scripts (pact_ffi / verifier_cli )
  - allow building individual targets
  - refactor similar steps
  - generate musl .so with `RUSTFLAGS="-C target-feature=-crt-static"` fixes #436 
  - smoke test dynamic lib loading (for pact-php, pact-js, pact-net, pact-go) fixes #436 
  
## Breaking changes
  
BREAKING CHANGE: macos aarch64 binaries now renamed to <app_name>-macos-aarch64. (previously was apple-darwin for aarch64)

Rationale: for consistency with x86_64 apple target and other platforms

BREAKING CHANGE: macos binaries are now only published with <app_name>-macos-<arch>. `osx` flavoured varieties are now discontinued

Rationale: for consistency with nomenclature, as osx not relevant today with latest version being macos 14

BREAKING CHANGE: sha256 files no longer contain full paths to files, only filenames

Rationale: The additional information is superfluous for end users, and requires them to modify the file for it to be usable. [see pact-net](https://github.com/pact-foundation/pact-net/blob/09ee8189a3dba1c47a02e571e8872924b90caaa8/build/download-native-libs.sh#L43-L50)
