### PR TITLE
test: Add test for atLeast, atMost at the beginning of the matching expression

### DIFF
--- a/rust/pact_models/src/matchingrules/expressions.rs
+++ b/rust/pact_models/src/matchingrules/expressions.rs
@@ -1761,6 +1761,32 @@ mod test {
         generator: None,
         expression: exp.to_string()
       });
+    let exp = "atLeast(1), atMost(2), eachKey(matching(type, 'test')), eachValue(matching(type, 1))";
+    assert_eq!(super::parse_matcher_def(exp).unwrap(),
+      MatchingRuleDefinition {
+        value: "".to_string(),
+        value_type: ValueType::Unknown,
+        rules: vec![
+          Either::Left(MatchingRule::MinType(1)),
+          Either::Left(MatchingRule::MaxType(2)),
+          Either::Left(MatchingRule::EachKey(MatchingRuleDefinition {
+            value: "test".to_string(),
+            value_type: ValueType::String,
+            rules: vec![Either::Left(MatchingRule::Type)],
+            generator: None,
+            expression: exp.to_string()
+          })),
+          Either::Left(MatchingRule::EachValue(MatchingRuleDefinition {
+            value: "1".to_string(),
+            value_type: ValueType::Integer,
+            rules: vec![Either::Left(MatchingRule::Type)],
+            generator: None,
+            expression: exp.to_string()
+          }))
+        ],
+        generator: None,
+        expression: exp.to_string()
+      });
   }
 
   #[test_log::test]


### PR DESCRIPTION
This test is  for verifying that the matching expression doesn't have syntax errors. Related issue:

https://github.com/pactflow/pact-protobuf-plugin/issues/179