### PR TITLE
fix(verifier): add Accept-Charset=utf8 header when post/put

### DIFF
--- a/rust/pact_verifier/src/pact_broker.rs
+++ b/rust/pact_verifier/src/pact_broker.rs
@@ -495,6 +495,7 @@ impl HALClient {
       .header("Content-Type", "application/json")
       .header("Accept", "application/hal+json")
       .header("Accept", "application/json")
+      .header("Accept-Charset", "utf-8")
       .body(body.to_string());
 
     let response = with_retries(self.retries, request_builder).await;


### PR DESCRIPTION
Fixes 406 Not Acceptable on publishing verification results, when using a pact broker started with thin. (puma / webrick do not exhibit the issue