### PR TITLE
fix(pact-ffi): pactffi_create_mock_server_for_transport is unable to start a TLS mock server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "regex-syntax",
  "reqwest 0.13.3",
  "rstest 0.26.1",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -59,6 +59,7 @@ pretty_assertions = "1.4.1"
 quickcheck = "1.0.3"
 reqwest = { version = "0.13.1", default-features = false, features = ["rustls", "blocking", "json", "multipart"] }
 rstest = "0.26.1"
+rustls = { version = "0.23", features = ["ring"] }
 test-log = "0.2.19"
 tempfile = "3.24.0"
 

--- a/rust/pact_ffi/src/mock_server/mod.rs
+++ b/rust/pact_ffi/src/mock_server/mod.rs
@@ -120,7 +120,7 @@ ffi_fn! {
   /// * `pact` - Handle to a Pact model created with created with `pactffi_new_pact`.
   /// * `addr` - Address to bind to (i.e. `127.0.0.1` or `[::1]`). Must be a valid UTF-8 NULL-terminated string, or NULL or empty, in which case the loopback adapter is used.
   /// * `port` - Port number to bind to. A value of zero will result in the operating system allocating an available port.
-  /// * `transport` - The transport to use (i.e. http, https, grpc). Must be a valid UTF-8 NULL-terminated string, or NULL or empty, in which case http will be used.
+  /// * `transport` - The transport to use (i.e. http, https, grpc). Must be a valid UTF-8 NULL-terminated string, or NULL or empty, in which case http will be used. Passing `https` will start a TLS-enabled server using a self-signed certificate; use `pactffi_get_tls_ca_certificate` to obtain the CA cert for client configuration.
   /// * `transport_config` - (OPTIONAL) Configuration for the transport as a valid JSON string. Set to NULL or empty if not required.
   ///
   /// The port of the mock server is returned.
@@ -181,12 +181,22 @@ ffi_fn! {
             .with_id(Uuid::new_v4().to_string())
             .bind_to(socket_addr.to_string());
 
-          let builder = match builder.with_transport(transport.as_str()) {
-            Ok(builder) => builder,
-            Err(err) => {
-              error!("Failed to configure mock server transport '{}' - {}", transport, err);
-              return -3;
-            }
+          let builder = match transport.as_str() {
+            "https" => match builder.with_self_signed_tls() {
+              Ok(builder) => builder,
+              Err(err) => {
+                error!("Failed to configure TLS for HTTPS mock server - {}", err);
+                return -3;
+              }
+            },
+            "http" => builder,
+            _ => match builder.with_transport(transport.as_str()) {
+              Ok(builder) => builder,
+              Err(err) => {
+                error!("Failed to configure mock server transport '{}' - {}", transport, err);
+                return -3;
+              }
+            },
           };
 
           match attach_to_manager(builder) {

--- a/rust/pact_ffi/tests/tests.rs
+++ b/rust/pact_ffi/tests/tests.rs
@@ -2557,3 +2557,53 @@ fn mime_multipart_with_json_and_image() {
 
   expect!(mismatches).to(be_equal_to("[]"));
 }
+
+#[test]
+#[allow(deprecated)]
+fn https_mock_server_starts_and_responds_over_tls() {
+  // Both ring (via pact_mock_server) and aws-lc-rs (via reqwest 0.13) are compiled into the test
+  // binary. Rustls panics if neither has been set as the process default, so install ring first.
+  rustls::crypto::ring::default_provider().install_default().ok();
+
+  let consumer_name = CString::new("https-consumer").unwrap();
+  let provider_name = CString::new("https-provider").unwrap();
+  let pact_handle = pactffi_new_pact(consumer_name.as_ptr(), provider_name.as_ptr());
+  let description = CString::new("an HTTPS request").unwrap();
+  let interaction = pactffi_new_interaction(pact_handle, description.as_ptr());
+  let method = CString::new("GET").unwrap();
+  let path = CString::new("/").unwrap();
+
+  pactffi_upon_receiving(interaction, description.as_ptr());
+  pactffi_with_request(interaction, method.as_ptr(), path.as_ptr());
+  pactffi_response_status(interaction, 200);
+
+  let address = CString::new("127.0.0.1").unwrap();
+  let transport = CString::new("https").unwrap();
+  let port = pactffi_create_mock_server_for_transport(
+    pact_handle, address.as_ptr(), 0, transport.as_ptr(), null()
+  );
+  expect!(port).to(be_greater_than(0));
+
+  let client = reqwest::blocking::Client::builder()
+    .danger_accept_invalid_certs(true)
+    .build()
+    .unwrap();
+  let result = client.get(format!("https://127.0.0.1:{}/", port)).send();
+
+  thread::sleep(Duration::from_millis(100));
+
+  let matched = pactffi_mock_server_matched(port);
+  let mismatches = unsafe {
+    CStr::from_ptr(pactffi_mock_server_mismatches(port)).to_string_lossy().into_owned()
+  };
+
+  pactffi_cleanup_mock_server(port);
+  pactffi_free_pact_handle(pact_handle);
+
+  match result {
+    Ok(res) => expect!(res.status()).to(be_eq(200)),
+    Err(err) => panic!("HTTPS request to mock server failed: {}", err),
+  };
+  expect!(matched).to(be_true());
+  expect!(mismatches).to(be_equal_to("[]"));
+}


### PR DESCRIPTION

# fix(pact_ffi): `pactffi_create_mock_server_for_transport` now starts a TLS server when transport is `"https"`

## Problem

Callers passing `"https"` to `pactffi_create_mock_server_for_transport` received a plain HTTP server, not an HTTPS one. The function's doc comment explicitly lists `https` as a supported transport value, so this was a silent regression against the documented contract.

## Root cause

The function forwarded every transport string — including `"http"` and `"https"` — directly to `MockServerBuilder::with_transport(...)`. That method looks up the transport in the plugin catalogue and stores a `CatalogueEntry` on the builder config. It has no effect on whether the underlying server uses TLS.

Whether TLS is used is decided later, in `ServerManager::spawn_http_mock_server`, which checks `builder.tls_configured()`. That flag is only set to `true` when one of the explicit TLS-configuration methods (`with_tls_config`, `with_tls_certs`, or `with_self_signed_tls`) has been called on the builder. Because the FFI path called none of them, `"https"` was silently treated as plain HTTP.

The older, now-deprecated FFI functions (`create_tls_mock_server*`, `start_tls_mock_server*`) worked correctly because they took an explicit `ServerConfig` and passed it straight through to the mock server. That explicit TLS branch was dropped when the replacement `pactffi_create_mock_server_for_transport` was introduced.

## Fix

Special-case the transport string in `pactffi_create_mock_server_for_transport` before dispatching to the builder:

| Transport | Behaviour |
|-----------|-----------|
| `"https"` | Calls `builder.with_self_signed_tls()` — sets `tls_config` on the builder, causing `spawn_http_mock_server` to call `start_https()` |
| `"http"` | Passes the builder through unchanged (HTTP is the default path) |
| anything else | Calls `builder.with_transport(...)` for plugin-provided transports (unchanged) |

The doc comment on the function has been updated to state that `"https"` starts a TLS server using a self-signed certificate, and points callers to `pactffi_get_tls_ca_certificate` for configuring their HTTP clients.

## Test

A new integration test `https_mock_server_starts_and_responds_over_tls` in `pact_ffi/tests/tests.rs`:

1. Builds a pact with a single `GET /` → 200 interaction via the handle API.
2. Starts the mock server with `transport = "https"` and port 0 (OS-assigned).
3. Sends an HTTPS GET request using a reqwest client configured with `danger_accept_invalid_certs(true)` (the self-signed cert is not trusted by the system CA store).
4. Asserts the response status is 200, `pactffi_mock_server_matched` returns true, and the mismatch list is empty.

### Note on crypto provider initialisation

The test binary links both the `ring` backend (via `pact_mock_server`) and the `aws-lc-rs` backend (via `reqwest 0.13`). When both are present, rustls panics at `ServerConfig::builder()` unless a process-level `CryptoProvider` has been explicitly installed. `MockServerBuilder::with_self_signed_tls` is missing the provider-installation guard that `with_tls_certs` already has, so the test installs the ring provider explicitly at startup:

```rust
rustls::crypto::ring::default_provider().install_default().ok();
```

`rustls` has been added to `pact_ffi`'s `[dev-dependencies]` with the `ring` feature for this purpose. This is a test-only dependency; it does not affect the shipped library. The missing guard in `with_self_signed_tls` should be reported as a bug upstream in `pact-core-mock-server`.

## Files changed

- `rust/pact_ffi/src/mock_server/mod.rs` — transport dispatch logic and doc update
- `rust/pact_ffi/tests/tests.rs` — new integration test
- `rust/pact_ffi/Cargo.toml` — `rustls` added to `[dev-dependencies]`
