### PR TITLE
chore(ci): don't run on every push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Pact-Rust Build
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Instead, only trigger the 'push' step once merged into `master`.