### PR TITLE
feat(plugins): Register the standard matching rules and generators as core plugin capabilities

### DIFF
--- a/rust/pact_matching/src/core_capabilities.rs
+++ b/rust/pact_matching/src/core_capabilities.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 
 use pact_models::bodies::OptionalBody;
 use pact_models::content_types::{ContentType, ContentTypeHint};
-use pact_models::generators::{Generator, GeneratorTestMode};
+use pact_models::generators::{GenerateValue, Generator, GeneratorTestMode, VariantMatcher};
 use pact_models::matchingrules::{Category, MatchingRule, MatchingRuleCategory, RuleLogic};
 use pact_models::path_exp::DocPath;
 use pact_models::plugins::{PluginSupport, set_plugin_support};
@@ -29,8 +29,12 @@ use pact_models::v4::http_parts::HttpResponse;
 use pact_plugin_driver::core_capabilities::{
   CoreContentGenerator,
   CoreContentMatcher,
+  CoreFieldGenerator,
+  CoreFieldMatcher,
   register_core_content_generator,
-  register_core_content_matcher
+  register_core_content_matcher,
+  register_core_field_generator,
+  register_core_field_matcher
 };
 use pact_plugin_driver::field::{
   FieldContext,
@@ -38,6 +42,14 @@ use pact_plugin_driver::field::{
   find_field_generator,
   find_field_matcher,
   TestMode as FieldTestMode
+};
+use pact_plugin_driver::proto_v2::{
+  ContentMismatch as FieldContentMismatch,
+  GenerateFieldRequest,
+  GenerateFieldResponse,
+  generate_content_request::TestMode as ProtoTestMode,
+  MatchFieldRequest,
+  MatchFieldResponse
 };
 use pact_plugin_driver::proto::{
   body,
@@ -53,6 +65,7 @@ use pact_plugin_driver::proto::{
 use pact_plugin_driver::utils::proto_struct_to_json;
 
 use crate::{CoreMatchingContext, DiffConfig, Mismatch};
+use crate::matchingrules::DoMatch;
 use crate::generators::DefaultVariantMatcher;
 use crate::generators::bodies::generators_process_body;
 
@@ -233,6 +246,270 @@ impl CoreContentGenerator for BinaryCoreContentGenerator {
   }
 }
 
+/// The matching rules this crate can apply to a single value, and so registers a field-level
+/// handler for. Every other rule it implements is collection-wide (see [`COLLECTION_RULES`]).
+const FIELD_RULES: [&str; 16] = ["equality", "regex", "type", "include", "number", "integer",
+  "decimal", "boolean", "null", "date", "time", "datetime", "content-type", "not-empty", "semver",
+  "status-code"];
+
+/// The matching rules that decide *which* values they apply to, and so can not be handed one value
+/// at a time - see proposal 006's non-goals. They get a handler anyway, so a plugin naming one is
+/// told why it can not have it rather than being told nothing is registered.
+const COLLECTION_RULES: [&str; 7] = ["min-type", "max-type", "min-max-type", "values",
+  "array-contains", "each-key", "each-value"];
+
+/// The generators this crate can apply to a single value. `ProviderState` and `MockServerURL` are
+/// included: both read host state, but it reaches them through the request's test context, which
+/// is what proposal 006 requires of any generator.
+const FIELD_GENERATORS: [&str; 12] = ["RandomInt", "RandomDecimal", "RandomHexadecimal",
+  "RandomString", "RandomBoolean", "Regex", "Uuid", "Date", "Time", "DateTime", "ProviderState",
+  "MockServerURL"];
+
+/// Generators that build a value inside a structure their caller owns, so there is no single value
+/// to generate. See [`COLLECTION_RULES`].
+const COLLECTION_GENERATORS: [&str; 1] = ["ArrayContains"];
+
+/// Rule and generator configuration crosses the plugin interface as a `google.protobuf.Struct`,
+/// which has one number type - a double - so a `min` of 2 arrives as `2.0`. `pact_models` reads
+/// those attributes with `as_i64`/`as_u64`, which reject a float, and silently falls back to the
+/// attribute's default: a `RandomInt(5, 5)` from a plugin would generate from `0..10` instead.
+/// Whole floats are put back to integers here, on the way in, so a configuration value means what
+/// the plugin sent.
+///
+/// This is the configuration-value counterpart of what `FieldValue`'s per-type arms do for the
+/// value being matched, which does not go through a `Struct` for exactly this reason.
+fn whole_floats_to_integers(value: serde_json::Value) -> serde_json::Value {
+  match value {
+    serde_json::Value::Number(number) => match number.as_f64() {
+      Some(float) if float.fract() == 0.0 && !number.is_i64() && !number.is_u64() =>
+        serde_json::Value::Number((float as i64).into()),
+      _ => serde_json::Value::Number(number)
+    },
+    serde_json::Value::Array(values) => serde_json::Value::Array(
+      values.into_iter().map(whole_floats_to_integers).collect()
+    ),
+    serde_json::Value::Object(values) => serde_json::Value::Object(
+      values.into_iter().map(|(k, v)| (k, whole_floats_to_integers(v))).collect()
+    ),
+    value => value
+  }
+}
+
+/// The rule named by a field-level request: the rule it carries, or - if it carries none - the
+/// catalogue key it was dispatched under, so `host_match_field("not-empty", ...)` works without
+/// having to restate the rule.
+fn rule_from_request(request: &MatchFieldRequest) -> anyhow::Result<MatchingRule> {
+  let name = request.rule.as_ref()
+    .map(|rule| rule.r#type.clone())
+    .filter(|name| !name.is_empty())
+    .unwrap_or_else(|| request.key.clone());
+  let values = request.rule.as_ref()
+    .and_then(|rule| rule.values.as_ref())
+    .map(proto_struct_to_json)
+    .map(whole_floats_to_integers)
+    .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+
+  let rule = MatchingRule::create(name.as_str(), &values)
+    .map_err(|err| anyhow!("'{}' is not a valid matching rule - {}", name, err))?;
+  // An unrecognised name parses into a plugin rule, which would send the call straight back out to
+  // a plugin. A core handler answers for core rules only.
+  if let MatchingRule::Plugin { .. } = rule {
+    return Err(anyhow!("'{}' is not one of the matching rules provided by this framework", name));
+  }
+  Ok(rule)
+}
+
+/// The generator named by a field-level request. See [`rule_from_request`].
+fn generator_from_request(request: &GenerateFieldRequest) -> anyhow::Result<Generator> {
+  let name = request.generator.as_ref()
+    .map(|generator| generator.r#type.clone())
+    .filter(|name| !name.is_empty())
+    .unwrap_or_else(|| request.key.clone());
+  let values = request.generator.as_ref()
+    .and_then(|generator| generator.values.as_ref())
+    .map(proto_struct_to_json)
+    .map(whole_floats_to_integers)
+    .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+  let values = values.as_object().cloned().unwrap_or_default();
+
+  match Generator::from_map(name.as_str(), &values) {
+    Some(Generator::Plugin { .. }) | None =>
+      Err(anyhow!("'{}' is not one of the generators provided by this framework", name)),
+    Some(generator) => Ok(generator)
+  }
+}
+
+/// Apply a matching rule to one value, picking the comparison for the types the two sides actually
+/// have. Binary values are compared as bytes rather than being stringified, which is the whole
+/// reason `FieldValue` has a binary arm.
+fn apply_field_rule(
+  rule: &MatchingRule,
+  expected: &FieldValue,
+  actual: &FieldValue
+) -> anyhow::Result<()> {
+  match (expected, actual) {
+    (FieldValue::Json(expected), FieldValue::Json(actual)) =>
+      rule.match_value(expected, actual, false, true),
+    (FieldValue::Binary(expected), FieldValue::Binary(actual)) =>
+      rule.match_value(expected, actual, false, true),
+    // Text on one side and bytes on the other is a legitimate pairing (a plugin that decoded one
+    // of them), so compare as bytes rather than refusing
+    (FieldValue::Json(serde_json::Value::String(expected)), FieldValue::Binary(actual)) =>
+      rule.match_value(&Bytes::from(expected.clone().into_bytes()), actual, false, true),
+    (FieldValue::Binary(expected), FieldValue::Json(serde_json::Value::String(actual))) =>
+      rule.match_value(expected, &Bytes::from(actual.clone().into_bytes()), false, true),
+    (expected, actual) => Err(anyhow!("Can not apply the '{}' matching rule to {} against {}",
+      rule.name(), describe_field_value(expected), describe_field_value(actual)))
+  }
+}
+
+fn describe_field_value(value: &FieldValue) -> String {
+  match value {
+    FieldValue::Json(value) => format!("a JSON value ({})", value),
+    FieldValue::Binary(bytes) => format!("{} bytes of binary data", bytes.len())
+  }
+}
+
+/// The bytes a mismatch reports for a value. `ContentMismatch` carries bytes so that a binary value
+/// survives being reported, which means a JSON value has to be rendered into some form here.
+fn field_value_bytes(value: &FieldValue) -> Vec<u8> {
+  match value {
+    FieldValue::Json(serde_json::Value::String(value)) => value.clone().into_bytes(),
+    FieldValue::Json(value) => value.to_string().into_bytes(),
+    FieldValue::Binary(bytes) => bytes.to_vec()
+  }
+}
+
+/// Applies one of this crate's standard matching rules to a single value, on behalf of a plugin
+/// that does not want to reimplement it (proposal 009). Registered against every key in
+/// [`FIELD_RULES`] - the rule to apply comes from the request, so one handler serves them all.
+#[derive(Debug)]
+struct CoreFieldRuleMatcher;
+
+#[async_trait]
+impl CoreFieldMatcher for CoreFieldRuleMatcher {
+  async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse> {
+    let rule = match rule_from_request(&request) {
+      Ok(rule) => rule,
+      Err(err) => return Ok(MatchFieldResponse { error: err.to_string(), mismatches: vec![] })
+    };
+    let expected = request.expected.as_ref()
+      .map(FieldValue::from_proto)
+      .unwrap_or(FieldValue::Json(serde_json::Value::Null));
+    let actual = request.actual.as_ref()
+      .map(FieldValue::from_proto)
+      .unwrap_or(FieldValue::Json(serde_json::Value::Null));
+
+    debug!(path = request.path.as_str(), "Applying the core '{}' matching rule to a single value",
+      rule.name());
+    match apply_field_rule(&rule, &expected, &actual) {
+      Ok(()) => Ok(MatchFieldResponse::default()),
+      Err(err) => Ok(MatchFieldResponse {
+        error: String::default(),
+        mismatches: vec![FieldContentMismatch {
+          expected: Some(field_value_bytes(&expected)),
+          actual: Some(field_value_bytes(&actual)),
+          mismatch: err.to_string(),
+          path: request.path.clone(),
+          diff: String::default(),
+          mismatch_type: request.mismatch_type.clone()
+        }]
+      })
+    }
+  }
+}
+
+/// Answers for the collection-wide rules: they are real capabilities this framework has, so they
+/// are in the catalogue, but the matching engine has to interpret them itself to know which values
+/// they cover. See [`COLLECTION_RULES`].
+#[derive(Debug)]
+struct CollectionRuleMatcher;
+
+#[async_trait]
+impl CoreFieldMatcher for CollectionRuleMatcher {
+  async fn match_field(&self, request: MatchFieldRequest) -> anyhow::Result<MatchFieldResponse> {
+    Ok(MatchFieldResponse {
+      error: format!("The '{}' matching rule applies to a collection as a whole, not to a single \
+        value, so it can not be applied through MatchField. Match the collection with a content \
+        matcher instead.", request.key),
+      mismatches: vec![]
+    })
+  }
+}
+
+/// Applies one of this crate's standard generators to a single value, on behalf of a plugin
+/// (proposal 009). Registered against every key in [`FIELD_GENERATORS`].
+#[derive(Debug)]
+struct CoreFieldValueGenerator;
+
+#[async_trait]
+impl CoreFieldGenerator for CoreFieldValueGenerator {
+  async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse> {
+    let generator = match generator_from_request(&request) {
+      Ok(generator) => generator,
+      Err(err) => return Ok(GenerateFieldResponse { error: err.to_string(), value: None })
+    };
+    let example = request.example_value.as_ref()
+      .map(FieldValue::from_proto)
+      .unwrap_or(FieldValue::Json(serde_json::Value::Null));
+    let mode = match ProtoTestMode::try_from(request.test_mode) {
+      Ok(ProtoTestMode::Consumer) => GeneratorTestMode::Consumer,
+      _ => GeneratorTestMode::Provider
+    };
+
+    // A generator that does not apply on this side of the test leaves the example value alone,
+    // the same as it would when applied to a body
+    if !generator.corresponds_to_mode(&mode) {
+      return Ok(GenerateFieldResponse { error: String::default(), value: Some(example.to_proto()) });
+    }
+
+    let context_values = request.test_context.as_ref()
+      .map(proto_struct_to_json)
+      .and_then(|value| value.as_object().cloned())
+      .unwrap_or_default();
+    let context: HashMap<&str, serde_json::Value> = context_values.iter()
+      .map(|(key, value)| (key.as_str(), value.clone()))
+      .collect();
+
+    debug!(path = request.path.as_str(), "Applying the core '{}' generator to a single value",
+      generator.name());
+    let generated = match &example {
+      FieldValue::Json(value) => generator
+        .generate_value(value, &context, &DefaultVariantMatcher.boxed())
+        .map(FieldValue::Json),
+      // A generator produces a JSON-ish value, so binary is only usable here if it is text
+      FieldValue::Binary(bytes) => match std::str::from_utf8(bytes.as_ref()) {
+        Ok(text) => generator
+          .generate_value(&text.to_string(), &context, &DefaultVariantMatcher.boxed())
+          .map(|generated| FieldValue::Binary(Bytes::from(generated.into_bytes()))),
+        Err(err) => Err(anyhow!("Can not apply the '{}' generator to {} bytes of binary data - {}",
+          generator.name(), bytes.len(), err))
+      }
+    };
+
+    match generated {
+      Ok(value) => Ok(GenerateFieldResponse { error: String::default(), value: Some(value.to_proto()) }),
+      Err(err) => Ok(GenerateFieldResponse { error: err.to_string(), value: None })
+    }
+  }
+}
+
+/// Answers for generators that build values inside a structure their caller owns. See
+/// [`CollectionRuleMatcher`].
+#[derive(Debug)]
+struct CollectionValueGenerator;
+
+#[async_trait]
+impl CoreFieldGenerator for CollectionValueGenerator {
+  async fn generate_field(&self, request: GenerateFieldRequest) -> anyhow::Result<GenerateFieldResponse> {
+    Ok(GenerateFieldResponse {
+      error: format!("The '{}' generator generates values within a collection, not a single value, \
+        so it can not be applied through GenerateField.", request.key),
+      value: None
+    })
+  }
+}
+
 /// Resolves plugin-provided matching rules and generators on behalf of `pact_models`, which has no
 /// visibility of the plugin catalogue - the driver depends on it, not the other way around. See
 /// [`pact_models::plugins::PluginSupport`].
@@ -297,4 +574,299 @@ pub(crate) fn register_core_capabilities() {
 
   register_core_content_generator("json", Arc::new(JsonCoreContentGenerator));
   register_core_content_generator("binary", Arc::new(BinaryCoreContentGenerator));
+
+  for rule in FIELD_RULES {
+    register_core_field_matcher(rule, Arc::new(CoreFieldRuleMatcher));
+  }
+  for rule in COLLECTION_RULES {
+    register_core_field_matcher(rule, Arc::new(CollectionRuleMatcher));
+  }
+
+  for generator in FIELD_GENERATORS {
+    register_core_field_generator(generator, Arc::new(CoreFieldValueGenerator));
+  }
+  for generator in COLLECTION_GENERATORS {
+    register_core_field_generator(generator, Arc::new(CollectionValueGenerator));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashSet;
+
+  use expectest::prelude::*;
+  use pact_plugin_driver::proto_v2::{Generator as ProtoGenerator, MatchingRule as ProtoMatchingRule};
+  use pact_plugin_driver::utils::to_proto_struct;
+  use serde_json::json;
+
+  use super::*;
+
+  fn match_request(key: &str, rule: Option<ProtoMatchingRule>, expected: FieldValue, actual: FieldValue) -> MatchFieldRequest {
+    MatchFieldRequest {
+      key: key.to_string(),
+      rule,
+      path: "$.one".to_string(),
+      mismatch_type: "body".to_string(),
+      expected: Some(expected.to_proto()),
+      actual: Some(actual.to_proto()),
+      .. MatchFieldRequest::default()
+    }
+  }
+
+  fn proto_rule(name: &str, values: serde_json::Value) -> ProtoMatchingRule {
+    ProtoMatchingRule {
+      r#type: name.to_string(),
+      values: Some(to_proto_struct(&values.as_object().unwrap().iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()))
+    }
+  }
+
+  #[tokio::test]
+  async fn applies_a_core_rule_to_a_single_value() {
+    let request = match_request("regex", Some(proto_rule("regex", json!({ "regex": "\\d+" }))),
+      FieldValue::Json(json!("100")), FieldValue::Json(json!("200")));
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error).to(be_equal_to(String::default()));
+    expect!(response.mismatches.iter()).to(be_empty());
+  }
+
+  #[tokio::test]
+  async fn reports_a_mismatch_against_the_path_from_the_request() {
+    let request = match_request("regex", Some(proto_rule("regex", json!({ "regex": "\\d+" }))),
+      FieldValue::Json(json!("100")), FieldValue::Json(json!("not a number")));
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error).to(be_equal_to(String::default()));
+    expect!(response.mismatches.len()).to(be_equal_to(1));
+    let mismatch = &response.mismatches[0];
+    expect!(mismatch.path.as_str()).to(be_equal_to("$.one"));
+    expect!(mismatch.mismatch_type.as_str()).to(be_equal_to("body"));
+    expect!(mismatch.actual.clone().unwrap()).to(be_equal_to("not a number".as_bytes().to_vec()));
+    expect!(mismatch.mismatch.contains("to match")).to(be_true());
+  }
+
+  /// The distinction FieldValue's per-type arms exist for: an integer actual against a decimal
+  /// expected is a type mismatch, and would not be if both arrived as a JSON number
+  #[tokio::test]
+  async fn keeps_the_numeric_type_of_a_value() {
+    let integer = CoreFieldRuleMatcher.match_field(match_request("integer",
+      Some(proto_rule("integer", json!({}))), FieldValue::Json(json!(100)), FieldValue::Json(json!(200))))
+      .await.unwrap();
+    let decimal = CoreFieldRuleMatcher.match_field(match_request("decimal",
+      Some(proto_rule("decimal", json!({}))), FieldValue::Json(json!(100.0)), FieldValue::Json(json!(200))))
+      .await.unwrap();
+
+    expect!(integer.mismatches.iter()).to(be_empty());
+    expect!(decimal.mismatches.len()).to(be_equal_to(1));
+  }
+
+  #[tokio::test]
+  async fn falls_back_to_the_catalogue_key_when_the_request_carries_no_rule() {
+    let request = match_request("not-empty", None,
+      FieldValue::Json(json!("a")), FieldValue::Json(json!("")));
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error).to(be_equal_to(String::default()));
+    expect!(response.mismatches.len()).to(be_equal_to(1));
+  }
+
+  #[tokio::test]
+  async fn compares_a_binary_value_as_bytes() {
+    let expected = FieldValue::Binary(Bytes::from_static(&[0x00, 0xfe, 0x01]));
+    let actual = FieldValue::Binary(Bytes::from_static(&[0x00, 0xfe, 0x02]));
+    let request = match_request("equality", Some(proto_rule("equality", json!({}))),
+      expected, actual);
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.mismatches.len()).to(be_equal_to(1));
+    expect!(response.mismatches[0].actual.clone().unwrap()).to(be_equal_to(vec![0x00, 0xfe, 0x02]));
+  }
+
+  #[tokio::test]
+  async fn a_rule_this_framework_does_not_provide_is_an_error_not_a_call_back_out_to_a_plugin() {
+    let request = match_request("type", Some(proto_rule("creditcard", json!({ "brand": "visa" }))),
+      FieldValue::Json(json!("4111111111111111")), FieldValue::Json(json!("4111111111111111")));
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error.contains("'creditcard' is not one of the matching rules provided by this framework"))
+      .to(be_true());
+    expect!(response.mismatches.iter()).to(be_empty());
+  }
+
+  #[tokio::test]
+  async fn a_malformed_rule_is_reported_as_an_error() {
+    let request = match_request("regex", Some(proto_rule("regex", json!({}))),
+      FieldValue::Json(json!("100")), FieldValue::Json(json!("200")));
+
+    let response = CoreFieldRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error.contains("is not a valid matching rule")).to(be_true());
+  }
+
+  #[tokio::test]
+  async fn a_collection_wide_rule_says_why_it_can_not_be_applied() {
+    let request = match_request("each-value", None,
+      FieldValue::Json(json!(["a"])), FieldValue::Json(json!(["b"])));
+
+    let response = CollectionRuleMatcher.match_field(request).await.unwrap();
+
+    expect!(response.error.contains("applies to a collection as a whole")).to(be_true());
+    expect!(response.mismatches.iter()).to(be_empty());
+  }
+
+  fn generate_request(key: &str, generator: Option<ProtoGenerator>, example: FieldValue, mode: ProtoTestMode) -> GenerateFieldRequest {
+    GenerateFieldRequest {
+      key: key.to_string(),
+      generator,
+      path: "$.one".to_string(),
+      example_value: Some(example.to_proto()),
+      test_mode: mode as i32,
+      .. GenerateFieldRequest::default()
+    }
+  }
+
+  fn proto_generator(name: &str, values: serde_json::Value) -> ProtoGenerator {
+    ProtoGenerator {
+      r#type: name.to_string(),
+      values: Some(to_proto_struct(&values.as_object().unwrap().iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()))
+    }
+  }
+
+  #[tokio::test]
+  async fn generates_a_single_value() {
+    let request = generate_request("RandomInt",
+      Some(proto_generator("RandomInt", json!({ "min": 5, "max": 5 }))),
+      FieldValue::Json(json!(0)), ProtoTestMode::Consumer);
+
+    let response = CoreFieldValueGenerator.generate_field(request).await.unwrap();
+
+    expect!(response.error).to(be_equal_to(String::default()));
+    expect!(FieldValue::from_proto(&response.value.unwrap())).to(be_equal_to(FieldValue::Json(json!(5))));
+  }
+
+  #[tokio::test]
+  async fn a_generator_for_the_other_side_of_the_test_leaves_the_example_value_alone() {
+    // MockServerURL only applies on the consumer side
+    let request = generate_request("MockServerURL",
+      Some(proto_generator("MockServerURL", json!({ "example": "http://localhost:1234/a", "regex": ".*(/a)" }))),
+      FieldValue::Json(json!("http://localhost:1234/a")), ProtoTestMode::Provider);
+
+    let response = CoreFieldValueGenerator.generate_field(request).await.unwrap();
+
+    expect!(response.error).to(be_equal_to(String::default()));
+    expect!(FieldValue::from_proto(&response.value.unwrap()))
+      .to(be_equal_to(FieldValue::Json(json!("http://localhost:1234/a"))));
+  }
+
+  #[tokio::test]
+  async fn a_generator_this_framework_does_not_provide_is_an_error() {
+    let request = generate_request("Uuid", Some(proto_generator("creditcard", json!({ "brand": "visa" }))),
+      FieldValue::Json(json!("4111111111111111")), ProtoTestMode::Consumer);
+
+    let response = CoreFieldValueGenerator.generate_field(request).await.unwrap();
+
+    expect!(response.error.contains("'creditcard' is not one of the generators provided by this framework"))
+      .to(be_true());
+    expect!(response.value).to(be_none());
+  }
+
+  #[tokio::test]
+  async fn a_collection_generator_says_why_it_can_not_be_applied() {
+    let request = generate_request("ArrayContains", None, FieldValue::Json(json!([])), ProtoTestMode::Consumer);
+
+    let response = CollectionValueGenerator.generate_field(request).await.unwrap();
+
+    expect!(response.error.contains("generates values within a collection")).to(be_true());
+  }
+
+  /// A `Struct` has one number type, so every whole number a plugin sends as configuration arrives
+  /// as a float. Fractional values are left alone - a `2.5` was meant to be a decimal.
+  #[test]
+  fn puts_whole_numbers_from_a_proto_struct_back_to_integers() {
+    let normalised = whole_floats_to_integers(json!({
+      "min": 2.0,
+      "max": -3.0,
+      "ratio": 2.5,
+      "nested": { "size": 8.0 },
+      "list": [1.0, 1.5],
+      "text": "2.0"
+    }));
+
+    expect!(normalised).to(be_equal_to(json!({
+      "min": 2,
+      "max": -3,
+      "ratio": 2.5,
+      "nested": { "size": 8 },
+      "list": [1, 1.5],
+      "text": "2.0"
+    })));
+  }
+
+  /// End to end through the driver: the catalogue entry `configure_core_catalogue` registers, the
+  /// resolver a plugin's callback goes through, and the handler registered under that key. A key
+  /// registered on one side but not the other would only show up here.
+  #[tokio::test]
+  async fn a_plugin_callback_for_a_core_rule_reaches_the_registered_handler() {
+    crate::matchingrules::configure_core_catalogue();
+
+    let matcher = pact_plugin_driver::field::find_field_matcher("type")
+      .expect("expected the core 'type' rule to resolve");
+    let context = FieldContext::new(&DocPath::new_unwrap("$.one"), "body");
+    let matched = matcher.match_field(&MatchingRule::Type, &FieldValue::Json(json!("a")),
+      &FieldValue::Json(json!("b")), &context).await;
+    let mismatched = matcher.match_field(&MatchingRule::Type, &FieldValue::Json(json!("a")),
+      &FieldValue::Json(json!(100)), &context).await;
+
+    expect!(matcher.is_core()).to(be_true());
+    expect!(matched).to(be_ok());
+    let mismatches = mismatched.expect_err("expected a string against a number to be a type mismatch");
+    expect!(mismatches.len()).to(be_equal_to(1));
+    expect!(mismatches[0].path.as_str()).to(be_equal_to("$.one"));
+  }
+
+  /// The generator half of [`a_plugin_callback_for_a_core_rule_reaches_the_registered_handler`].
+  #[tokio::test]
+  async fn a_plugin_callback_for_a_core_generator_reaches_the_registered_handler() {
+    crate::matchingrules::configure_core_catalogue();
+
+    let generator = pact_plugin_driver::field::find_field_generator("Uuid")
+      .expect("expected the core 'Uuid' generator to resolve");
+    let context = FieldContext::new(&DocPath::new_unwrap("$.one"), "body");
+    let generated = generator.generate_field(&Generator::Uuid(None), &FieldValue::Json(json!("")),
+      FieldTestMode::Consumer, &context).await;
+
+    expect!(generator.is_core()).to(be_true());
+    match generated.expect("expected a generated value") {
+      FieldValue::Json(serde_json::Value::String(value)) => {
+        expect!(value.len()).to(be_equal_to(36));
+      },
+      other => panic!("expected a UUID string, got {:?}", other)
+    }
+  }
+
+  /// Every key the catalogue advertises for this crate has a handler behind it, and no key has one
+  /// that is not advertised - the two lists are what proposal 009 step 3 is
+  #[test]
+  fn every_registered_field_handler_matches_a_catalogue_entry() {
+    let rules: HashSet<&str> = FIELD_RULES.iter().chain(COLLECTION_RULES.iter()).cloned().collect();
+    let generators: HashSet<&str> = FIELD_GENERATORS.iter().chain(COLLECTION_GENERATORS.iter()).cloned().collect();
+    let rule_entries: HashSet<&str> = crate::matchingrules::MATCHER_CATALOGUE_ENTRIES.iter()
+      .map(|entry| entry.key.as_str())
+      .collect();
+    let generator_entries: HashSet<&str> = crate::matchingrules::GENERATOR_CATALOGUE_ENTRIES.iter()
+      .map(|entry| entry.key.as_str())
+      .collect();
+
+    expect!(rules.symmetric_difference(&rule_entries).collect::<Vec<_>>()).to(be_equal_to(Vec::<&&str>::new()));
+    expect!(generators.symmetric_difference(&generator_entries).collect::<Vec<_>>()).to(be_equal_to(Vec::<&&str>::new()));
+  }
 }

--- a/rust/pact_matching/src/matchingrules.rs
+++ b/rust/pact_matching/src/matchingrules.rs
@@ -108,19 +108,53 @@ lazy_static! {
     entries
   };
 
-  static ref MATCHER_CATALOGUE_ENTRIES: Vec<CatalogueEntry> = {
+  /// Matching rule entries to add to the plugin catalogue, one per rule this crate implements.
+  ///
+  /// Each is keyed by the name the rule carries in a request - the same string
+  /// [`MatchingRule::name`] returns and the plugin driver puts in `MatchFieldRequest.rule.type` -
+  /// so a plugin handed a rule can name it straight back when it calls into the host, and does not
+  /// have to know which specification version introduced it. That version is a value on the entry
+  /// (`spec-version`) rather than part of the key. Must stay in step with `matcherCatalogueEntries`
+  /// in Pact-JVM's `MatcherExecutor.kt`, which differs only by the rules the two implement.
+  pub(crate) static ref MATCHER_CATALOGUE_ENTRIES: Vec<CatalogueEntry> = {
     let mut entries = vec![];
-    for matcher in ["v2-regex", "v2-type", "v3-number-type", "v3-integer-type", "v3-decimal-type",
-      "v3-date", "v3-time", "v3-datetime", "v2-min-type", "v2-max-type", "v2-minmax-type",
-      "v3-includes", "v3-null", "v4-equals-ignore-order", "v4-min-equals-ignore-order",
-      "v4-max-equals-ignore-order", "v4-minmax-equals-ignore-order", "v3-content-type",
-      "v4-array-contains", "v1-equality", "v4-not-empty", "v4-semver"] {
+    for (matcher, spec_version) in [("equality", "V1"), ("regex", "V2"), ("type", "V2"),
+      ("min-type", "V2"), ("max-type", "V2"), ("min-max-type", "V2"), ("include", "V3"),
+      ("number", "V3"), ("integer", "V3"), ("decimal", "V3"), ("null", "V3"), ("date", "V3"),
+      ("time", "V3"), ("datetime", "V3"), ("content-type", "V3"), ("values", "V3"),
+      ("array-contains", "V4"), ("boolean", "V4"), ("status-code", "V4"), ("not-empty", "V4"),
+      ("semver", "V4"), ("each-key", "V4"), ("each-value", "V4")] {
       entries.push(CatalogueEntry {
         entry_type: CatalogueEntryType::MATCHER,
         provider_type: CatalogueEntryProviderType::CORE,
         plugin: None,
         key: matcher.to_string(),
-        values: hashmap!{}
+        values: hashmap!{ "spec-version".to_string() => spec_version.to_string() }
+      });
+    }
+    entries
+  };
+
+  /// Generator entries to add to the plugin catalogue, one per generator this crate implements.
+  ///
+  /// Keyed the same way [`MATCHER_CATALOGUE_ENTRIES`] is - by the name the generator carries in a
+  /// request, which for generators is [`Generator::name`], the same `type` value the Pact file uses
+  /// and the plugin driver puts in `GenerateFieldRequest.generator.type`. That is `PascalCase` for
+  /// generators (`RandomInt`, `DateTime`) where it is kebab-case for matching rules; the point is
+  /// that it matches what a plugin was handed, not that it looks a particular way. Must stay in
+  /// step with `generatorCatalogueEntries` in Pact-JVM's `MatcherExecutor.kt`.
+  pub(crate) static ref GENERATOR_CATALOGUE_ENTRIES: Vec<CatalogueEntry> = {
+    let mut entries = vec![];
+    for (generator, spec_version) in [("RandomInt", "V3"), ("RandomDecimal", "V3"),
+      ("RandomHexadecimal", "V3"), ("RandomString", "V3"), ("RandomBoolean", "V3"),
+      ("Regex", "V3"), ("Uuid", "V3"), ("Date", "V3"), ("Time", "V3"), ("DateTime", "V3"),
+      ("ProviderState", "V3"), ("MockServerURL", "V4"), ("ArrayContains", "V4")] {
+      entries.push(CatalogueEntry {
+        entry_type: CatalogueEntryType::GENERATOR,
+        provider_type: CatalogueEntryProviderType::CORE,
+        plugin: None,
+        key: generator.to_string(),
+        values: hashmap!{ "spec-version".to_string() => spec_version.to_string() }
       });
     }
     entries
@@ -131,6 +165,7 @@ lazy_static! {
 pub fn configure_core_catalogue() {
   #[cfg(feature = "plugins")] #[cfg(not(target_family = "wasm"))] register_core_entries(CONTENT_MATCHER_CATALOGUE_ENTRIES.as_ref());
   #[cfg(feature = "plugins")] #[cfg(not(target_family = "wasm"))] register_core_entries(MATCHER_CATALOGUE_ENTRIES.as_ref());
+  #[cfg(feature = "plugins")] #[cfg(not(target_family = "wasm"))] register_core_entries(GENERATOR_CATALOGUE_ENTRIES.as_ref());
   #[cfg(feature = "plugins")] #[cfg(not(target_family = "wasm"))] crate::core_capabilities::register_core_capabilities();
 }
 
@@ -999,6 +1034,12 @@ impl <T: Debug + Display + PartialEq> DoMatch<&Vec<T>> for MatchingRule {
   }
 }
 
+/// The leading bytes of a value, for a mismatch message. `split_at` panics when asked for more
+/// bytes than there are, which any value shorter than the preview length would do.
+fn first_bytes(value: &Bytes) -> &[u8] {
+  &value[.. value.len().min(10)]
+}
+
 impl DoMatch<&Bytes> for MatchingRule {
   fn match_value(
     &self,
@@ -1030,7 +1071,7 @@ impl DoMatch<&Bytes> for MatchingRule {
           Ok(())
         } else {
           Err(anyhow!("Expected '{:?}...' ({} bytes) to be equal to '{:?}...' ({} bytes)",
-            expected_value.split_at(10).0, expected_value.len(), actual_value.split_at(10).0,
+            first_bytes(expected_value), expected_value.len(), first_bytes(actual_value),
             actual_value.len()))
         }
       },
@@ -1058,7 +1099,7 @@ impl DoMatch<&Bytes> for MatchingRule {
       }
       MatchingRule::Plugin { name, .. } => apply_plugin_rule(self, name, expected_value, actual_value),
       _ => if !cascaded || self.can_cascade() {
-        Err(anyhow!("Unable to match '{:?}...' ({} bytes) using {:?}", actual_value.split_at(10).0,
+        Err(anyhow!("Unable to match '{:?}...' ({} bytes) using {:?}", first_bytes(actual_value),
           actual_value.len(), self))
       } else {
         Ok(())
@@ -1624,6 +1665,7 @@ mod tests {
   use pact_models::{matchingrules, matchingrules_list};
   use pact_models::matchingrules::{MatchingRule, MatchingRuleCategory, RuleList};
   use pact_models::matchingrules::expressions::{MatchingRuleDefinition, ValueType};
+  #[cfg(feature = "plugins")] #[cfg(not(target_family = "wasm"))] use pact_models::generators::Generator;
   use pact_models::path_exp::DocPath;
   use pact_models::prelude::RuleLogic;
 
@@ -2418,6 +2460,126 @@ mod tests {
         <body>Don't forget me this weekend!</body>
       </note>"#;
       expect!(matcher.match_value("plain text", xml, false, false)).to(be_err());
+    }
+  }
+
+  /// The catalogue entry keys are the rule names, so a plugin can name a rule it was handed when it
+  /// calls back into the host. Adding a rule to `MatchingRule` without a catalogue entry would
+  /// leave it unreachable from a plugin, so this pins the two lists together. The `match` is
+  /// exhaustive on purpose: a new variant fails to compile here rather than going unnoticed.
+  #[test]
+  #[cfg(feature = "plugins")]
+  #[cfg(not(target_family = "wasm"))]
+  fn every_matching_rule_has_a_catalogue_entry_keyed_by_its_name() {
+    let rules = vec![
+      MatchingRule::Equality,
+      MatchingRule::Regex(".*".to_string()),
+      MatchingRule::Type,
+      MatchingRule::MinType(1),
+      MatchingRule::MaxType(1),
+      MatchingRule::MinMaxType(1, 2),
+      MatchingRule::Timestamp("yyyy".to_string()),
+      MatchingRule::Time("HH:mm".to_string()),
+      MatchingRule::Date("yyyy".to_string()),
+      MatchingRule::Include("a".to_string()),
+      MatchingRule::Number,
+      MatchingRule::Integer,
+      MatchingRule::Decimal,
+      MatchingRule::Null,
+      MatchingRule::ContentType("text/plain".to_string()),
+      MatchingRule::ArrayContains(vec![]),
+      MatchingRule::Values,
+      MatchingRule::Boolean,
+      MatchingRule::StatusCode(HttpStatus::Success),
+      MatchingRule::NotEmpty,
+      MatchingRule::Semver,
+      MatchingRule::EachKey(MatchingRuleDefinition::new("".to_string(), ValueType::String, MatchingRule::Equality, None, "".to_string())),
+      MatchingRule::EachValue(MatchingRuleDefinition::new("".to_string(), ValueType::String, MatchingRule::Equality, None, "".to_string()))
+    ];
+
+    // Exhaustiveness check - every variant above, and nothing left over except the plugin carrier,
+    // which names a rule the catalogue gets from the plugin rather than from here
+    for rule in &rules {
+      match rule {
+        MatchingRule::Equality | MatchingRule::Regex(_) | MatchingRule::Type |
+        MatchingRule::MinType(_) | MatchingRule::MaxType(_) | MatchingRule::MinMaxType(_, _) |
+        MatchingRule::Timestamp(_) | MatchingRule::Time(_) | MatchingRule::Date(_) |
+        MatchingRule::Include(_) | MatchingRule::Number | MatchingRule::Integer |
+        MatchingRule::Decimal | MatchingRule::Null | MatchingRule::ContentType(_) |
+        MatchingRule::ArrayContains(_) | MatchingRule::Values | MatchingRule::Boolean |
+        MatchingRule::StatusCode(_) | MatchingRule::NotEmpty | MatchingRule::Semver |
+        MatchingRule::EachKey(_) | MatchingRule::EachValue(_) => {},
+        MatchingRule::Plugin { .. } => panic!("a plugin rule is not a core catalogue entry")
+      }
+    }
+
+    let entry_keys = MATCHER_CATALOGUE_ENTRIES.iter()
+      .map(|entry| entry.key.clone())
+      .collect::<HashSet<_>>();
+    let rule_names = rules.iter()
+      .map(|rule| rule.name())
+      .collect::<HashSet<_>>();
+
+    expect!(rule_names.difference(&entry_keys).collect::<Vec<_>>()).to(be_equal_to(Vec::<&String>::new()));
+    expect!(entry_keys.difference(&rule_names).collect::<Vec<_>>()).to(be_equal_to(Vec::<&String>::new()));
+  }
+
+  /// The generator equivalent of
+  /// [`every_matching_rule_has_a_catalogue_entry_keyed_by_its_name`] - a generator without an entry
+  /// cannot be reached by a plugin calling back for it.
+  #[test]
+  #[cfg(feature = "plugins")]
+  #[cfg(not(target_family = "wasm"))]
+  fn every_generator_has_a_catalogue_entry_keyed_by_its_name() {
+    let generators = vec![
+      Generator::RandomInt(0, 10),
+      Generator::Uuid(None),
+      Generator::RandomDecimal(4),
+      Generator::RandomHexadecimal(4),
+      Generator::RandomString(4),
+      Generator::Regex(".*".to_string()),
+      Generator::Date(None, None),
+      Generator::Time(None, None),
+      Generator::DateTime(None, None),
+      Generator::RandomBoolean,
+      Generator::ProviderStateGenerator("a".to_string(), None),
+      Generator::MockServerURL("a".to_string(), ".*".to_string()),
+      Generator::ArrayContains(vec![])
+    ];
+
+    // Exhaustiveness check - a new variant fails to compile here rather than going unnoticed
+    for generator in &generators {
+      match generator {
+        Generator::RandomInt(_, _) | Generator::Uuid(_) | Generator::RandomDecimal(_) |
+        Generator::RandomHexadecimal(_) | Generator::RandomString(_) | Generator::Regex(_) |
+        Generator::Date(_, _) | Generator::Time(_, _) | Generator::DateTime(_, _) |
+        Generator::RandomBoolean | Generator::ProviderStateGenerator(_, _) |
+        Generator::MockServerURL(_, _) | Generator::ArrayContains(_) => {},
+        Generator::Plugin { .. } => panic!("a plugin generator is not a core catalogue entry")
+      }
+    }
+
+    let entry_keys = GENERATOR_CATALOGUE_ENTRIES.iter()
+      .map(|entry| entry.key.clone())
+      .collect::<HashSet<_>>();
+    let generator_names = generators.iter()
+      .map(|generator| generator.name())
+      .collect::<HashSet<_>>();
+
+    expect!(generator_names.difference(&entry_keys).collect::<Vec<_>>()).to(be_equal_to(Vec::<&String>::new()));
+    expect!(entry_keys.difference(&generator_names).collect::<Vec<_>>()).to(be_equal_to(Vec::<&String>::new()));
+  }
+
+  /// The specification version is a value on the entry, not part of the key.
+  #[test]
+  #[cfg(feature = "plugins")]
+  #[cfg(not(target_family = "wasm"))]
+  fn every_core_catalogue_entry_records_the_specification_version_it_was_introduced_in() {
+    for entry in MATCHER_CATALOGUE_ENTRIES.iter().chain(GENERATOR_CATALOGUE_ENTRIES.iter()) {
+      let version = entry.values.get("spec-version")
+        .unwrap_or_else(|| panic!("catalogue entry '{}' has no spec-version value", entry.key));
+      expect!(["V1", "V2", "V3", "V4"].contains(&version.as_str()))
+        .to(be_true());
     }
   }
 }


### PR DESCRIPTION
Proposal 009: let a plugin delegate a standard Pact rule to the host it is running under, instead of reimplementing it. The mechanism has been in the plugin driver since 006; nothing registered anything behind it, so a plugin naming a standard rule resolved the catalogue entry and then failed with "No core field matcher registered for 'type'".

Catalogue entries:

- the matcher entries are re-keyed by the name the rule carries in a request (`MatchingRule::name()`, the same string the driver puts in `MatchFieldRequest.rule.type`) rather than the specification version prefixed to the name, which moves to a `spec-version` value on the entry;
- generator entries are added - there were none at all, so `find_field_ generator("Uuid")` failed at the catalogue step and no `generator/*` capability was ever advertised;
- both lists are now exactly the rules and generators this crate implements, pinned by a test that compares them against the enum variants, with an exhaustive match so a new variant fails to compile until it has an entry.

Handlers:

- `CoreFieldRuleMatcher` answers for the 16 rules that act on a single value, and `CoreFieldValueGenerator` for the 12 generators that are a pure function of their configuration and the test context;
- the collection-wide rules (`min-type`, `values`, `array-contains`, `each-key`/`each-value`) and the `ArrayContains` generator are registered too, but answer with why they can not be applied one value at a time - they stay host-only per 006's non-goals, and a plugin naming one should be told that rather than that nothing is registered;
- a rule or generator name this crate does not provide is an error, not a call back out: an unrecognised name parses into the `Plugin` carrier variant, which would send the callback straight back to a plugin.

Two bugs this turned up:

- `MatchingRule::Equality` on `&Bytes` built its mismatch message with `split_at(10)`, which panics for any value shorter than 10 bytes;
- rule and generator configuration crosses the plugin interface as a `google.protobuf.Struct`, which has one number type, so a plugin's `min: 2` arrives as `2.0` and the integer accessors reading it fall back to the attribute's default - a `RandomInt(5, 5)` from a plugin generated from `0..10`. Whole floats are put back to integers on the way in.