### PR TITLE
fix: Fix can't compare 2 eachKey matching rules, 2 eachValue matching rules

### DIFF
--- a/rust/pact_consumer/src/patterns/special_rules.rs
+++ b/rust/pact_consumer/src/patterns/special_rules.rs
@@ -567,7 +567,7 @@ fn object_matching_test() {
       MatchingRule::EachKey(MatchingRuleDefinition::new("key1".to_string(), ValueType::String,
         MatchingRule::Regex("[a-z]{3}[0-9]".to_string()), None)),
       MatchingRule::EachValue(MatchingRuleDefinition::new("\"value1\"".to_string(),
-        ValueType::Unknown, MatchingRule::Type, None))
+        ValueType::String, MatchingRule::Type, None))
     ]
   }, rules);
 }
@@ -786,7 +786,7 @@ fn each_value_is_pattern() {
   matchable.extract_matching_rules(DocPath::root(), &mut rules);
   expect!(rules).to(be_equal_to(matchingrules_list! {
     "body"; "$" => [
-      MatchingRule::EachValue(MatchingRuleDefinition::new("100".to_string(), ValueType::String,
+      MatchingRule::EachValue(MatchingRuleDefinition::new("\"100\"".to_string(), ValueType::String,
         MatchingRule::Regex("\\d+".to_string()), None))
     ]
   }));
@@ -820,7 +820,7 @@ fn each_value_test() {
   result.extract_matching_rules(DocPath::root(), &mut rules);
   expect!(rules).to(be_equal_to(matchingrules_list! {
     "body"; "$" => [
-      MatchingRule::EachValue(MatchingRuleDefinition::new("value1".to_string(), ValueType::Unknown,
+      MatchingRule::EachValue(MatchingRuleDefinition::new("\"value1\"".to_string(), ValueType::String,
         MatchingRule::Regex("[a-z]{5}[0-9]".to_string()), None))
     ]
   }));

--- a/rust/pact_models/src/matchingrules/expressions.rs
+++ b/rust/pact_models/src/matchingrules/expressions.rs
@@ -1676,7 +1676,7 @@ mod test {
         value_type: ValueType::Unknown,
         rules: vec![
           Either::Left(MatchingRule::EachKey(MatchingRuleDefinition { value: "$.test.one".to_string(), value_type: ValueType::String, rules: vec![Either::Left(MatchingRule::Regex("\\$(\\.\\w+)+".to_string()))], generator: None } )),
-          Either::Left(MatchingRule::EachValue(MatchingRuleDefinition { value: "".to_string(), value_type: ValueType::Unknown, rules: vec![Either::Left(MatchingRule::Type)], generator: None } ))
+          Either::Left(MatchingRule::EachValue(MatchingRuleDefinition { value: "".to_string(), value_type: ValueType::String, rules: vec![Either::Left(MatchingRule::Type)], generator: None } ))
         ],
         generator: None
       }));

--- a/rust/pact_models/src/matchingrules/mod.rs
+++ b/rust/pact_models/src/matchingrules/mod.rs
@@ -2160,7 +2160,7 @@ mod tests {
       ]
     });
     expect!(MatchingRule::from_json(&json)).to(be_ok().value(
-      MatchingRule::EachValue(MatchingRuleDefinition::new("{\"price\": 1.23}".to_string(),
+      MatchingRule::EachValue(MatchingRuleDefinition::new("{\"price\":1.23}".to_string(),
         ValueType::Unknown, MatchingRule::Decimal, None)))
     );
   }
@@ -2633,6 +2633,24 @@ mod tests {
           "$.x-test" => [ MatchingRule::Regex(".*".to_owned()) ]
         }
       }
+    )
+  }
+
+  #[test]
+  #[should_panic]
+  fn each_value_matching_rule_comparation_test() {
+    assert_eq!(
+      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachValue(MatchingRuleDefinition::new("[\"string value\"]".to_string(), ValueType::Unknown, MatchingRule::Type, None))]},
+      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachValue(MatchingRuleDefinition::new("[\"something else\"]".to_string(), ValueType::Unknown, MatchingRule::Type, None))]}
+    )
+  }
+
+  #[test]
+  #[should_panic]
+  fn each_key_matching_rule_comparation_test() {
+    assert_eq!(
+      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachKey(MatchingRuleDefinition::new("a_key".to_string(), ValueType::Unknown, MatchingRule::Type, None))]},
+      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachKey(MatchingRuleDefinition::new("another_key".to_string(), ValueType::Unknown, MatchingRule::Type, None))]}
     )
   }
 }

--- a/rust/pact_models/src/matchingrules/mod.rs
+++ b/rust/pact_models/src/matchingrules/mod.rs
@@ -537,6 +537,8 @@ impl PartialEq for MatchingRule {
       (MatchingRule::Include(str1), MatchingRule::Include(str2)) => str1 == str2,
       (MatchingRule::ContentType(str1), MatchingRule::ContentType(str2)) => str1 == str2,
       (MatchingRule::ArrayContains(variants1), MatchingRule::ArrayContains(variants2)) => variants1 == variants2,
+      (MatchingRule::EachKey(definition1), MatchingRule::EachKey(definition2)) => definition1 == definition2,
+      (MatchingRule::EachValue(definition1), MatchingRule::EachValue(definition2)) => definition1 == definition2,
       _ => mem::discriminant(self) == mem::discriminant(other)
     }
   }


### PR DESCRIPTION
### Each Value

Given this test:

```rust
  #[test]
  fn each_value_matching_rule_comparation_test() {
    assert_eq!(
      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachValue(MatchingRuleDefinition::new("[\"string value\"]".to_string(), ValueType::Unknown, MatchingRule::Type, None))]},
      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachValue(MatchingRuleDefinition::new("[\"something else\"]".to_string(), ValueType::Unknown, MatchingRule::Type, None))]}
    )
  }
```

Without the fix, this test will pass

With the fix, this test will failed with:

```

---- mock_server::bodies::test::each_value_matching_rule_comparation_test stdout ----
thread 'mock_server::bodies::test::each_value_matching_rule_comparation_test' panicked at pact_ffi/src/mock_server/bodies.rs:1133:5:
assertion failed: `(left == right)`

Diff < left / right > :
 MatchingRuleCategory {
     name: BODY,
     rules: {
         DocPath {
             path_tokens: [
                 Root,
                 Field(
                     "array_values",
                 ),
             ],
             expr: "$.array_values",
         }: RuleList {
             rules: [
                 EachValue(
                     MatchingRuleDefinition {
<                        value: "[\"string value\"]",
>                        value: "[\"something else\"]",
                         value_type: Unknown,
                         rules: [
                             Left(
                                 Type,
                             ),
                         ],
                         generator: None,
                     },
                 ),
             ],
             rule_logic: And,
             cascaded: false,
         },
     },
 }


```

### Each Key

Given this test:

```rust
  #[test]
  fn each_key_matching_rule_comparation_test() {
    assert_eq!(
      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachKey(MatchingRuleDefinition::new("a_key".to_string(), ValueType::Unknown, MatchingRule::Type, None))]},
      matchingrules_list!{"body"; "$.array_values" => [MatchingRule::EachKey(MatchingRuleDefinition::new("another_key".to_string(), ValueType::Unknown, MatchingRule::Type, None))]}
    )
  }
```

Without this fix, the test will pass

With this fix, the test will failed with:

```

failures:

---- mock_server::bodies::test::each_key_matching_rule_comparation_test stdout ----
thread 'mock_server::bodies::test::each_key_matching_rule_comparation_test' panicked at pact_ffi/src/mock_server/bodies.rs:1141:5:
assertion failed: `(left == right)`

Diff < left / right > :
 MatchingRuleCategory {
     name: BODY,
     rules: {
         DocPath {
             path_tokens: [
                 Root,
                 Field(
                     "array_values",
                 ),
             ],
             expr: "$.array_values",
         }: RuleList {
             rules: [
                 EachKey(
                     MatchingRuleDefinition {
<                        value: "a_key",
>                        value: "another_key",
                         value_type: Unknown,
                         rules: [
                             Left(
                                 Type,
                             ),
                         ],
                         generator: None,
                     },
                 ),
             ],
             rule_logic: And,
             cascaded: false,
         },
     },
 }

```