### PR TITLE
feat(pact_verifier): include pact and mismatch details in interaction results

### DIFF
--- a/rust/pact_ffi/src/verifier/mod.rs
+++ b/rust/pact_ffi/src/verifier/mod.rs
@@ -702,6 +702,14 @@ ffi_fn! {
     /// Extracts the verification result as a JSON document. The returned string will need to be
     /// freed with the `free_string` function call to avoid leaking memory.
     ///
+    /// The document has the attributes `result` (overall pass/fail), `notices`, `output` (the
+    /// verification output lines), `errors`, `pendingErrors` and `interactionResults`. Each entry
+    /// in `interactionResults` has the attributes `consumer`, `provider`, `description`,
+    /// `providerStates`, `result` (`OK` or `Error`), `pending`, `duration`, a `mismatch` attribute
+    /// with the details when the result is `Error`, and `interactionId`/`interactionKey` when
+    /// they are known. See the JSON report section in the pact_verifier_cli documentation for
+    /// more details.
+    ///
     /// Will return a NULL pointer if the handle is invalid.
     fn pactffi_verifier_json(handle: *const handle::VerifierHandle) -> *const c_char {
       let handle = as_ref!(handle);

--- a/rust/pact_verifier/src/lib.rs
+++ b/rust/pact_verifier/src/lib.rs
@@ -1522,9 +1522,13 @@ pub async fn verify_pact_internal<'a, F: RequestFilterExecutor, S: ProviderState
   }
 
   let mut errors: Vec<VerificationInteractionResult> = vec![];
+  let consumer_name = pact.consumer().name.clone();
+  let provider_name = pact.provider().name.clone();
   for (interaction, match_result) in results {
-    let mut description = format!("Verifying a pact between {} and {}",
-      pact.consumer().name.clone(), pact.provider().name.clone());
+    let mut description = format!("Verifying a pact between {} and {}", consumer_name, provider_name);
+    let provider_state_names = interaction.provider_states().iter()
+      .map(|state| state.name.clone())
+      .collect_vec();
 
     output.push(String::default());
     let duration = match match_result {
@@ -1618,8 +1622,11 @@ pub async fn verify_pact_internal<'a, F: RequestFilterExecutor, S: ProviderState
         errors.push(VerificationInteractionResult {
           interaction_id: interaction.id(),
           interaction_key,
+          consumer: consumer_name.clone(),
+          provider: provider_name.clone(),
           description: description.clone(),
           interaction_description: interaction.description(),
+          provider_states: provider_state_names.clone(),
           result: Ok(()),
           pending: pending || interaction.pending(),
           duration
@@ -1629,8 +1636,11 @@ pub async fn verify_pact_internal<'a, F: RequestFilterExecutor, S: ProviderState
         errors.push(VerificationInteractionResult {
           interaction_id: interaction.id(),
           interaction_key,
+          consumer: consumer_name.clone(),
+          provider: provider_name.clone(),
           description: description.clone(),
           interaction_description: interaction.description(),
+          provider_states: provider_state_names.clone(),
           result: Err(err.clone()),
           pending: pending || interaction.pending(),
           duration

--- a/rust/pact_verifier/src/tests.rs
+++ b/rust/pact_verifier/src/tests.rs
@@ -357,6 +357,9 @@ async fn publish_successful_result_to_broker() {
   publish_result(&[VerificationInteractionResult {
       interaction_id: Some("1".to_string()),
       interaction_key: None,
+      consumer: "".to_string(),
+      provider: "".to_string(),
+      provider_states: vec![],
       description: "".to_string(),
       interaction_description: "".to_string(),
       result: Ok(()),
@@ -380,6 +383,9 @@ async fn publish_successful_result_to_broker() {
   super::publish_result(&[VerificationInteractionResult {
       interaction_id: Some("1".to_string()),
       interaction_key: None,
+      consumer: "".to_string(),
+      provider: "".to_string(),
+      provider_states: vec![],
       description: "".to_string(),
       interaction_description: "".to_string(),
       result: Ok(()),

--- a/rust/pact_verifier/src/verification_result.rs
+++ b/rust/pact_verifier/src/verification_result.rs
@@ -15,10 +15,16 @@ pub struct VerificationInteractionResult {
   pub interaction_id: Option<String>,
   /// Interaction key (this will be set if the Pact is a V4 Pact)
   pub interaction_key: Option<String>,
+  /// Name of the consumer of the Pact the interaction belongs to
+  pub consumer: String,
+  /// Name of the provider of the Pact the interaction belongs to
+  pub provider: String,
   /// Descriptive text of the verification that was preformed
   pub description: String,
   /// Interaction description from the Pact file
   pub interaction_description: String,
+  /// Names of the provider states of the interaction, in the order they are defined in the Pact
+  pub provider_states: Vec<String>,
   /// Result of the verification
   pub result: Result<(), crate::MismatchResult>,
   /// If the Pact or interaction is pending
@@ -97,10 +103,22 @@ impl Into<Value> for &VerificationExecutionResult {
         if let Some(interaction_key) = &r.interaction_key {
           attributes.insert("interactionKey".to_string(), Value::String(interaction_key.clone()));
         }
+        attributes.insert("consumer".to_string(), Value::String(r.consumer.clone()));
+        attributes.insert("provider".to_string(), Value::String(r.provider.clone()));
         attributes.insert("description".to_string(), Value::String(r.interaction_description.clone()));
-        match r.result {
-          Ok(_) => attributes.insert("result".to_string(), Value::String("OK".to_string())),
-          Err(_) => attributes.insert("result".to_string(), Value::String("Error".to_string()))
+        attributes.insert("providerStates".to_string(), Value::Array(
+          r.provider_states.iter().map(|s| Value::String(s.clone())).collect()
+        ));
+        attributes.insert("pending".to_string(), Value::Bool(r.pending));
+        match &r.result {
+          Ok(_) => {
+            attributes.insert("result".to_string(), Value::String("OK".to_string()));
+          }
+          Err(err) => {
+            attributes.insert("result".to_string(), Value::String("Error".to_string()));
+            let mismatch: Value = (&VerificationMismatchResult::from(err)).into();
+            attributes.insert("mismatch".to_string(), mismatch);
+          }
         };
         attributes.insert("duration".to_string(), Value::String(format!("{:?}", r.duration)));
         Value::Object(attributes)
@@ -189,6 +207,7 @@ mod tests {
   use serde_json::{json, Value};
 
   use pact_matching::Mismatch;
+  use pact_models::sync_interaction::RequestResponseInteraction;
 
   use crate::{MismatchResult, VerificationExecutionResult};
   use crate::verification_result::{VerificationInteractionResult, VerificationMismatchResult};
@@ -315,6 +334,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: None,
+          consumer: "Consumer A".to_string(),
+          provider: "Provider".to_string(),
+          provider_states: vec![],
           description: "".to_string(),
           interaction_description: "result-1".to_string(),
           result: Ok(()),
@@ -324,6 +346,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: None,
+          consumer: "Consumer A".to_string(),
+          provider: "Provider".to_string(),
+          provider_states: vec![],
           description: "".to_string(),
           interaction_description: "result-2".to_string(),
           result: Err(MismatchResult::Error("test".to_string(), None)),
@@ -333,18 +358,35 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: Some("test-id".to_string()),
           interaction_key: None,
+          consumer: "Consumer B".to_string(),
+          provider: "Provider".to_string(),
+          provider_states: vec!["state 1".to_string(), "state 2".to_string()],
           description: "".to_string(),
           interaction_description: "result-3".to_string(),
           result: Ok(()),
-          pending: false,
+          pending: true,
           duration: Default::default(),
         },
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: Some("test-key".to_string()),
+          consumer: "Consumer B".to_string(),
+          provider: "Provider".to_string(),
+          provider_states: vec![],
           description: "".to_string(),
           interaction_description: "result-4".to_string(),
-          result: Ok(()),
+          result: Err(MismatchResult::Mismatches {
+            mismatches: vec![
+              Mismatch::StatusMismatch {
+                expected: 200,
+                actual: 500,
+                mismatch: "expected 200 but was 500".to_string()
+              }
+            ],
+            expected: Box::new(RequestResponseInteraction::default()),
+            actual: Box::new(RequestResponseInteraction::default()),
+            interaction_id: None
+          }),
           pending: false,
           duration: Default::default(),
         }
@@ -358,26 +400,59 @@ mod tests {
       "errors": [],
       "interactionResults": [
         {
+          "consumer": "Consumer A",
           "description": "result-1",
           "duration": "0ns",
+          "pending": false,
+          "provider": "Provider",
+          "providerStates": [],
           "result": "OK",
         },
         {
+          "consumer": "Consumer A",
           "description": "result-2",
           "duration": "0ns",
+          "mismatch": {
+            "interactionId": "",
+            "message": "test",
+            "type": "error"
+          },
+          "pending": false,
+          "provider": "Provider",
+          "providerStates": [],
           "result": "Error",
         },
         {
+          "consumer": "Consumer B",
           "description": "result-3",
           "duration": "0ns",
           "interactionId": "test-id",
+          "pending": true,
+          "provider": "Provider",
+          "providerStates": ["state 1", "state 2"],
           "result": "OK",
         },
         {
+          "consumer": "Consumer B",
           "description": "result-4",
           "duration": "0ns",
           "interactionKey": "test-key",
-          "result": "OK",
+          "mismatch": {
+            "interactionId": "",
+            "mismatches": [
+              {
+                "actual": 500,
+                "expected": 200,
+                "mismatch": "expected 200 but was 500",
+                "type": "StatusMismatch"
+              }
+            ],
+            "type": "mismatches"
+          },
+          "pending": false,
+          "provider": "Provider",
+          "providerStates": [],
+          "result": "Error",
         }
       ],
       "notices": [],

--- a/rust/pact_verifier/tests/pact-with-provider-states.json
+++ b/rust/pact_verifier/tests/pact-with-provider-states.json
@@ -1,0 +1,39 @@
+{
+  "consumer": {
+    "name": "test_consumer"
+  },
+  "provider": {
+    "name": "test_provider"
+  },
+  "interactions": [
+    {
+      "description": "interaction without provider states",
+      "request": {
+        "method": "GET",
+        "path": "/"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "interaction with provider states",
+      "providerStates": [
+        { "name": "state one" },
+        { "name": "state two", "params": { "id": 1 } }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/"
+      },
+      "response": {
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  }
+}

--- a/rust/pact_verifier/tests/tests.rs
+++ b/rust/pact_verifier/tests/tests.rs
@@ -1260,3 +1260,45 @@ async fn verify_pact_with_redirects() {
 
   expect!(result.unwrap().results.get(0).unwrap().result.as_ref()).to(be_ok());
 }
+
+#[test_log::test(tokio::test)]
+async fn interaction_results_include_the_pact_and_provider_state_details() {
+  let provider = ProviderInfo {
+    name: "test_provider".to_string(),
+    host: "127.0.0.1".to_string(),
+    .. ProviderInfo::default()
+  };
+
+  let pact_file = fixture_path("pact-with-provider-states.json");
+  let pact = read_pact(pact_file.as_path()).unwrap();
+  let options: VerificationOptions<NullRequestFilterExecutor> = VerificationOptions::default();
+  let provider_states = Arc::new(DummyProviderStateExecutor{});
+
+  let result = verify_pact_internal(
+    &provider,
+    &FilterInfo::None,
+    pact,
+    &options,
+    &provider_states,
+    false,
+    Duration::default()
+  ).await.unwrap();
+
+  expect!(result.results.len()).to(be_equal_to(2));
+
+  let first = result.results.first().unwrap();
+  expect!(first.consumer.as_str()).to(be_equal_to("test_consumer"));
+  expect!(first.provider.as_str()).to(be_equal_to("test_provider"));
+  expect!(first.interaction_description.as_str()).to(be_equal_to("interaction without provider states"));
+  expect!(first.provider_states.is_empty()).to(be_true());
+  expect!(first.description.as_str()).to(be_equal_to(
+    "Verifying a pact between test_consumer and test_provider - interaction without provider states"));
+
+  let second = result.results.get(1).unwrap();
+  expect!(second.consumer.as_str()).to(be_equal_to("test_consumer"));
+  expect!(second.provider.as_str()).to(be_equal_to("test_provider"));
+  expect!(second.interaction_description.as_str()).to(be_equal_to("interaction with provider states"));
+  expect!(second.provider_states.clone()).to(be_equal_to(vec!["state one".to_string(), "state two".to_string()]));
+  expect!(second.description.as_str()).to(be_equal_to(
+    "Verifying a pact between test_consumer and test_provider Given state one And state two - interaction with provider states"));
+}

--- a/rust/pact_verifier_cli/README.md
+++ b/rust/pact_verifier_cli/README.md
@@ -248,6 +248,37 @@ and Pact files.
 The `--last-failed` option will only execute interactions that have previously failed. It requires the `--json` option
 (the previous state will be loaded from this file).
 
+### JSON report (`--json`)
+
+The `--json` option writes the verification result as a JSON document. It has the following top-level attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `result` | Overall pass/fail result |
+| `notices` | Notices provided by the Pact Broker |
+| `output` | The human readable verification output, one entry per line |
+| `errors` | Failed interactions (`interaction` is the descriptive text, `mismatch` the details) |
+| `pendingErrors` | Failed interactions that are marked as pending and do not fail the verification |
+| `interactionResults` | One entry per verified interaction, in the order they were verified |
+
+Each entry in `interactionResults` has the following attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `consumer` | Name of the consumer of the Pact the interaction belongs to |
+| `provider` | Name of the provider of the Pact the interaction belongs to |
+| `description` | Interaction description from the Pact file |
+| `providerStates` | Names of the provider states of the interaction (empty if there are none) |
+| `result` | `OK` or `Error` |
+| `pending` | If the interaction (or the Pact) is pending |
+| `mismatch` | Only present when the result is `Error`. Same structure as the `mismatch` attribute in `errors` |
+| `duration` | Duration of the verification of the interaction |
+| `interactionId` | Only present for Pacts loaded from a Pact Broker |
+| `interactionKey` | Only present for V4 Pacts where the interaction has a key |
+
+The `consumer`, `provider` and `providerStates` attributes allow the results to be grouped by Pact, e.g. to report
+each Pact and interaction as a separate test case.
+
 ## Example run
 
 This will verify all the pacts for the `happy_provider` found in the pact broker (running on localhost) against the provider running on localhost port 5050. Only the pacts for the consumers `Consumer` and `Consumer2` will be verified.

--- a/rust/pact_verifier_cli/src/lib.rs
+++ b/rust/pact_verifier_cli/src/lib.rs
@@ -244,6 +244,37 @@
 //! The `--last-failed` option will only execute interactions that have previously failed. It requires the `--json` option
 //! (the previous state will be loaded from this file).
 //!
+//! ### JSON report (`--json`)
+//!
+//! The `--json` option writes the verification result as a JSON document. It has the following top-level attributes:
+//!
+//! | Attribute | Description |
+//! | --------- | ----------- |
+//! | `result` | Overall pass/fail result |
+//! | `notices` | Notices provided by the Pact Broker |
+//! | `output` | The human readable verification output, one entry per line |
+//! | `errors` | Failed interactions (`interaction` is the descriptive text, `mismatch` the details) |
+//! | `pendingErrors` | Failed interactions that are marked as pending and do not fail the verification |
+//! | `interactionResults` | One entry per verified interaction, in the order they were verified |
+//!
+//! Each entry in `interactionResults` has the following attributes:
+//!
+//! | Attribute | Description |
+//! | --------- | ----------- |
+//! | `consumer` | Name of the consumer of the Pact the interaction belongs to |
+//! | `provider` | Name of the provider of the Pact the interaction belongs to |
+//! | `description` | Interaction description from the Pact file |
+//! | `providerStates` | Names of the provider states of the interaction (empty if there are none) |
+//! | `result` | `OK` or `Error` |
+//! | `pending` | If the interaction (or the Pact) is pending |
+//! | `mismatch` | Only present when the result is `Error`. Same structure as the `mismatch` attribute in `errors` |
+//! | `duration` | Duration of the verification of the interaction |
+//! | `interactionId` | Only present for Pacts loaded from a Pact Broker |
+//! | `interactionKey` | Only present for V4 Pacts where the interaction has a key |
+//!
+//! The `consumer`, `provider` and `providerStates` attributes allow the results to be grouped by Pact, e.g. to report
+//! each Pact and interaction as a separate test case.
+//!
 //! ## Example run
 //!
 //! This will verify all the pacts for the `happy_provider` found in the pact broker (running on localhost) against the provider running on localhost port 5050. Only the pacts for the consumers `Consumer` and `Consumer2` will be verified.

--- a/rust/pact_verifier_cli/src/reports/xml.rs
+++ b/rust/pact_verifier_cli/src/reports/xml.rs
@@ -285,6 +285,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: None,
+          consumer: "".to_string(),
+          provider: "".to_string(),
+          provider_states: vec![],
           description: "request 1".to_string(),
           interaction_description: "GET /foo returns 200".to_string(),
           result: Ok(()),
@@ -294,6 +297,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: Some("interaction-123".to_string()),
           interaction_key: Some("key-abc".to_string()),
+          consumer: "".to_string(),
+          provider: "".to_string(),
+          provider_states: vec![],
           description: "request 2".to_string(),
           interaction_description: "POST /bar returns 201".to_string(),
           result: Ok(()),
@@ -323,6 +329,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: None,
+          consumer: "".to_string(),
+          provider: "".to_string(),
+          provider_states: vec![],
           description: "request 1".to_string(),
           interaction_description: "GET /foo returns 200".to_string(),
           result: Err(MismatchResult::Error("Connection refused".to_string(), None)),
@@ -382,6 +391,9 @@ mod tests {
         VerificationInteractionResult {
           interaction_id: None,
           interaction_key: None,
+          consumer: "".to_string(),
+          provider: "".to_string(),
+          provider_states: vec![],
           description: "pending request".to_string(),
           interaction_description: "GET /pending-foo returns 200".to_string(),
           result: Err(MismatchResult::Error("Provider state setup failed".to_string(), None)),


### PR DESCRIPTION
## Summary

The JSON verification result (`pactffi_verifier_json`, `pact-verifier --json`) lists one entry per verified interaction in `interactionResults`, but each entry only carries `description`, `result` and `duration`. Consumer and provider are only available as free text in `errors[].interaction`, provider states not at all, and mismatches have to be joined to the interaction via that text.

When several pacts of different consumers are verified in one run, the entries cannot be assigned to their pact. This prevents consumers of the JSON (language bindings such as pact-js, or test framework reporters) from reporting the outcome per pact and per interaction, for example as one test suite per pact with one test case per interaction.

## Changes

- `VerificationInteractionResult` gains `consumer`, `provider` and `provider_states` (the state names in pact order). They are populated in `verify_pact_internal`, where the pact and interaction are available.
- Every `interactionResults` entry in the JSON additionally has:
  - `consumer`, `provider`
  - `providerStates` (array of names, empty if none)
  - `pending`
  - `mismatch` for failed interactions, with the same structure as `errors[].mismatch`
- Existing attributes (`description`, `result`, `duration`, `interactionId`, `interactionKey`) are unchanged, so the change is additive. `errors`, `pendingErrors`, `output` and the JUnit XML report are unchanged.
- Documents the structure of the JSON report in the `pact_verifier_cli` README / crate docs and in the doc comment of `pactffi_verifier_json`.

Example entry for a failed interaction:

```json
{
  "consumer": "DemoConsumer",
  "provider": "DemoProvider",
  "description": "interaction 3 - GET /three",
  "providerStates": ["resource three is available"],
  "pending": false,
  "result": "Error",
  "mismatch": {
    "type": "mismatches",
    "interactionId": "",
    "mismatches": [
      { "type": "BodyMismatch", "path": "$.ok", "expected": "true", "actual": "\"true\"", "mismatch": "Expected 'true' (String) to be the same type as true (Boolean)" }
    ]
  },
  "duration": "2ms"
}
```

## Test plan

- [x] `cargo test -p pact_verifier` (lib and integration tests), including a new integration test `interaction_results_include_the_pact_and_provider_state_details` with a pact fixture that has interactions with and without provider states
- [x] Extended `verification_execution_result_to_json_includes_interaction_details` to cover the new attributes and the `mismatch` attribute for both the error and the mismatches variant
- [x] `cargo test -p pact_verifier_cli --lib reports` (JUnit XML snapshots unchanged)
- [x] `cargo check -p pact_ffi`, `cargo doc -p pact_verifier_cli --no-deps`
- [x] End-to-end: built `pact-verifier` and verified two pact files of different consumers against a passing and a deliberately failing provider with `--json`; every entry carries its consumer, provider, provider states and, when failed, its mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
