### PR TITLE
Issue/434 missing buffer logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
+      - name: Run mock_server_logs test
+        run: cargo test -p pact_ffi returns_mock_server_logs -- --nocapture --include-ignored
+        working-directory: rust
+        env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: 1
       - name: Build Components
         run: cargo build
         working-directory: rust

--- a/compatibility-suite/Cargo.toml
+++ b/compatibility-suite/Cargo.toml
@@ -65,5 +65,5 @@ harness = false
 [patch.crates-io]
 pact_matching = { path = "../rust/pact_matching" }
 pact_models = { path = "../rust/pact_models" }
-pact_mock_server = { git = 'https://github.com/you54f/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
-pact-plugin-driver = { git = 'https://github.com/you54f/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }
+pact_mock_server = { git = 'https://github.com/pact-foundation/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
+pact-plugin-driver = { git = 'https://github.com/pact-foundation/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }

--- a/compatibility-suite/Cargo.toml
+++ b/compatibility-suite/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.4.0"
 maplit = "1.0.2"
 pact_models = { version = "~1.2.0" }
 pact_matching = { version = "1.2.3", path = "../rust/pact_matching" }
-pact_mock_server = { version = "1.2.8" }
+pact_mock_server = { version = "1.2.9" }
 pact_verifier = { version = "1.2.1", path = "../rust/pact_verifier" }
 pact_consumer = { version = "1.2.0", path = "../rust/pact_consumer" }
 pretty_assertions = "1.4.0"
@@ -26,8 +26,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"
 sxd-document = "0.3.2"
 tokio = { version = "1.33.0", features = ["full"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "tracing-log", "fmt"] }
+tracing = "=0.1.40"
+tracing-subscriber = { version = "=0.3.18", features = ["env-filter", "tracing-log", "fmt"] }
 uuid = { version = "1.5.0", features = ["v4"] }
 
 [[test]]
@@ -64,3 +64,6 @@ harness = false
 
 [patch.crates-io]
 pact_matching = { path = "../rust/pact_matching" }
+pact_models = { path = "../rust/pact_models" }
+pact_mock_server = { git = 'https://github.com/you54f/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
+pact-plugin-driver = { git = 'https://github.com/you54f/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1863,7 +1863,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pact-plugin-driver"
 version = "0.6.2"
-source = "git+https://github.com/you54f/pact-plugins.git?branch=fix/logging_min#baeff6ca0f474bd5fe348daf8fb7b873bd6397a2"
+source = "git+https://github.com/pact-foundation/pact-plugins.git?branch=issue/134_missing_buffer_logs#63b28a993044ee6320fb9a8f971bff4bebdf36c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "pact_mock_server"
 version = "1.2.9"
-source = "git+https://github.com/you54f/pact-core-mock-server.git?branch=fix/logging_min#46689503e977fd42f993a54a8bf9a658e711987b"
+source = "git+https://github.com/pact-foundation/pact-core-mock-server.git?branch=issue/134_missing_buffer_logs#c5ed4b633b6085756a5b6eadb2ccb15060f4a64f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -156,7 +156,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -167,7 +167,7 @@ version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -195,7 +195,7 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf3ee19dbc0a46d740f6f0926bde8c50f02bdbc7b536842da28f6ac56513a8b"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -213,7 +213,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -461,18 +461,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -607,7 +607,7 @@ checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "strsim 0.11.1",
  "syn 2.0.66",
@@ -640,7 +640,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -866,7 +866,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1188,7 +1188,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1219,7 +1219,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1498,7 +1498,7 @@ checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "regex-syntax 0.6.29",
  "syn 2.0.66",
@@ -1667,7 +1667,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197eff6c12b80ff5de6173e438fa3c1340a9e708118c1626e690f65aee1e5332"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1679,7 +1679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef492b5cf80f90c050b287e747228a1fa6517e9d754f364b5a7e0e038e49a25f"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.1.5"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1862,9 +1862,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pact-plugin-driver"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dafb1371bf02e0fa25212061d41cc5cbc4ad1116d1e988a86eede5e5bb338931"
+version = "0.6.2"
+source = "git+https://github.com/you54f/pact-plugins.git?branch=fix/logging_min#baeff6ca0f474bd5fe348daf8fb7b873bd6397a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1881,7 +1880,7 @@ dependencies = [
  "maplit",
  "md5",
  "os_info",
- "pact_models 1.2.0",
+ "pact_models",
  "prost",
  "prost-types",
  "regex",
@@ -1916,9 +1915,9 @@ dependencies = [
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching 1.2.4",
+ "pact_matching",
  "pact_mock_server",
- "pact_models 1.2.0",
+ "pact_models",
  "pretty_assertions",
  "quickcheck",
  "rand",
@@ -1960,9 +1959,9 @@ dependencies = [
  "onig",
  "os_info",
  "pact-plugin-driver",
- "pact_matching 1.2.4",
+ "pact_matching",
  "pact_mock_server",
- "pact_models 1.2.0",
+ "pact_models",
  "pact_verifier",
  "panic-message",
  "pretty_assertions",
@@ -1987,47 +1986,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "zeroize",
-]
-
-[[package]]
-name = "pact_matching"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd60651cf03381d1834353687140ab2f0756b5a7c15a1860d1831fee3380dba"
-dependencies = [
- "ansi_term",
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "difference",
- "futures",
- "hex",
- "http 1.1.0",
- "infer",
- "itertools 0.12.1",
- "lazy_static",
- "lenient_semver",
- "maplit",
- "md5",
- "mime",
- "multer",
- "nom",
- "onig",
- "pact-plugin-driver",
- "pact_models 1.2.0",
- "rand",
- "reqwest 0.12.4",
- "semver",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sxd-document",
- "tokio",
- "tracing",
- "tracing-core",
- "tree_magic_mini",
- "uuid",
 ]
 
 [[package]]
@@ -2058,7 +2016,7 @@ dependencies = [
  "ntest",
  "onig",
  "pact-plugin-driver",
- "pact_models 1.2.0",
+ "pact_models",
  "pretty_assertions",
  "quickcheck",
  "rand",
@@ -2080,21 +2038,20 @@ dependencies = [
 
 [[package]]
 name = "pact_mock_server"
-version = "1.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c30ce7d0fb6daf3bd3d60ab0781ca618ac76f53354e48967a48b846f05288cf"
+version = "1.2.9"
+source = "git+https://github.com/you54f/pact-core-mock-server.git?branch=fix/logging_min#46689503e977fd42f993a54a8bf9a658e711987b"
 dependencies = [
  "anyhow",
  "bytes",
  "futures",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "itertools 0.12.1",
  "lazy_static",
  "maplit",
  "pact-plugin-driver",
- "pact_matching 1.2.3",
- "pact_models 1.2.0",
+ "pact_matching",
+ "pact_models",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -2105,45 +2062,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "url",
- "uuid",
-]
-
-[[package]]
-name = "pact_models"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3bf784d5fc22d0332041fa8f9dd9992e0ce2b22236462847ca1b1377297e10"
-dependencies = [
- "anyhow",
- "ariadne",
- "base64 0.21.7",
- "bytes",
- "chrono",
- "chrono-tz 0.8.6",
- "fs2",
- "gregorian",
- "hashers",
- "hex",
- "indextree",
- "itertools 0.10.5",
- "lazy_static",
- "lenient_semver",
- "logos",
- "maplit",
- "mime",
- "nom",
- "onig",
- "parse-zoneinfo",
- "rand",
- "rand_regex",
- "regex",
- "regex-syntax 0.6.29",
- "reqwest 0.11.27",
- "semver",
- "serde",
- "serde_json",
- "sxd-document",
- "tracing",
  "uuid",
 ]
 
@@ -2216,8 +2134,8 @@ dependencies = [
  "mime",
  "pact-plugin-driver",
  "pact_consumer",
- "pact_matching 1.2.4",
- "pact_models 1.2.0",
+ "pact_matching",
+ "pact_models",
  "pretty_assertions",
  "quickcheck",
  "regex",
@@ -2241,13 +2159,13 @@ version = "1.1.3"
 dependencies = [
  "ansi_term",
  "anyhow",
- "clap 4.5.4",
+ "clap 4.5.6",
  "env_logger 0.11.3",
  "expectest",
  "junit-report",
  "log",
  "maplit",
- "pact_models 1.2.0",
+ "pact_models",
  "pact_verifier",
  "regex",
  "reqwest 0.12.4",
@@ -2398,7 +2316,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -2455,7 +2373,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "syn 2.0.66",
 ]
 
@@ -2479,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2525,7 +2443,7 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -2574,7 +2492,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
 ]
 
 [[package]]
@@ -2719,7 +2637,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -2826,7 +2744,7 @@ checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "regex",
  "relative-path",
@@ -3050,7 +2968,7 @@ version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3112,7 +3030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3192,9 +3110,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snapbox"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94204b12a4d3550420babdb4148c6639692e4e3e61060866929c5107f208aeb6"
+checksum = "9e5cb88aa548c9514cd7dba04a5d8d80a9464ae6d04a1d203fa7d469c71b75e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3303,7 +3221,7 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -3314,7 +3232,7 @@ version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -3363,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -3401,7 +3319,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3430,7 +3348,7 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3493,9 +3411,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3522,11 +3440,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3591,14 +3509,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -3623,15 +3541,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.9",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -3648,7 +3566,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -3668,7 +3586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "prost-build",
  "quote 1.0.36",
  "syn 2.0.66",
@@ -3724,7 +3642,7 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
 ]
@@ -3808,7 +3726,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -3855,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -3937,7 +3855,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
 ]
 
@@ -3994,7 +3912,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
  "wasm-bindgen-shared",
@@ -4028,7 +3946,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.84",
+ "proc-macro2 1.0.85",
  "quote 1.0.36",
  "syn 2.0.66",
  "wasm-bindgen-backend",
@@ -4264,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,3 +12,7 @@ resolver = "2"
 
 [patch.crates-io]
 onig = { git = "https://github.com/rust-onig/rust-onig", default-features = false }
+pact_models = { path = "./pact_models" }
+pact_matching = { path = "./pact_matching" }
+pact_mock_server = { git = 'https://github.com/pact-reference/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
+pact-plugin-driver = { git = 'https://github.com/pact-reference/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,5 +14,5 @@ resolver = "2"
 onig = { git = "https://github.com/rust-onig/rust-onig", default-features = false }
 pact_models = { path = "./pact_models" }
 pact_matching = { path = "./pact_matching" }
-pact_mock_server = { git = 'https://github.com/pact-reference/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
-pact-plugin-driver = { git = 'https://github.com/pact-reference/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }
+pact_mock_server = { git = 'https://github.com/pact-foundation/pact-core-mock-server.git', branch = "issue/134_missing_buffer_logs" }
+pact-plugin-driver = { git = 'https://github.com/pact-foundation/pact-plugins.git', branch = "issue/134_missing_buffer_logs" }

--- a/rust/pact_consumer/Cargo.toml
+++ b/rust/pact_consumer/Cargo.toml
@@ -29,10 +29,10 @@ futures = "0.3.30"
 itertools = "0.12.1"
 lazy_static = "1.4.0"
 maplit = "1.0.2"
-pact_matching = { version = "~1.2.3", path = "../pact_matching", default-features = false }
-pact_mock_server = { version = "~1.2.8", default-features = false }
-pact_models = { version = "~1.2.0", default-features = false }
-pact-plugin-driver = { version = "~0.6.1", optional = true, default-features = false }
+pact_matching = { version = "~1.2.4", path = "../pact_matching", default-features = false }
+pact_mock_server = { version = "~1.2.9", default-features = false }
+pact_models = { version = "~1.2.0", default-features = false, path = "../pact_models"  }
+pact-plugin-driver = { version = "~0.6.2", optional = true, default-features = false }
 regex = "1.10.4"
 serde_json = "1.0.115"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -31,9 +31,9 @@ maplit = "1.0.2"
 multipart = { version = "0.18.0", default-features = false, features = ["client", "mock"] }
 onig = { version = "6.4.0", default-features = false }
 pact_matching = { version = "~1.2.3", path = "../pact_matching" }
-pact_mock_server = { version = "~1.2.8" }
-pact_models = { version = "~1.2.0" }
-pact-plugin-driver = { version = "~0.6.1" }
+pact_mock_server = { version = "~1.2.9" }
+pact_models = { version = "~1.2.0", path = "../pact_models"  }
+pact-plugin-driver = { version = "~0.6.2" }
 pact_verifier = { version = "~1.2.1", path = "../pact_verifier" }
 panic-message = "0.3.0"
 rand = "0.8.5"

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -9,7 +9,9 @@ use bytes::Bytes;
 use expectest::prelude::*;
 use itertools::Itertools;
 use libc::c_char;
+use log::LevelFilter;
 use maplit::*;
+use pact_ffi::log::pactffi_log_to_buffer;
 use pact_models::bodies::OptionalBody;
 use pact_models::PactSpecification;
 use pretty_assertions::assert_eq;
@@ -19,14 +21,14 @@ use tempfile::TempDir;
 use serde_json::{json, Value};
 use rstest::rstest;
 use regex::Regex;
-
 #[allow(deprecated)]
 use pact_ffi::mock_server::{
   pactffi_cleanup_mock_server,
   pactffi_create_mock_server,
   pactffi_create_mock_server_for_pact,
   pactffi_mock_server_mismatches,
-  pactffi_write_pact_file
+  pactffi_write_pact_file,
+  pactffi_mock_server_logs,
 };
 #[allow(deprecated)]
 use pact_ffi::mock_server::handles::{
@@ -1405,4 +1407,31 @@ fn matching_definition_expressions_matcher() {
       panic!("expected 200 response but request failed: {}", err);
     }
   };
+}
+
+// Run independently as this log settings are global, and other tests affect this one.
+// cargo test -p pact_ffi returns_mock_server_logs -- --nocapture --include-ignored
+#[ignore]
+#[test]
+fn returns_mock_server_logs() {
+  let pact_json = include_str!("post-pact.json");
+  let pact_json_c = CString::new(pact_json).expect("Could not construct C string from json");
+  let address = CString::new("127.0.0.1:0").unwrap();
+  #[allow(deprecated)]
+  let port = pactffi_create_mock_server(pact_json_c.as_ptr(), address.as_ptr(), false);
+  expect!(port).to(be_greater_than(0));
+  pactffi_log_to_buffer(LevelFilter::Debug.into());
+  let client = Client::default();
+  client.post(format!("http://127.0.0.1:{}/path", port).as_str())
+    .header(CONTENT_TYPE, "application/json")
+    .body(r#"{"foo":"no-very-bar"}"#)
+    .send().expect("Sent POST request to mock server");
+
+  let logs =  unsafe {
+    CStr::from_ptr(pactffi_mock_server_logs(port)).to_string_lossy().into_owned()
+  };
+  println!("{}",logs);
+  assert_ne!(logs,"", "logs are empty");
+
+  pactffi_cleanup_mock_server(port);
 }

--- a/rust/pact_matching/Cargo.toml
+++ b/rust/pact_matching/Cargo.toml
@@ -42,7 +42,7 @@ multer = { version = "3.0.0", features = ["all"], optional = true }
 nom = "7.1.3"
 onig = { version = "6.4.0", default-features = false }
 pact_models = { version = "~1.2.0", default-features = false }
-pact-plugin-driver = { version = "~0.6.1", optional = true, default-features = false }
+pact-plugin-driver = { version = "~0.6.2", optional = true, default-features = false }
 rand = "0.8.5"
 reqwest = { version = "0.12.3", default-features = false, features = ["rustls-tls-native-roots", "json"] }
 semver = "1.0.22"

--- a/rust/pact_models/Cargo.toml
+++ b/rust/pact_models/Cargo.toml
@@ -45,7 +45,7 @@ semver = "1.0.17"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 sxd-document = { version = "0.3.2", optional = true }
-tracing = "0.1.37" # This needs to be the same version across all the libs (i.e. Pact FFI and plugin driver)
+tracing = "0.1.40" # This needs to be the same version across all the libs (i.e. Pact FFI and plugin driver)
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 fs2 = "0.4.3"
@@ -64,7 +64,7 @@ pretty_assertions = "1.3.0"
 rstest = "0.19.0"
 speculate = "0.1.2"
 test-log = { version = "0.2.11", features = ["trace"] }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "tracing-log", "fmt"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "tracing-log", "fmt"] }
 trim-margin = "0.1.0"
 
 [build-dependencies]

--- a/rust/pact_verifier/Cargo.toml
+++ b/rust/pact_verifier/Cargo.toml
@@ -36,8 +36,8 @@ lazy_static = "1.4.0"
 maplit = "1.0.2"
 mime = "0.3.17"
 pact_matching = { version = "~1.2.3", path = "../pact_matching", default-features = false }
-pact_models = { version = "~1.2.0", default-features = false }
-pact-plugin-driver = { version = "~0.6.1", optional = true, default-features = false }
+pact_models = { version = "~1.2.0", default-features = false, path = "../pact_models"  }
+pact-plugin-driver = { version = "~0.6.2", optional = true, default-features = false }
 regex = "1.10.4"
 reqwest = { version = "0.12.3", default-features = false, features = ["rustls-tls-native-roots", "blocking", "json"] }
 serde = "1.0.197"

--- a/rust/scripts/ci-musl-build.sh
+++ b/rust/scripts/ci-musl-build.sh
@@ -5,3 +5,4 @@ set -ex
 rustc --print cfg
 cargo build
 cargo test
+cargo test -p pact_ffi returns_mock_server_logs -- --nocapture --include-ignored


### PR DESCRIPTION
fixes #434 

I believe this issue stems from one of the pact crates having a different version of the tracing crate used for logging.

This seems like an awkward position to be in, when upgrading dependencies of each of the indiv pact rust crates, especially as two sit across different repos (pact_mock_server / pact-plugin-driver).

Would it make sense to crate a pact_logging crate that wraps the required deps for logging, and this singular crate can be imported by all the other pact rust crates.

If we need to update the logging deps, we update them in the pact_logging crate, and then can use the workspace override to patch all crates to use the same versions (via pact_logging)
