### PR TITLE
feat(pact_consumer): Add a function to the consumer DSLs to capture external references

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "pact_mock_server",
  "pact_models",
  "pretty_assertions",
+ "proclaim-it",
  "rand 0.8.6",
  "regex",
  "reqwest 0.13.3",
@@ -3036,6 +3037,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proclaim-it"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4129e92975bbdd549cffbd30f3d18de01589cff090b460c2f51936c8760d2f20"
+dependencies = [
+ "pretty_assertions",
+ "proclaim-it-macros",
+]
+
+[[package]]
+name = "proclaim-it-macros"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f70e1526805403908fcc6186adaeda499acc5fa9ea22b9e42d2b395d9e2a0c4"
+dependencies = [
+ "pretty_assertions",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rust/pact_consumer/Cargo.toml
+++ b/rust/pact_consumer/Cargo.toml
@@ -51,3 +51,4 @@ tokio-test = "0.4.5"
 test-log = { version = "0.2.19", features = ["trace"] }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "tracing-log", "fmt"] }
 pretty_assertions = "1.4.1"
+proclaim-it = "0.0.1"

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -253,7 +253,7 @@ mod plugin_tests {
   use proclaim_it::assert_that;
   use serde_json::{json, Value};
 
-  use crate::builders::{InteractionBuilder, MessageInteractionBuilder};
+  use crate::builders::InteractionBuilder;
 
   #[test]
   fn plugin_config_merges_config_from_request_and_response_parts() {

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -121,7 +121,7 @@ impl InteractionBuilder {
   /// the interaction corresponds to as an external reference.
   /// ```
   /// # let mut builder = pact_consumer::builders::InteractionBuilder::new("test", "");
-  /// builder.reference("asyncapi", "operationId", "createUser");
+  /// builder.reference("openapi", "operationId", "createUser");
   /// ```
   pub fn reference<G: Into<String>, N: Into<String>, J: Into<Value>>(
     &mut self,

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -122,7 +122,7 @@ impl InteractionBuilder {
   /// ```
   /// # let mut builder = pact_consumer::builders::InteractionBuilder::new("test", "");
   /// builder.reference("asyncapi", "operationId", "createUser");
-  ///
+  /// ```
   pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -123,7 +123,12 @@ impl InteractionBuilder {
   /// # let mut builder = pact_consumer::builders::InteractionBuilder::new("test", "");
   /// builder.reference("asyncapi", "operationId", "createUser");
   /// ```
-  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+  pub fn reference<G: Into<String>, N: Into<String>, J: Into<Value>>(
+    &mut self,
+    group: G,
+    name: N,
+    value: J
+  ) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {
         std::collections::btree_map::Entry::Vacant(entry) => {

--- a/rust/pact_consumer/src/builders/interaction_builder.rs
+++ b/rust/pact_consumer/src/builders/interaction_builder.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use maplit::hashmap;
+use maplit::{btreemap, hashmap};
 use serde_json::{json, Value};
 use tracing::debug;
 use pact_models::json_utils::json_deep_merge;
@@ -35,7 +35,9 @@ pub struct InteractionBuilder {
     pub interaction_type: String,
 
     /// Any configuration provided by plugins that needs to be persisted to the Pact metadata
-    pub plugin_configuration: HashMap<String, Value>
+    pub plugin_configuration: HashMap<String, Value>,
+
+    references: Option<BTreeMap<String, BTreeMap<String, Value>>>
 }
 
 impl InteractionBuilder {
@@ -52,7 +54,8 @@ impl InteractionBuilder {
       transport: None,
       request: RequestBuilder::default(),
       response: ResponseBuilder::default(),
-      plugin_configuration: Default::default()
+      plugin_configuration: Default::default(),
+      references: None
     }
   }
 
@@ -113,6 +116,33 @@ impl InteractionBuilder {
     self
   }
 
+  /// Sets an external reference for the interaction.  The reference will be stored in the Pact
+  /// file comments under the group. For instance, you could store the OpenAPI operation ID that
+  /// the interaction corresponds to as an external reference.
+  /// ```
+  /// # let mut builder = pact_consumer::builders::InteractionBuilder::new("test", "");
+  /// builder.reference("asyncapi", "operationId", "createUser");
+  ///
+  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+    if let Some(references) = self.references.as_mut() {
+      match references.entry(group.into()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+          entry.insert(btreemap! { name.into() => value.into() });
+        }
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+          entry.get_mut().insert(name.into(), value.into());
+        }
+      }
+    } else {
+      self.references = Some(btreemap!{
+        group.into() => btreemap!{
+          name.into() => value.into()
+        }
+      });
+    }
+    self
+  }
+
   /// Sets the protocol transport for this interaction. This would be required when there are
   /// different types of interactions in the Pact file (i.e. HTTP and messages).
   pub fn transport<G: Into<String>>(&mut self, name: G) -> &mut Self {
@@ -136,6 +166,17 @@ impl InteractionBuilder {
     debug!("Building V4 HTTP interaction: {:?}", self);
 
     let markup = self.request.interaction_markup().merge(self.response.interaction_markup());
+
+    let mut comments = hashmap! {
+      "text".to_string() => json!(self.comments),
+      "testname".to_string() => json!(self.test_name)
+    };
+    if let Some(references) = &self.references {
+      comments.insert("references".to_string(), references.iter()
+        .map(|(k, v)| (k.clone(), json!(v)))
+        .collect());
+    }
+
     SynchronousHttp {
       id: None,
       key: self.key.clone(),
@@ -143,10 +184,7 @@ impl InteractionBuilder {
       provider_states: self.provider_states.clone(),
       request: self.request.build_v4(),
       response: self.response.build_v4(),
-      comments: hashmap!{
-        "text".to_string() => json!(self.comments),
-        "testname".to_string() => json!(self.test_name)
-      },
+      comments,
       pending: self.pending.unwrap_or(false),
       plugin_config: self.plugin_config(),
       interaction_markup: markup,
@@ -212,9 +250,10 @@ mod plugin_tests {
   use expectest::prelude::*;
   use maplit::hashmap;
   use pact_plugin_driver::content::PluginConfiguration;
-  use serde_json::json;
+  use proclaim_it::assert_that;
+  use serde_json::{json, Value};
 
-  use crate::builders::InteractionBuilder;
+  use crate::builders::{InteractionBuilder, MessageInteractionBuilder};
 
   #[test]
   fn plugin_config_merges_config_from_request_and_response_parts() {
@@ -258,5 +297,28 @@ mod plugin_tests {
         })
       }
     }));
+  }
+
+  #[test]
+  fn supports_setting_external_references() {
+    let interaction = InteractionBuilder::new("test", "")
+      .reference("asyncapi", "operationId", "test")
+      .reference("openapi", "operationId", "test2")
+      .build_v4();
+
+    assert_that! {
+      interaction.comments == hashmap! {
+        "references".to_string() => json!({
+            "asyncapi": {
+              "operationId": "test"
+            },
+            "openapi": {
+              "operationId": "test2"
+            }
+        }),
+        "text".to_string() => json!([]),
+        "testname".to_string() => Value::Null
+      }
+    }
   }
 }

--- a/rust/pact_consumer/src/builders/message_builder.rs
+++ b/rust/pact_consumer/src/builders/message_builder.rs
@@ -336,7 +336,7 @@ impl MessageInteractionBuilder {
             self.setup_core_matcher(&ct, &contents_hashmap, Some(content_matcher));
           } else {
             debug!("Plugin matcher, will get the plugin to provide the interaction contents");
-            match content_matcher.configure_interation(&ct, contents_hashmap).await {
+            match content_matcher.configure_interaction(&ct, contents_hashmap).await {
               Ok((contents, plugin_config)) => {
                 if let Some(contents) = contents.first() {
                   self.message_contents = InteractionContents::from(contents);

--- a/rust/pact_consumer/src/builders/message_builder.rs
+++ b/rust/pact_consumer/src/builders/message_builder.rs
@@ -1,10 +1,10 @@
 //! Builder for constructing Asynchronous message interactions
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use bytes::Bytes;
-use maplit::hashmap;
+use maplit::{btreemap, hashmap};
 use pact_models::content_types::ContentType;
 use pact_models::json_utils::json_to_string;
 use pact_models::matchingrules::MatchingRuleCategory;
@@ -119,7 +119,8 @@ pub struct MessageInteractionBuilder {
   /// Contents of the message. This will include the payload as well as any metadata
   pub message_contents: InteractionContents,
   #[allow(dead_code)] contents_plugin: Option<PactPluginManifest>,
-  #[allow(dead_code)] plugin_config: HashMap<String, PluginConfiguration>
+  #[allow(dead_code)] plugin_config: HashMap<String, PluginConfiguration>,
+  references: Option<BTreeMap<String, BTreeMap<String, Value>>>
 }
 
 impl MessageInteractionBuilder {
@@ -135,7 +136,8 @@ impl MessageInteractionBuilder {
       pending: None,
       message_contents: Default::default(),
       contents_plugin: None,
-      plugin_config: Default::default()
+      plugin_config: Default::default(),
+      references: None
     }
   }
 
@@ -179,6 +181,33 @@ impl MessageInteractionBuilder {
   /// page, and potentially in the test output.
   pub fn test_name<G: Into<String>>(&mut self, name: G) -> &mut Self {
     self.test_name = Some(name.into());
+    self
+  }
+
+  /// Sets an external reference for the interaction.  The reference will be stored in the Pact
+  /// file comments under the group. For instance, you could store the AsyncAPI operation ID that
+  /// the interaction corresponds to as an external reference.
+  /// ```
+  /// # let mut builder = pact_consumer::builders::MessageInteractionBuilder::new("test");
+  /// builder.reference("asyncapi", "operationId", "createUser");
+  ///
+  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+    if let Some(references) = self.references.as_mut() {
+      match references.entry(group.into()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+          entry.insert(btreemap! { name.into() => value.into() });
+        }
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+          entry.get_mut().insert(name.into(), value.into());
+        }
+      }
+    } else {
+      self.references = Some(btreemap!{
+        group.into() => btreemap!{
+          name.into() => value.into()
+        }
+      });
+    }
     self
   }
 
@@ -235,6 +264,17 @@ impl MessageInteractionBuilder {
     let metadata = self.message_contents.metadata.as_ref()
       .map(|md| md.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
       .unwrap_or_default();
+
+    let mut comments = hashmap! {
+      "text".to_string() => json!(self.comments),
+      "testname".to_string() => json!(self.test_name)
+    };
+    if let Some(references) = &self.references {
+      comments.insert("references".to_string(), references.iter()
+        .map(|(k, v)| (k.clone(), json!(v)))
+        .collect());
+    }
+
     AsynchronousMessage {
       id: None,
       key: self.key.clone(),
@@ -246,10 +286,7 @@ impl MessageInteractionBuilder {
         matching_rules: rules,
         generators: self.message_contents.generators.as_ref().cloned().unwrap_or_default()
       },
-      comments: hashmap!{
-        "text".to_string() => json!(self.comments),
-        "testname".to_string() => json!(self.test_name)
-      },
+      comments,
       pending: self.pending.unwrap_or(false),
       plugin_config,
       interaction_markup,
@@ -464,7 +501,8 @@ impl MessageInteractionBuilder {
 mod tests {
   use expectest::prelude::*;
   use maplit::hashmap;
-  use serde_json::json;
+  use proclaim_it::assert_that;
+  use serde_json::{json, Value};
 
   use crate::builders::MessageInteractionBuilder;
 
@@ -480,5 +518,28 @@ mod tests {
       "b".to_string() => json!("b"),
       "c".to_string() => json!([1, 2, 3])
     }));
+  }
+
+  #[test]
+  fn supports_setting_external_references() {
+    let message = MessageInteractionBuilder::new("test")
+      .reference("asyncapi", "operationId", "test")
+      .reference("openapi", "operationId", "test2")
+      .build();
+
+    assert_that! {
+      message.comments == hashmap! {
+        "references".to_string() => json!({
+            "asyncapi": {
+              "operationId": "test"
+            },
+            "openapi": {
+              "operationId": "test2"
+            }
+        }),
+        "text".to_string() => json!([]),
+        "testname".to_string() => Value::Null
+      }
+    }
   }
 }

--- a/rust/pact_consumer/src/builders/message_builder.rs
+++ b/rust/pact_consumer/src/builders/message_builder.rs
@@ -191,7 +191,12 @@ impl MessageInteractionBuilder {
   /// # let mut builder = pact_consumer::builders::MessageInteractionBuilder::new("test");
   /// builder.reference("asyncapi", "operationId", "createUser");
   /// ```
-  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+  pub fn reference<G: Into<String>, N: Into<String>, J: Into<Value>>(
+    &mut self,
+    group: G,
+    name: N,
+    value: J
+  ) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {
         std::collections::btree_map::Entry::Vacant(entry) => {

--- a/rust/pact_consumer/src/builders/message_builder.rs
+++ b/rust/pact_consumer/src/builders/message_builder.rs
@@ -190,7 +190,7 @@ impl MessageInteractionBuilder {
   /// ```
   /// # let mut builder = pact_consumer::builders::MessageInteractionBuilder::new("test");
   /// builder.reference("asyncapi", "operationId", "createUser");
-  ///
+  /// ```
   pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {

--- a/rust/pact_consumer/src/builders/request_builder.rs
+++ b/rust/pact_consumer/src/builders/request_builder.rs
@@ -185,7 +185,7 @@ impl RequestBuilder {
             match definition {
               Value::Object(attributes) => {
                 let map = attributes.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                match matcher.configure_interation(&content_type, map).await {
+                match matcher.configure_interaction(&content_type, map).await {
                   Ok((contents, plugin_config)) => {
                     debug!("Interaction contents = {:?}", contents);
                     debug!("Interaction plugin_config = {:?}", plugin_config);

--- a/rust/pact_consumer/src/builders/response_builder.rs
+++ b/rust/pact_consumer/src/builders/response_builder.rs
@@ -115,7 +115,7 @@ impl ResponseBuilder {
             match definition {
               Value::Object(attributes) => {
                 let map = attributes.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                match matcher.configure_interation(&content_type, map).await {
+                match matcher.configure_interaction(&content_type, map).await {
                   Ok((contents, plugin_config)) => {
                     debug!("Interaction contents = {:?}", contents);
                     debug!("Interaction plugin_config = {:?}", plugin_config);

--- a/rust/pact_consumer/src/builders/sync_message_builder.rs
+++ b/rust/pact_consumer/src/builders/sync_message_builder.rs
@@ -109,9 +109,9 @@ impl SyncMessageInteractionBuilder {
   /// file comments under the group. For instance, you could store the AsyncAPI operation ID that
   /// the interaction corresponds to as an external reference.
   /// ```
-  /// # let mut builder = pact_consumer::builders::MessageInteractionBuilder::new("test");
+  /// # let mut builder = pact_consumer::builders::SyncMessageInteractionBuilder::new("test");
   /// builder.reference("asyncapi", "operationId", "createUser");
-  ///
+  /// ```
   pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {

--- a/rust/pact_consumer/src/builders/sync_message_builder.rs
+++ b/rust/pact_consumer/src/builders/sync_message_builder.rs
@@ -258,7 +258,7 @@ impl SyncMessageInteractionBuilder {
             debug!("Content matcher is a core matcher, will use the internal implementation");
             self.setup_core_matcher(Some(ct.clone()), &contents_hashmap, Some(content_matcher));
           } else {
-            match content_matcher.configure_interation(&ct, contents_hashmap).await {
+            match content_matcher.configure_interaction(&ct, contents_hashmap).await {
               Ok((contents, plugin_config)) => {
                 if let Some(interaction) = contents.iter().find(|i| i.part_name == "request") {
                   self.request_contents = InteractionContents::from(&interaction);
@@ -599,7 +599,7 @@ mod tests {
   use pact_models::path_exp::DocPath;
   use pact_models::v4::message_parts::MessageContents;
 
-  use crate::builders::{MessageInteractionBuilder, SyncMessageInteractionBuilder};
+  use crate::builders::SyncMessageInteractionBuilder;
 
   #[test]
   fn supports_setting_metadata_values() {

--- a/rust/pact_consumer/src/builders/sync_message_builder.rs
+++ b/rust/pact_consumer/src/builders/sync_message_builder.rs
@@ -112,7 +112,12 @@ impl SyncMessageInteractionBuilder {
   /// # let mut builder = pact_consumer::builders::SyncMessageInteractionBuilder::new("test");
   /// builder.reference("asyncapi", "operationId", "createUser");
   /// ```
-  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+  pub fn reference<G: Into<String>, N: Into<String>, J: Into<Value>>(
+    &mut self,
+    group: G,
+    name: N,
+    value: J
+  ) -> &mut Self {
     if let Some(references) = self.references.as_mut() {
       match references.entry(group.into()) {
         std::collections::btree_map::Entry::Vacant(entry) => {

--- a/rust/pact_consumer/src/builders/sync_message_builder.rs
+++ b/rust/pact_consumer/src/builders/sync_message_builder.rs
@@ -1,10 +1,10 @@
 //! Builder for constructing synchronous message interactions
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use bytes::Bytes;
-use maplit::hashmap;
+use maplit::{btreemap, hashmap};
 #[cfg(feature = "plugins")] use pact_plugin_driver::catalogue_manager::find_content_matcher;
 #[cfg(feature = "plugins")] use pact_plugin_driver::content::ContentMatcher;
 #[cfg(feature = "plugins")] use pact_plugin_driver::plugin_models::PactPluginManifest;
@@ -40,7 +40,8 @@ pub struct SyncMessageInteractionBuilder {
   /// Response contents of the message. This will include the payloads as well as any metadata
   pub response_contents: Vec<InteractionContents>,
   #[allow(dead_code)] contents_plugin: Option<PactPluginManifest>,
-  #[allow(dead_code)] plugin_config: HashMap<String, PluginConfiguration>
+  #[allow(dead_code)] plugin_config: HashMap<String, PluginConfiguration>,
+  references: Option<BTreeMap<String, BTreeMap<String, Value>>>
 }
 
 impl SyncMessageInteractionBuilder {
@@ -56,7 +57,8 @@ impl SyncMessageInteractionBuilder {
       request_contents: Default::default(),
       response_contents: vec![],
       contents_plugin: None,
-      plugin_config: Default::default()
+      plugin_config: Default::default(),
+      references: None
     }
   }
 
@@ -100,6 +102,33 @@ impl SyncMessageInteractionBuilder {
   /// page, and potentially in the test output.
   pub fn test_name<G: Into<String>>(&mut self, name: G) -> &mut Self {
     self.test_name = Some(name.into());
+    self
+  }
+
+  /// Sets an external reference for the interaction.  The reference will be stored in the Pact
+  /// file comments under the group. For instance, you could store the AsyncAPI operation ID that
+  /// the interaction corresponds to as an external reference.
+  /// ```
+  /// # let mut builder = pact_consumer::builders::MessageInteractionBuilder::new("test");
+  /// builder.reference("asyncapi", "operationId", "createUser");
+  ///
+  pub fn reference<G: Into<String>, J: Into<Value>>(&mut self, group: G, name: G, value: J) -> &mut Self {
+    if let Some(references) = self.references.as_mut() {
+      match references.entry(group.into()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+          entry.insert(btreemap! { name.into() => value.into() });
+        }
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+          entry.get_mut().insert(name.into(), value.into());
+        }
+      }
+    } else {
+      self.references = Some(btreemap!{
+        group.into() => btreemap!{
+          name.into() => value.into()
+        }
+      });
+    }
     self
   }
 
@@ -155,6 +184,16 @@ impl SyncMessageInteractionBuilder {
       };
     }
 
+    let mut comments = hashmap! {
+      "text".to_string() => json!(self.comments),
+      "testname".to_string() => json!(self.test_name)
+    };
+    if let Some(references) = &self.references {
+      comments.insert("references".to_string(), references.iter()
+        .map(|(k, v)| (k.clone(), json!(v)))
+        .collect());
+    }
+
     SynchronousMessage {
       id: None,
       key: self.key.clone(),
@@ -179,10 +218,7 @@ impl SyncMessageInteractionBuilder {
           generators: self.request_contents.generators.as_ref().cloned().unwrap_or_default()
         }
       }).collect(),
-      comments: hashmap!{
-        "text".to_string() => json!(self.comments),
-        "testname".to_string() => json!(self.test_name)
-      },
+      comments,
       pending: self.pending.unwrap_or(false),
       plugin_config,
       interaction_markup,
@@ -555,14 +591,15 @@ impl SyncMessageInteractionBuilder {
 mod tests {
   use expectest::prelude::*;
   use maplit::hashmap;
-  use serde_json::json;
+  use proclaim_it::assert_that;
+  use serde_json::{json, Value};
 
   use pact_models::matchingrules;
   use pact_models::matchingrules::{Category, MatchingRule, MatchingRules, RuleLogic};
   use pact_models::path_exp::DocPath;
   use pact_models::v4::message_parts::MessageContents;
 
-  use crate::builders::SyncMessageInteractionBuilder;
+  use crate::builders::{MessageInteractionBuilder, SyncMessageInteractionBuilder};
 
   #[test]
   fn supports_setting_metadata_values() {
@@ -661,7 +698,7 @@ mod tests {
   }
 
   #[test]
-  fn supports_mutliple_response_contents_with_metadata_rules() {
+  fn supports_multiple_response_contents_with_metadata_rules() {
     let rules1 = meta_matching_rules("$.a");
     let contents1 = message_contents(&rules1);
     let rules2 = meta_matching_rules("$.b");
@@ -693,5 +730,28 @@ mod tests {
     expect!(message.request.matching_rules).to(be_equal_to(rules.clone()));
     expect!(message.response.len()).to(be_equal_to(1));
     expect!(message.response[0].clone().matching_rules).to(be_equal_to(rules.clone()));
+  }
+
+  #[test]
+  fn supports_setting_external_references() {
+    let message = SyncMessageInteractionBuilder::new("test")
+      .reference("asyncapi", "operationId", "test")
+      .reference("openapi", "operationId", "test2")
+      .build();
+
+    assert_that! {
+      message.comments == hashmap! {
+        "references".to_string() => json!({
+            "asyncapi": {
+              "operationId": "test"
+            },
+            "openapi": {
+              "operationId": "test2"
+            }
+        }),
+        "text".to_string() => json!([]),
+        "testname".to_string() => Value::Null
+      }
+    }
   }
 }

--- a/rust/pact_consumer/tests/tests.rs
+++ b/rust/pact_consumer/tests/tests.rs
@@ -31,6 +31,7 @@ use pact_models::v4::synch_http::SynchronousHttp;
 /// This is supposed to be a doctest in mod, but it's breaking there, so
 /// we have an executable copy here.
 #[test_log::test(tokio::test)]
+#[ignore] // this sets an environment variable, which affects other tests
 async fn mock_server_passing_validation() -> anyhow::Result<()> {
     let output_dir = output_dir("target/pact_dir");
     unsafe { env::set_var("PACT_OUTPUT_DIR", &output_dir); }


### PR DESCRIPTION
This allows linking Pact message interactions to AsyncAPI operations