### PR TITLE
fix: Fix can't match array of numbers

### DIFF
--- a/rust/pact_matching/src/matchingrules.rs
+++ b/rust/pact_matching/src/matchingrules.rs
@@ -79,6 +79,7 @@ impl <T: Debug + Display + PartialEq + Clone> Matches<&[T]> for &[T] {
       MatchingRule::EachKey(_) => Ok(()),
       MatchingRule::EachValue(_) => Ok(()),
       MatchingRule::Values => Ok(()),
+      MatchingRule::Number | MatchingRule::Decimal | MatchingRule::Integer => Ok(()),
       _ => Err(anyhow!("Unable to match {} using {:?}", self.for_mismatch(), matcher))
     };
     debug!("Comparing '{:?}' to '{:?}' using {:?} -> {:?}", self, actual, matcher, result);


### PR DESCRIPTION
Before the fix:

```
2024-09-06T04:24:10.924510Z DEBUG tokio-runtime-worker pact_matching: --> Mismatches: [BodyMismatch { path: "$.$.age", expected: Some(b"[\"27\"]"), actual: Some(b"[\"41\"]"), mismatch: "Unable to match [\"27\"] using Number" }]
```

After the fix:

```
2024-09-06T04:18:29.737113Z DEBUG tokio-runtime-worker pact_matching::matchingrules: Comparing '["27"]' to '["41"]' using Number -> Ok(())
2024-09-06T04:18:29.737122Z DEBUG tokio-runtime-worker pact_matching::matchingrules: Comparing list item 0 with value 'Some("41")' to '"27"'
2024-09-06T04:18:29.737147Z DEBUG tokio-runtime-worker pact_matching::matchers: String -> String: comparing '27' to '41' ==> true cascaded=true matcher=Number
```