### PR TITLE
Feat/smaller binaries

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,3 +12,8 @@ resolver = "2"
 
 [patch.crates-io]
 onig = { git = "https://github.com/rust-onig/rust-onig", default-features = false }
+
+[profile.release]
+strip = true
+opt-level = "z"
+codegen-units = 1


### PR DESCRIPTION
## Slim executables as per 

- https://github.com/pact-foundation/pact-stub-server/pull/64
- https://github.com/pact-foundation/pact-plugins/pull/59
- https://github.com/pactflow/pact-protobuf-plugin/pull/57

```
[profile.release]
strip = true
opt-level = "z"
codegen-units = 1
```

we do not use `lto=true`, as this config is applied at the root level to both the `pact_ffi` and `verifier_cli` crates. 

`lto=true` inflates the size of the static libraries dramatically generated by \pact_ffi`. 

It may be prudent to apply these additional `RUSTFLAGS` in the release scripts for the verifier cli to allow for further executable size reductions.

## Question

- Should we elect
  - for setting these values conditionally in the release scripts
  - custom profile in Cargo.toml that inherits from release, such that we dont affect the release profile for other crates in the workspace?
  
  
## Testing

Have been testing in this draft PR against my forks, which are all working as expected however it uncovered an issue in one of pact-net's test against the current released 0.4.20 version (more detail in the pr draft) - I've still to yak shave that one but it's not relevant to this PR

https://github.com/YOU54F/pact-reference/pull/6