### PR TITLE
update bytes to 1.11.1 to resolve RUSTSEC-2026-0007

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -345,9 +345,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/rust/pact_consumer/Cargo.toml
+++ b/rust/pact_consumer/Cargo.toml
@@ -25,7 +25,7 @@ colour = ["dep:yansi"]
 [dependencies]
 anyhow = "1.0.100"
 async-trait = "0.1.89"
-bytes = "1.11.0"
+bytes = "1.11.1"
 itertools = "0.14.0"
 maplit = "1.0.2"
 pact_matching = { version = "~2.0.2", path = "../pact_matching", default-features = false }

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1.0.100"
-bytes = "1.11.0"
+bytes = "1.11.1"
 chrono = "0.4.42"
 either = "1.15.0"
 futures = "0.3.31"


### PR DESCRIPTION
chore(pact_consumer): update bytes to 1.11.1 to resolve RUSTSEC-2026-0007
chore(pact_ffi): update bytes to 1.11.1 to resolve RUSTSEC-2026-0007