### PR TITLE
chore(pact_models): use neutral values in arrayContains expression tests

### DIFF
--- a/rust/pact_models/src/matchingrules/expressions.rs
+++ b/rust/pact_models/src/matchingrules/expressions.rs
@@ -2212,14 +2212,14 @@ mod test {
 
   #[test]
   fn is_matcher_def_array_contains() {
-    assert!(is_matcher_def("arrayContains(matching(equalTo, 'PUBLIC'))"));
+    assert!(is_matcher_def("arrayContains(matching(equalTo, 'HARDCOVER'))"));
     assert!(is_matcher_def("arrayContains(matching(equalTo, 'A'), matching(equalTo, 'B'))"));
     assert!(!is_matcher_def("notArrayContains"));
   }
 
   #[test]
   fn parse_array_contains_single_variant() {
-    let result = parse_matcher_def("arrayContains(matching(equalTo, 'PUBLIC'))").unwrap();
+    let result = parse_matcher_def("arrayContains(matching(equalTo, 'HARDCOVER'))").unwrap();
     assert_eq!(result.rules.len(), 1);
     match &result.rules[0] {
       Either::Left(MatchingRule::ArrayContains(variants)) => {
@@ -2232,12 +2232,12 @@ mod test {
       }
       _ => panic!("Expected ArrayContains rule, got {:?}", result.rules[0]),
     }
-    assert_eq!(result.value, "PUBLIC");
+    assert_eq!(result.value, "HARDCOVER");
   }
 
   #[test]
   fn parse_array_contains_multi_variant() {
-    let result = parse_matcher_def("arrayContains(matching(equalTo, 'PUBLIC'), matching(equalTo, 'PRIVATE_LINK'))").unwrap();
+    let result = parse_matcher_def("arrayContains(matching(equalTo, 'HARDCOVER'), matching(equalTo, 'PAPERBACK'))").unwrap();
     assert_eq!(result.rules.len(), 1);
     match &result.rules[0] {
       Either::Left(MatchingRule::ArrayContains(variants)) => {
@@ -2247,7 +2247,7 @@ mod test {
       }
       _ => panic!("Expected ArrayContains rule"),
     }
-    assert_eq!(result.value, "PUBLIC");
+    assert_eq!(result.value, "HARDCOVER");
   }
 
   #[test]
@@ -2277,20 +2277,20 @@ mod test {
 
   #[test]
   fn parse_array_contains_with_regex() {
-    let result = parse_matcher_def("arrayContains(matching(regex, 'PUBLIC|PRIVATE.*', 'PUBLIC'))").unwrap();
+    let result = parse_matcher_def("arrayContains(matching(regex, 'HARDCOVER|PAPER.*', 'HARDCOVER'))").unwrap();
     assert_eq!(result.rules.len(), 1);
     match &result.rules[0] {
       Either::Left(MatchingRule::ArrayContains(variants)) => {
         assert_eq!(variants.len(), 1);
         let rule_list = variants[0].1.rules.get(&DocPath::root()).unwrap();
         match &rule_list.rules[0] {
-          MatchingRule::Regex(re) => assert_eq!(re, "PUBLIC|PRIVATE.*"),
+          MatchingRule::Regex(re) => assert_eq!(re, "HARDCOVER|PAPER.*"),
           other => panic!("Expected Regex, got {:?}", other),
         }
       }
       _ => panic!("Expected ArrayContains"),
     }
-    assert_eq!(result.value, "PUBLIC");
+    assert_eq!(result.value, "HARDCOVER");
   }
 
   #[test]
@@ -2301,14 +2301,14 @@ mod test {
 
   #[test]
   fn parse_array_contains_combined_with_at_least() {
-    let result = parse_matcher_def("atLeast(2), arrayContains(matching(equalTo, 'PUBLIC'))").unwrap();
+    let result = parse_matcher_def("atLeast(2), arrayContains(matching(equalTo, 'HARDCOVER'))").unwrap();
     assert!(result.rules.iter().any(|r| matches!(r, Either::Left(MatchingRule::MinType(2)))));
     assert!(result.rules.iter().any(|r| matches!(r, Either::Left(MatchingRule::ArrayContains(_)))));
   }
 
   #[test]
   fn parse_array_contains_combined_with_each_value() {
-    let result = parse_matcher_def("eachValue(matching(type, 'X')), arrayContains(matching(equalTo, 'PUBLIC'))").unwrap();
+    let result = parse_matcher_def("eachValue(matching(type, 'X')), arrayContains(matching(equalTo, 'HARDCOVER'))").unwrap();
     assert!(result.rules.iter().any(|r| matches!(r, Either::Left(MatchingRule::EachValue(_)))));
     assert!(result.rules.iter().any(|r| matches!(r, Either::Left(MatchingRule::ArrayContains(_)))));
   }


### PR DESCRIPTION
> **Authorship disclosure: this is AI-generated.** The investigation, the code, the tests, and this description were all produced by an AI agent (Claude Opus) operating on behalf of @stan-is-hate. Please review with that in mind.

The `arrayContains` tests I added in #523 used string constants taken straight from my employer's product domain. They carry no meaning in this crate and shouldn't have gone upstream.

Swapped for neutral book-format values throughout `rust/pact_models/src/matchingrules/expressions.rs` (exact before/after in the diff): the two `equalTo` sample values become `'HARDCOVER'` and `'PAPERBACK'`, and the regex test uses the pattern `'HARDCOVER|PAPER.*'`.

**Test data only** — assertions, coverage and parser behaviour are unchanged.

Note these strings are already published in `pact_models` 1.3.10 and 1.3.11, so this only cleans things up going forward. No urgency from my side.

## Verification

`cargo test --lib matchingrules::expressions` — 63 passed, 0 failed.