### PR TITLE
chore: reduce ci usage

### DIFF
--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -33,13 +33,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          components: rustfmt
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
-          components: rustfmt
       - name: Install doxygen
         if: runner.os == 'Linux'
         run: sudo apt-get install -y doxygen

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          shared-key: ${{ runner.os }}
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -1,6 +1,16 @@
 name: Pact-Rust FFI Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -12,6 +12,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  RUST_BACKTRACE: "1"
+  RUST_LOG: "debug"
+  PACT_DO_NOT_TRACK: "true"
+  CARGO_TERM_COLOR: always
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -20,8 +26,6 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
         rust: [ stable ]
-    env:
-      pact_do_not_track: true
     steps:
       - uses: actions/checkout@v3
       - run: rustc --version || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,20 @@ jobs:
 
   musl-build:
     runs-on: ubuntu-latest
+    container:
+      image: pactfoundation/rust-musl-build
     steps:
       - uses: actions/checkout@v3
-      - run: |
-         docker run --rm --user "$(id -u)":"$(id -g)" -v $(pwd):/workspace -w /workspace/rust -t -e TZ=UTC pactfoundation/rust-musl-build ./scripts/ci-musl-build.sh
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Tests
+        run: cargo nextest run
+        working-directory: rust
 
 
   check-features:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  RUST_BACKTRACE: "1"
+  RUST_LOG: "debug"
+  PACT_DO_NOT_TRACK: "true"
+  CARGO_TERM_COLOR: always
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -20,8 +26,6 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
         rust: [ stable ]
-    env:
-      pact_do_not_track: true
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -37,15 +41,9 @@ jobs:
       - name: Tests
         run: cargo nextest run
         working-directory: rust
-        env:
-          RUST_LOG: debug
-          RUST_BACKTRACE: 1
       - name: Run mock_server_logs test
         run: cargo nextest run -p pact_ffi returns_mock_server_logs -- --include-ignored
         working-directory: rust
-        env:
-          RUST_LOG: debug
-          RUST_BACKTRACE: 1
       - name: Clippy
         if: runner.os == 'Linux'
         run: cargo clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          shared-key: ${{ runner.os }}-musl
       - name: Tests
         run: cargo nextest run
         working-directory: rust

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Pact-Rust Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -55,4 +65,3 @@ jobs:
       - uses: actions/checkout@v3
       - run: cargo check --no-default-features
         working-directory: rust
-         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,24 +28,24 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Install shared mime info DB
         if: runner.os == 'macOS'
         run: brew install shared-mime-info
       - name: Tests
-        run: cargo test
+        run: cargo nextest run
         working-directory: rust
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
       - name: Run mock_server_logs test
-        run: cargo test -p pact_ffi returns_mock_server_logs -- --nocapture --include-ignored
+        run: cargo nextest run -p pact_ffi returns_mock_server_logs -- --include-ignored
         working-directory: rust
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
-      - name: Build Components
-        run: cargo build
-        working-directory: rust
       - name: Clippy
         if: runner.os == 'Linux'
         run: cargo clippy

--- a/.github/workflows/compatability-suite.yml
+++ b/.github/workflows/compatability-suite.yml
@@ -1,6 +1,16 @@
 name: Pact-Rust Compatibility Suite
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   pact_do_not_track: true

--- a/.github/workflows/compatability-suite.yml
+++ b/.github/workflows/compatability-suite.yml
@@ -13,7 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  pact_do_not_track: true
+  RUST_BACKTRACE: "1"
+  RUST_LOG: "debug"
+  PACT_DO_NOT_TRACK: "true"
+  CARGO_TERM_COLOR: always
 
 jobs:
   compatibility-suite:

--- a/.github/workflows/compatability-suite.yml
+++ b/.github/workflows/compatability-suite.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            rust
+            compatibility-suite
+          shared-key: ${{ runner.os }}
       - name: Run Cucumber
         # Note: cucumber's test executables are incompatible with nextest
         # See: https://github.com/nextest-rs/nextest/issues/1329

--- a/.github/workflows/compatability-suite.yml
+++ b/.github/workflows/compatability-suite.yml
@@ -16,51 +16,20 @@ env:
   pact_do_not_track: true
 
 jobs:
-  v1:
+  compatibility-suite:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
-    steps:
-    - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@stable
-    - name: Run Cucumber
-      run: cargo test --test v1*
-      working-directory: compatibility-suite
-  v2:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
+        operating-system: [ubuntu-latest, windows-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Run Cucumber
-        run: cargo test --test v2*
-        working-directory: compatibility-suite
-  v3:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run Cucumber
-        run: cargo test --test v3*
-        working-directory: compatibility-suite
-  v4:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run Cucumber
-        run: cargo test --test v4*
+        # Note: cucumber's test executables are incompatible with nextest
+        # See: https://github.com/nextest-rs/nextest/issues/1329
+        run: cargo test
         working-directory: compatibility-suite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          key: ${{ matrix.targets }}
+          shared-key: ${{ runner.os }}
 
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && startsWith(matrix.targets, 'aarch64')
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUST_BACKTRACE: "1"
+  RUST_LOG: "debug"
+  PACT_DO_NOT_TRACK: "true"
+  CARGO_TERM_COLOR: always
+
 jobs:
   build-release:
     name: build-release (${{ matrix.targets }})
@@ -42,9 +48,6 @@ jobs:
           - operating-system: macos-14
             targets: aarch64-apple-darwin
       fail-fast: false
-
-    env:
-      pact_do_not_track: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should help reduce the CI usage by:

1. Only running  CI on either:

   - PRs targetting `master`
   - pushes to `master`

   Most importantly, CI is no longer doubled in PRs (as previously, `push` and `pull_request` would _both_ be triggered, consuming double the number of runners).

2. Cancelling existing runs if a new commit is added

3. Speeding up some existing builds by not unnecessarily rebuilding everything (especially with the compatibility suite)

4. Using nextest in place of `cargo test` as it is typically faster

5. Using caching of build dependencies where possible