### PR TITLE
feat(verifier): support fallback_branch consumer version selector

### DIFF
--- a/rust/pact_verifier/src/selectors.rs
+++ b/rust/pact_verifier/src/selectors.rs
@@ -24,6 +24,7 @@ pub fn consumer_tags_to_selectors(tags: Vec<&str>) -> Vec<ConsumerVersionSelecto
       main_branch: None,
       environment: None,
       matching_branch: None,
+      fallback_branch: None,
     }
   }).collect()
 }


### PR DESCRIPTION
fixes #195 - also documents consumer version selector options as per pact broker docs