### PR TITLE
fix: ArrayContains variants must serialise as objects in values()

### DIFF
--- a/rust/pact_models/src/matchingrules/mod.rs
+++ b/rust/pact_models/src/matchingrules/mod.rs
@@ -302,9 +302,16 @@ impl MatchingRule {
       MatchingRule::ContentType(ct) => hashmap!{ "value" => Value::String(ct.clone()) },
       MatchingRule::ArrayContains(variants) => hashmap! { "variants" =>
         variants.iter().map(|(variant, rules, gens)| {
-          Value::Array(vec![json!(variant), rules.to_v3_json(), Value::Object(gens.iter().map(|(key, g)| {
-            (key.to_string(), g.to_json().unwrap())
-          }).collect())])
+          let mut v = json!({
+            "index": variant,
+            "rules": rules.to_v3_json()
+          });
+          if !gens.is_empty() {
+            v["generators"] = Value::Object(gens.iter().map(|(key, g)| {
+              (key.to_string(), g.to_json().unwrap())
+            }).collect());
+          }
+          v
         }).collect()
       },
       MatchingRule::Values => empty,
@@ -2844,5 +2851,23 @@ mod tests {
         MatchingRule::EachKey(MatchingRuleDefinition::new("another_key".to_string(), ValueType::Unknown, MatchingRule::Type, None, "".to_string()))
       ]}
     )
+  }
+
+  #[test]
+  fn array_contains_values_round_trip() {
+    // Regression test: MatchingRule::values() is used by pact-plugin-driver to encode
+    // matching rules over the gRPC plugin protocol. The variants must serialise in a
+    // form that MatchingRule::create() can deserialise — i.e. as objects with
+    // `index` / `rules` / `generators` keys, not as arrays.
+    let original = MatchingRule::ArrayContains(vec![
+      (0, matchingrules_list! { "body"; "$.foo" => [ MatchingRule::Equality ] }, HashMap::default()),
+      (1, matchingrules_list! { "body"; "$.bar" => [ MatchingRule::Type ] }, HashMap::default()),
+    ]);
+
+    let values = original.values();
+    let attributes = json!({ "variants": values["variants"].clone() });
+    let restored = MatchingRule::create("arrayContains", &attributes).unwrap();
+
+    expect!(restored).to(be_equal_to(original));
   }
 }


### PR DESCRIPTION
## Summary

`MatchingRule::values()` was serialising `ArrayContains` variants as 3-element arrays `[index, rules, generators]`, but the receiving side (`MatchingRule::create()` line 407) expects each variant as an object with `index` / `rules` / `generators` keys. The two ends of the round-trip disagreed on the format, so variants couldn't be reconstructed.

## Why this matters

`values()` is used by pact-plugin-driver to encode matching rules over the gRPC plugin protocol — see [content.rs#L349](https://github.com/pact-foundation/pact-plugins/blob/main/drivers/rust/driver/src/content.rs#L349):

```rust
values: Some(to_proto_struct(&rule.values().iter()...))
```

Plugins call back into the pact driver with matching rules they've constructed. With the bug, plugin-generated `ArrayContains` rules with anything beyond the default — particularly per-variant field rules for repeated message fields — were silently corrupted during the gRPC round-trip. The receiver fell back to a default equality rule at empty path, and the actual variant rules were lost.

This was found while integrating arrayContains into pact-protobuf-plugin. The reference form (`arrayContains(matching($'someMessage'))`) for repeated message fields produced corrupted matching rules in the generated pact file.

## Changes

- `rust/pact_models/src/matchingrules/mod.rs`: change `values()` to emit each variant as `{ "index": ..., "rules": ..., "generators": ... }` (matching what `create()` reads). Generators are only included when non-empty, matching the existing `to_json()` behaviour.
- Adds a round-trip regression test that constructs a `MatchingRule::ArrayContains` with two variants and verifies that `values()` → `create()` reproduces the original.

## Test plan

- [x] New regression test passes (`cargo test array_contains_values_round_trip`)
- [x] Confirmed the test fails without the fix (variants collapse to default equality at empty path — exact symptom seen in pact-protobuf-plugin)
- [x] Full pact_models test suite passes (613 tests, +1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)