### PR TITLE
chore: add crate name and version to all http clients

### DIFF
--- a/rust/pact_matching/src/metrics.rs
+++ b/rust/pact_matching/src/metrics.rs
@@ -190,7 +190,16 @@ pub async fn send_metrics_async(event: MetricEvent) {
           "ev" => value.as_str()                            // Value
           };
     debug!("Sending event to GA - {:?}", event_payload);
-    let result = Client::new().post(GA_URL)
+    let client = match Client::builder()
+      .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+      .build() {
+      Ok(c) => c,
+      Err(err) => {
+        debug!("Failed to build HTTP client: {}", err);
+        return;
+      }
+    };
+    let result = client.post(GA_URL)
       .form(&event_payload)
       .send()
       .await;

--- a/rust/pact_models/src/http_utils.rs
+++ b/rust/pact_models/src/http_utils.rs
@@ -30,7 +30,10 @@ impl HttpAuth {
 
 /// Fetches the JSON from a URL
 pub fn fetch_json_from_url(url: &String, auth: &Option<HttpAuth>) -> anyhow::Result<(String, Value)> {
-  let client = Client::new();
+  let client = Client::builder()
+    .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+    .build()
+    .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {}", e))?;
   let request = match auth {
     &Some(ref auth) => {
       match auth {

--- a/rust/pact_verifier/src/callback_executors.rs
+++ b/rust/pact_verifier/src/callback_executors.rs
@@ -2,13 +2,20 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Either;
 use maplit::*;
 use serde_json::{json, Value};
+
+static DEFAULT_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+  reqwest::Client::builder()
+    .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+    .build()
+    .expect("Failed to build default HTTP client")
+});
 
 use pact_models::bodies::OptionalBody;
 use pact_models::content_types::JSON;
@@ -153,7 +160,7 @@ impl ProviderStateExecutor for HttpRequestProviderStateExecutor {
           }
           state_change_request.query = Some(query);
         }
-        make_state_change_request(client.unwrap_or(&reqwest::Client::default()), &state_change_url, &state_change_request, self.retries).await
+        make_state_change_request(client.unwrap_or(&DEFAULT_CLIENT), &state_change_url, &state_change_request, self.retries).await
           .map_err(|err| ProviderStateError { description: err.to_string(), interaction_id }.into())
       },
       None => {

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -701,6 +701,7 @@ pub(crate) fn configure_http_client<F: RequestFilterExecutor>(
   options: &VerificationOptions<F>
 ) -> anyhow::Result<Client> {
   let mut client_builder = reqwest::Client::builder()
+    .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
     .danger_accept_invalid_certs(options.disable_ssl_verification)
     .timeout(Duration::from_millis(options.request_timeout));
 

--- a/rust/pact_verifier/src/pact_broker.rs
+++ b/rust/pact_verifier/src/pact_broker.rs
@@ -231,7 +231,7 @@ impl HALClientBuilder {
   pub fn build(&self) -> HALClient {
     HALClient {
       client: self.client.clone().unwrap_or_else(|| reqwest::ClientBuilder::new()
-        .user_agent(format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")))
+        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
         .tcp_keepalive(None)
         .build()
         .unwrap()),
@@ -603,7 +603,7 @@ impl Default for HALClient {
   fn default() -> Self {
     HALClient {
       client: reqwest::ClientBuilder::new()
-        .user_agent(format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")))
+        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
         .tcp_keepalive(None)
         .build()
         .unwrap(),
@@ -1316,7 +1316,7 @@ mod tests {
             .interaction("a request to the broker includes a user-agent", "", |mut i| {
                 i.request
                   .path("/user-agent")
-                  .header("user-agent", format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")));
+                  .header("user-agent", concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")));
 
                 i.response
                   .status(200)


### PR DESCRIPTION
To help identify traffic from the Pact ecosystem.

Also replaced the runtime `format!` call to a compile time `concat!`.